### PR TITLE
Make annotation discovery a global setting

### DIFF
--- a/engine/src/main/java/org/hibernate/search/v6poc/engine/impl/SearchMappingRepositoryBuilderImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/engine/impl/SearchMappingRepositoryBuilderImpl.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
@@ -27,14 +28,14 @@ import org.hibernate.search.v6poc.engine.spi.BeanResolver;
 import org.hibernate.search.v6poc.engine.spi.BuildContext;
 import org.hibernate.search.v6poc.engine.spi.ReflectionBeanResolver;
 import org.hibernate.search.v6poc.engine.spi.ServiceManager;
-import org.hibernate.search.v6poc.entity.mapping.building.spi.TypeMetadataContributor;
-import org.hibernate.search.v6poc.entity.mapping.building.spi.TypeMetadataContributorProvider;
-import org.hibernate.search.v6poc.entity.mapping.spi.MappingKey;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.Mapper;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.MapperFactory;
-import org.hibernate.search.v6poc.entity.mapping.building.spi.MetadataContributor;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.MetadataCollector;
+import org.hibernate.search.v6poc.entity.mapping.building.spi.MetadataContributor;
+import org.hibernate.search.v6poc.entity.mapping.building.spi.TypeMetadataContributorProvider;
+import org.hibernate.search.v6poc.entity.mapping.building.spi.TypeMetadataDiscoverer;
 import org.hibernate.search.v6poc.entity.mapping.spi.MappingImplementor;
+import org.hibernate.search.v6poc.entity.mapping.spi.MappingKey;
 import org.hibernate.search.v6poc.entity.model.spi.MappableTypeModel;
 import org.hibernate.search.v6poc.util.AssertionFailure;
 import org.hibernate.search.v6poc.util.SearchException;
@@ -127,21 +128,23 @@ public class SearchMappingRepositoryBuilderImpl implements SearchMappingReposito
 		private boolean frozen = false;
 
 		@Override
-		public <C extends TypeMetadataContributor> void collect(MapperFactory<C, ?> mapperFactory,
-				MappableTypeModel typeModel, String indexName, C contributor) {
-			// Adding new contributors to already known mappings is fine, see MapperContribution
-			if ( frozen && !contributionByMappingKey.containsKey( mapperFactory ) ) {
-				throw new AssertionFailure(
-						"Attempt to add a mapping contribution for a new mapper factory"
-								+ " after Hibernate Search has started to build the mappings."
-								+ " There is a bug in the mapper factory implementation."
-								+ " Mapper factory: " + mapperFactory + ". Type model: " + typeModel + "."
-				);
-			}
-			@SuppressWarnings("unchecked")
-			MapperContribution<C, ?> contribution = (MapperContribution<C, ?>)
-					contributionByMappingKey.computeIfAbsent( mapperFactory, ignored -> new MapperContribution<>( mapperFactory ));
-			contribution.update( typeModel, indexName, contributor );
+		public void mapToIndex(MapperFactory<?, ?> mapperFactory, MappableTypeModel typeModel, String indexName) {
+			checkNotFrozen( mapperFactory, typeModel );
+			getOrCreateContribution( mapperFactory ).mapToIndex( typeModel, indexName );
+		}
+
+		@Override
+		public <C> void collectContributor(MapperFactory<C, ?> mapperFactory,
+				MappableTypeModel typeModel, C contributor) {
+			checkNotFrozen( mapperFactory, typeModel );
+			getOrCreateContribution( mapperFactory ).collectContributor( typeModel, contributor );
+		}
+
+		@Override
+		public <C> void collectDiscoverer(MapperFactory<C, ?> mapperFactory,
+				TypeMetadataDiscoverer<C> metadataDiscoverer) {
+			checkNotFrozen( mapperFactory, null );
+			getOrCreateContribution( mapperFactory ).collectDiscoverer( metadataDiscoverer );
 		}
 
 		Map<MappingKey<?>, Mapper<?, ?>> createMappers(
@@ -155,31 +158,52 @@ public class SearchMappingRepositoryBuilderImpl implements SearchMappingReposito
 			} );
 			return mappers;
 		}
+
+		@SuppressWarnings("unchecked")
+		private <C> MapperContribution<C, ?> getOrCreateContribution(
+				MapperFactory<C, ?> mapperFactory) {
+			return (MapperContribution<C, ?>) contributionByMappingKey.computeIfAbsent(
+					mapperFactory, ignored -> new MapperContribution<>( mapperFactory )
+			);
+		}
+
+		private void checkNotFrozen(MapperFactory<?, ?> mapperFactory, MappableTypeModel typeModel) {
+			if ( frozen ) {
+				throw new AssertionFailure(
+						"Attempt to add a mapping contribution"
+						+ " after Hibernate Search has started to build the mappings."
+						+ " There is a bug in the mapper factory implementation."
+						+ " Mapper factory: " + mapperFactory + "."
+						+ (
+								typeModel == null ? ""
+								: " Type model for the unexpected contribution: " + typeModel + "."
+						)
+				);
+			}
+		}
 	}
 
-	private static class MapperContribution<C extends TypeMetadataContributor, M extends MappingImplementor> {
+	private static class MapperContribution<C, M extends MappingImplementor> {
 
 		private final MapperFactory<C, M> mapperFactory;
-		private final Set<MappableTypeModel> typesLeftToProcess = new LinkedHashSet<>();
-		private final Set<MappableTypeModel> typesBeingProcessed = new LinkedHashSet<>();
-		private final Set<MappableTypeModel> freezedTypes = new HashSet<>();
-		private final Map<MappableTypeModel, TypeMappingContribution<C>> contributionByType = new HashMap<>();
+		private final Map<MappableTypeModel, TypeMappingContribution<C>> contributionByType = new LinkedHashMap<>();
+		private final List<TypeMetadataDiscoverer<C>> metadataDiscoverers = new ArrayList<>();
+		private final Set<MappableTypeModel> typesSubmittedToDiscoverers = new HashSet<>();
 
 		MapperContribution(MapperFactory<C, M> mapperFactory) {
 			this.mapperFactory = mapperFactory;
 		}
 
-		public void update(MappableTypeModel typeModel, String indexName, C contributor) {
-			if ( freezedTypes.contains( typeModel ) ) {
-				throw new AssertionFailure(
-						"Attempt to add a mapping contribution for a type that has already been mapped"
-								+ " or is being mapped. There is a bug in the mapper implementation."
-								+ " Mapper factory: " + mapperFactory + ". Type model: " + typeModel + "."
-				);
-			}
-			typesLeftToProcess.add( typeModel );
-			contributionByType.computeIfAbsent( typeModel, TypeMappingContribution::new )
-					.update( indexName, contributor );
+		public void mapToIndex(MappableTypeModel typeModel, String indexName) {
+			getOrCreateContribution( typeModel ).mapToIndex( indexName );
+		}
+
+		public void collectContributor(MappableTypeModel typeModel, C contributor) {
+			getOrCreateContribution( typeModel ).collectContributor( contributor );
+		}
+
+		public void collectDiscoverer(TypeMetadataDiscoverer<C> metadataDiscoverer) {
+			metadataDiscoverers.add( metadataDiscoverer );
 		}
 
 		public Mapper<C, M> preBuild(BuildContext buildContext, ConfigurationPropertySource propertySource,
@@ -187,64 +211,55 @@ public class SearchMappingRepositoryBuilderImpl implements SearchMappingReposito
 			ContributorProvider contributorProvider = new ContributorProvider();
 			Mapper<C, M> mapper = mapperFactory.createMapper( buildContext, propertySource );
 
-			/*
-			 * We have to loop, and copy the set of types before starting processing,
-			 * because we allow mappers to add new contributions to new types
-			 * when we call org.hibernate.search.v6poc.entity.mapping.building.spi.Mapper.addIndexed.
-			 * This is necessary to allow annotation-based mapping,
-			 * which may discover new embedded types while mapping a type.
-			 *
-			 * We do not, however, allow new contributions to types already encountered in this method
-			 * (the "freezed" types).
-			 */
-			while ( !typesLeftToProcess.isEmpty() ) {
-				typesBeingProcessed.clear();
-				typesBeingProcessed.addAll( typesLeftToProcess );
-				typesLeftToProcess.clear();
-				freezedTypes.addAll( typesBeingProcessed );
-
-				for ( MappableTypeModel typeModel : typesBeingProcessed ) {
-					Optional<String> indexNameOptional = typeModel.getAscendingSuperTypes()
-							.map( contributionByType::get )
-							.filter( Objects::nonNull )
-							.map( TypeMappingContribution::getIndexName )
-							.filter( Objects::nonNull )
-							.findFirst();
-					if ( indexNameOptional.isPresent() ) {
-						String indexName = indexNameOptional.get();
-						mapper.addIndexed(
-								typeModel,
-								indexManagerBuildingStateHolder.startBuilding( indexName ),
-								contributorProvider
-						);
-					}
+			Set<MappableTypeModel> potentiallyMappedToIndexTypes = new LinkedHashSet<>( contributionByType.keySet() );
+			for ( MappableTypeModel typeModel : potentiallyMappedToIndexTypes ) {
+				TypeMappingContribution<C> contribution = contributionByType.get( typeModel );
+				String indexName = contribution.getIndexName();
+				if ( indexName != null ) {
+					mapper.addIndexed(
+							typeModel,
+							indexManagerBuildingStateHolder.startBuilding( indexName ),
+							contributorProvider
+					);
 				}
 			}
+
 			return mapper;
 		}
 
-		private class ContributorProvider implements TypeMetadataContributorProvider<C> {
-			private C currentContributor = null;
+		private TypeMappingContribution<C> getOrCreateContribution(MappableTypeModel typeModel) {
+			TypeMappingContribution<C> contribution = contributionByType.get( typeModel );
+			if ( contribution == null ) {
+				contribution = new TypeMappingContribution<>( typeModel );
+				contributionByType.put( typeModel, contribution );
+			}
+			return contribution;
+		}
 
+		private TypeMappingContribution<C> getContributionIncludingAutomaticallyDiscovered(
+				MappableTypeModel typeModel) {
+			if ( !typesSubmittedToDiscoverers.contains( typeModel ) ) {
+				// Allow automatic discovery of metadata the first time we encounter each type
+				for ( TypeMetadataDiscoverer<C> metadataDiscoverer : metadataDiscoverers ) {
+					Optional<C> discoveredContributor = metadataDiscoverer.discover( typeModel );
+					if ( discoveredContributor.isPresent() ) {
+						getOrCreateContribution( typeModel )
+								.collectContributor( discoveredContributor.get() );
+					}
+				}
+				typesSubmittedToDiscoverers.add( typeModel );
+			}
+			return contributionByType.get( typeModel );
+		}
+
+		private class ContributorProvider implements TypeMetadataContributorProvider<C> {
 			@Override
 			public void forEach(MappableTypeModel typeModel, Consumer<C> contributorConsumer) {
-				if ( currentContributor != null ) {
-					currentContributor.beforeNestedContributions( typeModel );
-				}
-				C previousContributor = currentContributor;
 				typeModel.getDescendingSuperTypes()
-						.map( contributionByType::get )
+						.map( MapperContribution.this::getContributionIncludingAutomaticallyDiscovered )
 						.filter( Objects::nonNull )
 						.flatMap( TypeMappingContribution::getContributors )
-						.forEach( contributor -> {
-							currentContributor = contributor;
-							try {
-								contributorConsumer.accept( contributor );
-							}
-							finally {
-								currentContributor = previousContributor;
-							}
-						} );
+						.forEach( contributorConsumer );
 			}
 		}
 	}
@@ -254,7 +269,7 @@ public class SearchMappingRepositoryBuilderImpl implements SearchMappingReposito
 		private String indexName;
 		private final List<C> contributors = new ArrayList<>();
 
-		public TypeMappingContribution(MappableTypeModel typeModel) {
+		TypeMappingContribution(MappableTypeModel typeModel) {
 			this.typeModel = typeModel;
 		}
 
@@ -262,14 +277,15 @@ public class SearchMappingRepositoryBuilderImpl implements SearchMappingReposito
 			return indexName;
 		}
 
-		public void update(String indexName, C contributor) {
-			if ( indexName != null && !indexName.isEmpty() ) {
-				if ( this.indexName != null ) {
-					throw new SearchException( "Type '" + typeModel + "' mapped to multiple indexes: '"
-							+ this.indexName + "', '" + indexName + "'." );
-				}
-				this.indexName = indexName;
+		public void mapToIndex(String indexName) {
+			if ( this.indexName != null ) {
+				throw new SearchException( "Type '" + typeModel + "' mapped to multiple indexes: '"
+						+ this.indexName + "', '" + indexName + "'." );
 			}
+			this.indexName = indexName;
+		}
+
+		public void collectContributor(C contributor) {
 			this.contributors.add( contributor );
 		}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/entity/mapping/building/spi/MapperFactory.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/entity/mapping/building/spi/MapperFactory.java
@@ -8,8 +8,8 @@ package org.hibernate.search.v6poc.entity.mapping.building.spi;
 
 import org.hibernate.search.v6poc.cfg.ConfigurationPropertySource;
 import org.hibernate.search.v6poc.engine.spi.BuildContext;
-import org.hibernate.search.v6poc.entity.mapping.spi.MappingKey;
 import org.hibernate.search.v6poc.entity.mapping.spi.MappingImplementor;
+import org.hibernate.search.v6poc.entity.mapping.spi.MappingKey;
 
 /**
  * @author Yoann Rodiere

--- a/engine/src/main/java/org/hibernate/search/v6poc/entity/mapping/building/spi/MetadataCollector.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/entity/mapping/building/spi/MetadataCollector.java
@@ -8,13 +8,12 @@ package org.hibernate.search.v6poc.entity.mapping.building.spi;
 
 import org.hibernate.search.v6poc.entity.model.spi.MappableTypeModel;
 
-/**
- * @author Yoann Rodiere
- */
 public interface MetadataCollector {
 
-	<C extends TypeMetadataContributor> void collect(
-			MapperFactory<C, ?> mapperFactory, MappableTypeModel typeModel, String indexName, C contributor
-	);
+	void mapToIndex(MapperFactory<?, ?> mapperFactory, MappableTypeModel typeModel, String indexName);
+
+	<C> void collectContributor(MapperFactory<C, ?> mapperFactory, MappableTypeModel typeModel, C contributor);
+
+	<C> void collectDiscoverer(MapperFactory<C, ?> mapperFactory, TypeMetadataDiscoverer<C> metadataDiscoverer);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/entity/mapping/building/spi/TypeMetadataDiscoverer.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/entity/mapping/building/spi/TypeMetadataDiscoverer.java
@@ -6,21 +6,22 @@
  */
 package org.hibernate.search.v6poc.entity.mapping.building.spi;
 
+import java.util.Optional;
+
 import org.hibernate.search.v6poc.entity.model.spi.MappableTypeModel;
 
 /**
- * @author Yoann Rodiere
+ * @param <C> The type of contributors
  */
-public interface TypeMetadataContributor {
+public interface TypeMetadataDiscoverer<C> {
 
 	/**
-	 * A hook for plugging in custom behavior before metadata are contributed to a nested type.
-	 * <p>
-	 * Allows to discover metadata lazily during bootstrap, which can be helpful when resolving metadata
+	 * A hook to discover metadata lazily during bootstrap, which can be helpful when resolving metadata
 	 * from the type itself (Java annotations on a Java type, in particular).
 	 *
 	 * @param typeModel The type model which is about to be contributed to.
+	 * @return An additional, automatically discovered contributor.
 	 */
-	void beforeNestedContributions(MappableTypeModel typeModel);
+	Optional<C> discover(MappableTypeModel typeModel);
 
 }

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/CustomMarkerConsumingPropertyBridge.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/CustomMarkerConsumingPropertyBridge.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
 import org.hibernate.search.v6poc.backend.document.IndexObjectFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaElement;
@@ -18,8 +22,6 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoModelProperty;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomMarkerConsumingPropertyBridgeAnnotation;
 
 public final class CustomMarkerConsumingPropertyBridge implements PropertyBridge {
-
-	public static final String OBJECT_FIELD_NAME = "customMarkerField";
 
 	public static final class Builder
 			implements AnnotationBridgeBuilder<PropertyBridge, CustomMarkerConsumingPropertyBridgeAnnotation> {
@@ -34,7 +36,7 @@ public final class CustomMarkerConsumingPropertyBridge implements PropertyBridge
 		}
 	}
 
-	private IndexObjectFieldAccessor objectFieldAccessor;
+	private List<IndexObjectFieldAccessor> objectFieldAccessors = new ArrayList<>();
 
 	private CustomMarkerConsumingPropertyBridge() {
 	}
@@ -42,17 +44,18 @@ public final class CustomMarkerConsumingPropertyBridge implements PropertyBridge
 	@Override
 	public void bind(IndexSchemaElement indexSchemaElement, PojoModelProperty bridgedPojoModelProperty,
 			SearchModel searchModel) {
-		if ( bridgedPojoModelProperty.properties().flatMap( property -> property.markers( CustomMarker.class ) )
-				.findAny().isPresent() ) {
-			objectFieldAccessor = indexSchemaElement.objectField( OBJECT_FIELD_NAME ).createAccessor();
-		}
-		else {
-			throw new IllegalArgumentException( "Missing CustomMarker marker on the type's properties" );
+		List<PojoModelProperty> markedProperties = bridgedPojoModelProperty.properties()
+				.filter( property -> property.markers( CustomMarker.class ).findAny().isPresent() )
+				.collect( Collectors.toList() );
+		for ( PojoModelProperty property : markedProperties ) {
+			objectFieldAccessors.add( indexSchemaElement.objectField( property.getName() ).createAccessor() );
 		}
 	}
 
 	@Override
 	public void write(DocumentElement target, PojoElement source) {
-		objectFieldAccessor.add( target );
+		for ( IndexObjectFieldAccessor objectFieldAccessor : objectFieldAccessors ) {
+			objectFieldAccessor.add( target );
+		}
 	}
 }

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/CustomMarkerConsumingPropertyBridge.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/CustomMarkerConsumingPropertyBridge.java
@@ -6,6 +6,10 @@
  */
 package org.hibernate.search.v6poc.integrationtest.orm.bridge;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
 import org.hibernate.search.v6poc.backend.document.IndexObjectFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaElement;
@@ -18,8 +22,6 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoModelProperty;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomMarkerConsumingPropertyBridgeAnnotation;
 
 public final class CustomMarkerConsumingPropertyBridge implements PropertyBridge {
-
-	public static final String OBJECT_FIELD_NAME = "customMarkerField";
 
 	public static final class Builder
 			implements AnnotationBridgeBuilder<PropertyBridge, CustomMarkerConsumingPropertyBridgeAnnotation> {
@@ -34,7 +36,7 @@ public final class CustomMarkerConsumingPropertyBridge implements PropertyBridge
 		}
 	}
 
-	private IndexObjectFieldAccessor objectFieldAccessor;
+	private List<IndexObjectFieldAccessor> objectFieldAccessors = new ArrayList<>();
 
 	private CustomMarkerConsumingPropertyBridge() {
 	}
@@ -42,17 +44,18 @@ public final class CustomMarkerConsumingPropertyBridge implements PropertyBridge
 	@Override
 	public void bind(IndexSchemaElement indexSchemaElement, PojoModelProperty bridgedPojoModelProperty,
 			SearchModel searchModel) {
-		if ( bridgedPojoModelProperty.properties().flatMap( property -> property.markers( CustomMarker.class ) )
-				.findAny().isPresent() ) {
-			objectFieldAccessor = indexSchemaElement.objectField( OBJECT_FIELD_NAME ).createAccessor();
-		}
-		else {
-			throw new IllegalArgumentException( "Missing CustomMarker marker on the type's properties" );
+		List<PojoModelProperty> markedProperties = bridgedPojoModelProperty.properties()
+				.filter( property -> property.markers( CustomMarker.class ).findAny().isPresent() )
+				.collect( Collectors.toList() );
+		for ( PojoModelProperty property : markedProperties ) {
+			objectFieldAccessors.add( indexSchemaElement.objectField( property.getName() ).createAccessor() );
 		}
 	}
 
 	@Override
 	public void write(DocumentElement target, PojoElement source) {
-		objectFieldAccessor.add( target );
+		for ( IndexObjectFieldAccessor objectFieldAccessor : objectFieldAccessors ) {
+			objectFieldAccessor.add( target );
+		}
 	}
 }

--- a/integrationtest/util-common/src/main/java/org/hibernate/search/v6poc/integrationtest/util/common/stub/mapper/StubTypeMetadataContributor.java
+++ b/integrationtest/util-common/src/main/java/org/hibernate/search/v6poc/integrationtest/util/common/stub/mapper/StubTypeMetadataContributor.java
@@ -11,10 +11,8 @@ import java.util.function.Consumer;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.IndexManagerBuildingState;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.IndexModelBindingContext;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.MetadataCollector;
-import org.hibernate.search.v6poc.entity.mapping.building.spi.TypeMetadataContributor;
-import org.hibernate.search.v6poc.entity.model.spi.MappableTypeModel;
 
-class StubTypeMetadataContributor implements TypeMetadataContributor {
+class StubTypeMetadataContributor {
 
 	private final StubTypeModel typeIdentifier;
 	private final String indexName;
@@ -27,12 +25,10 @@ class StubTypeMetadataContributor implements TypeMetadataContributor {
 	}
 
 	final void contribute(StubMapperFactory factory, MetadataCollector collector) {
-		collector.collect( factory, typeIdentifier, indexName, this );
-	}
-
-	@Override
-	public void beforeNestedContributions(MappableTypeModel typeModel) {
-		// No-op
+		if ( indexName != null ) {
+			collector.mapToIndex( factory, typeIdentifier, indexName );
+		}
+		collector.collectContributor( factory, typeIdentifier, this );
 	}
 
 	public void contribute(IndexManagerBuildingState<?> indexManagerBuildingState) {

--- a/mapper-javabean/src/main/java/org/hibernate/search/v6poc/entity/javabean/JavaBeanMappingContributor.java
+++ b/mapper-javabean/src/main/java/org/hibernate/search/v6poc/entity/javabean/JavaBeanMappingContributor.java
@@ -21,16 +21,23 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.spi.PojoMappingContributor
 public final class JavaBeanMappingContributor extends PojoMappingContributorImpl<JavaBeanMapping, JavaBeanMappingImpl> {
 
 	public JavaBeanMappingContributor(SearchMappingRepositoryBuilder mappingRepositoryBuilder) {
-		this( mappingRepositoryBuilder, MethodHandles.publicLookup() );
+		this( mappingRepositoryBuilder, true );
 	}
 
-	public JavaBeanMappingContributor(SearchMappingRepositoryBuilder mappingRepositoryBuilder, MethodHandles.Lookup lookup) {
-		this( mappingRepositoryBuilder, new JavaBeanBootstrapIntrospector( lookup ) );
+	public JavaBeanMappingContributor(SearchMappingRepositoryBuilder mappingRepositoryBuilder,
+			boolean annotatedTypeDiscoveryEnabled) {
+		this( mappingRepositoryBuilder, MethodHandles.publicLookup(), annotatedTypeDiscoveryEnabled );
+	}
+
+	public JavaBeanMappingContributor(SearchMappingRepositoryBuilder mappingRepositoryBuilder,
+			MethodHandles.Lookup lookup, boolean annotatedTypeDiscoveryEnabled) {
+		this( mappingRepositoryBuilder, new JavaBeanBootstrapIntrospector( lookup ), annotatedTypeDiscoveryEnabled );
 	}
 
 	private JavaBeanMappingContributor(SearchMappingRepositoryBuilder mappingRepositoryBuilder,
-			JavaBeanBootstrapIntrospector introspector) {
-		super( mappingRepositoryBuilder, new JavaBeanMapperFactory( introspector ), introspector );
+			JavaBeanBootstrapIntrospector introspector, boolean annotatedTypeDiscoveryEnabled) {
+		super( mappingRepositoryBuilder, new JavaBeanMapperFactory( introspector ), introspector,
+				annotatedTypeDiscoveryEnabled );
 	}
 
 	@Override

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoTypeMetadataContributor.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoTypeMetadataContributor.java
@@ -7,16 +7,7 @@
 package org.hibernate.search.v6poc.entity.pojo.mapping.building.impl;
 
 
-import org.hibernate.search.v6poc.entity.mapping.building.spi.TypeMetadataContributor;
-import org.hibernate.search.v6poc.entity.model.spi.MappableTypeModel;
-
 public interface PojoTypeMetadataContributor
-		extends PojoMetadataContributor<PojoModelCollectorTypeNode, PojoMappingCollectorTypeNode>,
-		TypeMetadataContributor {
-
-	@Override
-	default void beforeNestedContributions(MappableTypeModel typeModel) {
-		// No-op by default
-	}
+		extends PojoMetadataContributor<PojoModelCollectorTypeNode, PojoMappingCollectorTypeNode> {
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/impl/AnnotationMappingDefinitionImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/impl/AnnotationMappingDefinitionImpl.java
@@ -7,22 +7,21 @@
 package org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.impl;
 
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Set;
 
 import org.hibernate.search.v6poc.engine.spi.BeanResolver;
 import org.hibernate.search.v6poc.engine.spi.BuildContext;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.MetadataCollector;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.MetadataContributor;
+import org.hibernate.search.v6poc.entity.mapping.building.spi.TypeMetadataDiscoverer;
 import org.hibernate.search.v6poc.entity.model.spi.MappableTypeModel;
-import org.hibernate.search.v6poc.entity.pojo.mapping.building.impl.PojoMappingCollectorTypeNode;
 import org.hibernate.search.v6poc.entity.pojo.mapping.building.impl.PojoTypeMetadataContributor;
-import org.hibernate.search.v6poc.entity.pojo.mapping.building.impl.PojoModelCollectorTypeNode;
 import org.hibernate.search.v6poc.entity.pojo.mapping.building.spi.PojoMapperFactory;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.AnnotationMappingDefinition;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoBootstrapIntrospector;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoRawTypeModel;
-import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
 
 /**
  * @author Yoann Rodiere
@@ -30,14 +29,15 @@ import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
 public class AnnotationMappingDefinitionImpl implements AnnotationMappingDefinition, MetadataContributor {
 
 	private final PojoMapperFactory<?> mapperFactory;
-
 	private final PojoBootstrapIntrospector introspector;
-
 	private final Set<Class<?>> annotatedTypes = new HashSet<>();
+	private final boolean annotatedTypeDiscoveryEnabled;
 
-	public AnnotationMappingDefinitionImpl(PojoMapperFactory<?> mapperFactory, PojoBootstrapIntrospector introspector) {
+	public AnnotationMappingDefinitionImpl(PojoMapperFactory<?> mapperFactory, PojoBootstrapIntrospector introspector,
+			boolean annotatedTypeDiscoveryEnabled) {
 		this.mapperFactory = mapperFactory;
 		this.introspector = introspector;
+		this.annotatedTypeDiscoveryEnabled = annotatedTypeDiscoveryEnabled;
 	}
 
 	@Override
@@ -54,91 +54,73 @@ public class AnnotationMappingDefinitionImpl implements AnnotationMappingDefinit
 
 	@Override
 	public void contribute(BuildContext buildContext, MetadataCollector collector) {
-		LazilyDiscoveringMetadataContributor contributor =
-				new LazilyDiscoveringMetadataContributor( mapperFactory, buildContext, collector );
+		BeanResolver beanResolver = buildContext.getServiceManager().getBeanResolver();
+
+		/*
+		 * For types that were explicitly requested for annotation scanning and their supertypes,
+		 * map the types to indexes if necessary, and add a metadata contributor.
+		 */
+		Set<PojoRawTypeModel<?>> alreadyContributedTypes = new HashSet<>();
 		annotatedTypes.stream()
 				.map( introspector::getTypeModel )
-				.forEach( typeModel -> contributor.contributeTypeAndSuperTypes( typeModel, true ) );
+				/*
+				 * Take super types into account
+				 * Note: the order of super types (ascending or descending) does not matter here.
+				 */
+				.flatMap( PojoRawTypeModel::getAscendingSuperTypes )
+				// Ignore types that were already contributed
+				.filter( alreadyContributedTypes::add )
+				// TODO filter out standard Java types, e.g. Object or standard Java interfaces such as Serializable?
+				.forEach( typeModel -> {
+					Optional<Indexed> indexedAnnotation = typeModel.getAnnotationByType( Indexed.class );
+					if ( indexedAnnotation.isPresent() ) {
+						collector.mapToIndex( mapperFactory, typeModel, indexedAnnotation.get().index() );
+					}
+
+					PojoTypeMetadataContributor contributor =
+							new AnnotationPojoTypeMetadataContributorImpl( beanResolver, typeModel );
+
+					collector.collectContributor( mapperFactory, typeModel, contributor );
+				} );
+
+		/*
+		 * If automatic discovery of annotated types is enabled,
+		 * also add a discoverer for new types (e.g. types encountered in an @IndexedEmbedded).
+		 */
+		if ( annotatedTypeDiscoveryEnabled ) {
+			AnnotationTypeMetadataDiscoverer discoverer =
+					new AnnotationTypeMetadataDiscoverer( beanResolver, alreadyContributedTypes );
+			collector.collectDiscoverer( mapperFactory, discoverer );
+		}
 	}
 
 	/**
-	 * A metadata contributor that will lazily discover nested types and register the annotation mappings accordingly.
+	 * A type metadata discoverer that will provide annotation-based metadata
+	 * for types that were not explicitly requested .
 	 */
-	private static class LazilyDiscoveringMetadataContributor {
-		private final PojoMapperFactory<?> mapperFactory;
+	private static class AnnotationTypeMetadataDiscoverer implements TypeMetadataDiscoverer<PojoTypeMetadataContributor> {
 		private final BeanResolver beanResolver;
-		private final MetadataCollector metadataCollector;
-		private final Set<PojoRawTypeModel<?>> alreadyContributedTypes = new HashSet<>();
+		private final Set<PojoRawTypeModel<?>> alreadyContributedTypes;
 
-		LazilyDiscoveringMetadataContributor(PojoMapperFactory<?> mapperFactory,
-				BuildContext buildContext, MetadataCollector metadataCollector) {
-			this.mapperFactory = mapperFactory;
-			this.beanResolver = buildContext.getServiceManager().getBeanResolver();
-			this.metadataCollector = metadataCollector;
+		AnnotationTypeMetadataDiscoverer(BeanResolver beanResolver, Set<PojoRawTypeModel<?>> alreadyContributedTypes) {
+			this.beanResolver = beanResolver;
+			this.alreadyContributedTypes = alreadyContributedTypes;
 		}
 
-		void contributeTypeAndSuperTypes(PojoRawTypeModel<?> subTypeModel, boolean mapToIndex) {
+		@Override
+		public Optional<PojoTypeMetadataContributor> discover(MappableTypeModel typeModel) {
+			PojoRawTypeModel<?> pojoTypeModel = (PojoRawTypeModel<?>) typeModel;
 			/*
-			 * Take super types into account
-			 * Note: the order of super types (ascending or descending) does not matter here.
+			 * Take care of not adding duplicate contributors: this could lead to mapping errors,
+			 * for instance a field being declared twice.
 			 */
-			subTypeModel.getAscendingSuperTypes()
-					// Ignore types that were already contributed
-					.filter( alreadyContributedTypes::add )
-					// TODO filter out standard Java types, e.g. Object or standard Java interfaces such as Serializable?
-					.forEach( typeModel -> {
-						String indexName;
-						if ( mapToIndex ) {
-							indexName = typeModel.getAnnotationByType( Indexed.class )
-									.map( Indexed::index ).orElse( null );
-						}
-						else {
-							indexName = null;
-						}
-
-						PojoTypeMetadataContributor contributor =
-								new AnnotationPojoTypeMetadataContributorImpl( beanResolver, typeModel );
-
-						// Make sure to enable automatically discovering types whenever this contributor is called
-						contributor = new LazilyDiscoveringTypeMetadataContributor( contributor );
-
-						metadataCollector.collect( mapperFactory, typeModel, indexName, contributor );
-					} );
-		}
-
-		private void discoverType(PojoTypeModel<?> typeModel) {
-			PojoRawTypeModel<?> rawTypeModel = typeModel.getRawType();
-			if ( !alreadyContributedTypes.contains( rawTypeModel ) ) {
-				/*
-				 * Do not map lazily discovered types to an index;
-				 * only explicitly registered types should be mapped to an index,
-				 * others should only be used in fields and indexed-embedded.
-				 */
-				contributeTypeAndSuperTypes( rawTypeModel, false );
+			boolean neverContributed = alreadyContributedTypes.add( pojoTypeModel );
+			if ( neverContributed ) {
+				// TODO filter out standard Java types, e.g. Object or standard Java interfaces such as Serializable?
+				return Optional.of( new AnnotationPojoTypeMetadataContributorImpl( beanResolver, pojoTypeModel ) );
 			}
-		}
-
-		private class LazilyDiscoveringTypeMetadataContributor implements PojoTypeMetadataContributor {
-			private final PojoTypeMetadataContributor delegate;
-
-			private LazilyDiscoveringTypeMetadataContributor(PojoTypeMetadataContributor delegate) {
-				this.delegate = delegate;
-			}
-
-			@Override
-			public void beforeNestedContributions(MappableTypeModel typeModel) {
-				discoverType( (PojoTypeModel<?>) typeModel );
-				delegate.beforeNestedContributions( typeModel );
-			}
-
-			@Override
-			public void contributeModel(PojoModelCollectorTypeNode collector) {
-				delegate.contributeModel( collector );
-			}
-
-			@Override
-			public void contributeMapping(PojoMappingCollectorTypeNode collector) {
-				delegate.contributeMapping( collector );
+			else {
+				return Optional.empty();
 			}
 		}
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/programmatic/impl/TypeMappingContextImpl.java
@@ -50,7 +50,10 @@ public class TypeMappingContextImpl implements TypeMappingContext, MetadataContr
 
 	@Override
 	public void contribute(BuildContext buildContext, MetadataCollector collector) {
-		collector.collect( mapperFactory, typeModel, indexName, this );
+		if ( indexName != null ) {
+			collector.mapToIndex( mapperFactory, typeModel, indexName );
+		}
+		collector.collectContributor( mapperFactory, typeModel, this );
 	}
 
 	@Override

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/spi/PojoMappingContributorImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/spi/PojoMappingContributorImpl.java
@@ -33,10 +33,23 @@ public abstract class PojoMappingContributorImpl<M extends PojoMapping, MI exten
 
 	protected PojoMappingContributorImpl(SearchMappingRepositoryBuilder mappingRepositoryBuilder,
 			PojoMapperFactory<MI> mapperFactory,
-			PojoBootstrapIntrospector introspector) {
+			PojoBootstrapIntrospector introspector,
+			boolean annotatedTypeDiscoveryEnabled) {
 		this.mappingRepositoryBuilder = mappingRepositoryBuilder;
 		this.mapperFactory = mapperFactory;
 		this.introspector = introspector;
+
+		/*
+		 * Make sure to create and add the annotation mapping even if the user does not call the
+		 * annotationMapping() method to register annotated types explicitly,
+		 * in case annotated type discovery is enabled.
+		 * Also, make sure to re-use the same mapping, so as not to parse annotations on a given type twice,
+		 * which would lead to duplicate field definitions.
+		 */
+		annotationMappingDefinition = new AnnotationMappingDefinitionImpl(
+				mapperFactory, introspector, annotatedTypeDiscoveryEnabled
+		);
+		mappingRepositoryBuilder.addMapping( annotationMappingDefinition );
 	}
 
 	@Override
@@ -48,17 +61,6 @@ public abstract class PojoMappingContributorImpl<M extends PojoMapping, MI exten
 
 	@Override
 	public AnnotationMappingDefinition annotationMapping() {
-		/*
-		 * Make sure to re-use the same mapping, so as not to parse annotations on a given type twice,
-		 * which would lead to duplicate field definitions.
-		 */
-		if ( annotationMappingDefinition == null ) {
-			AnnotationMappingDefinitionImpl definition = new AnnotationMappingDefinitionImpl(
-					mapperFactory, introspector
-			);
-			mappingRepositoryBuilder.addMapping( definition );
-			annotationMappingDefinition = definition;
-		}
 		return annotationMappingDefinition;
 	}
 

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/bootstrap/impl/HibernateSearchSessionFactoryObserver.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/bootstrap/impl/HibernateSearchSessionFactoryObserver.java
@@ -41,6 +41,12 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Anno
  */
 public class HibernateSearchSessionFactoryObserver implements SessionFactoryObserver {
 
+	private static final ConfigurationProperty<Boolean> ENABLE_ANNOTATION_MAPPING =
+			ConfigurationProperty.forKey( SearchOrmSettings.Radicals.ENABLE_ANNOTATION_MAPPING )
+					.asBoolean()
+					.withDefault( true )
+					.build();
+
 	private final ConfigurationPropertySource propertySource;
 	private final JndiService namingService;
 	private final ClassLoaderService classLoaderService;
@@ -55,7 +61,7 @@ public class HibernateSearchSessionFactoryObserver implements SessionFactoryObse
 	// TODO JMX
 //	private JMXHook jmx;
 
-	public HibernateSearchSessionFactoryObserver(
+	HibernateSearchSessionFactoryObserver(
 			Metadata metadata,
 			ConfigurationPropertySource propertySource,
 			FullTextIndexEventListener listener,
@@ -113,8 +119,11 @@ public class HibernateSearchSessionFactoryObserver implements SessionFactoryObse
 		boolean failedBoot = true;
 		try {
 			SearchMappingRepositoryBuilder builder = SearchMappingRepository.builder( propertySource );
+
+			boolean enableAnnotationMapping = ENABLE_ANNOTATION_MAPPING.get( propertySource );
+
 			HibernateOrmMappingContributor mappingContributor = new HibernateOrmMappingContributor(
-					builder, metadata, sessionFactoryImplementor
+					builder, metadata, sessionFactoryImplementor, enableAnnotationMapping
 			);
 
 			org.hibernate.search.v6poc.engine.spi.BeanResolver searchBeanResolver;
@@ -126,12 +135,14 @@ public class HibernateSearchSessionFactoryObserver implements SessionFactoryObse
 			}
 			builder.setBeanResolver( searchBeanResolver );
 
-			AnnotationMappingDefinition annotationMapping = mappingContributor.annotationMapping();
-			metadata.getEntityBindings().stream()
-					.map( PersistentClass::getMappedClass )
-					// getMappedClass() can return null, which should be ignored
-					.filter( Objects::nonNull )
-					.forEach( annotationMapping::add );
+			if ( enableAnnotationMapping ) {
+				AnnotationMappingDefinition annotationMapping = mappingContributor.annotationMapping();
+				metadata.getEntityBindings().stream()
+						.map( PersistentClass::getMappedClass )
+						// getMappedClass() can return null, which should be ignored
+						.filter( Objects::nonNull )
+						.forEach( annotationMapping::add );
+			}
 
 			ConfigurationProperty<Optional<HibernateOrmSearchMappingContributor>> userMappingContributorProperty =
 					ConfigurationProperty.forKey( SearchOrmSettings.Radicals.MAPPING_CONTRIBUTOR )

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/cfg/SearchOrmSettings.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/cfg/SearchOrmSettings.java
@@ -34,6 +34,13 @@ public final class SearchOrmSettings {
 	public static final String ENABLE_DIRTY_CHECK = PREFIX + Radicals.ENABLE_DIRTY_CHECK;
 
 	/**
+	 * When enabled, annotations will be automatically processed for entity types,
+	 * as well as nested types in those entity types, for instance embedded types.
+	 * Enabled by default. Disable to only consider {@link #MAPPING_CONTRIBUTOR}.
+	 */
+	public static final String ENABLE_ANNOTATION_MAPPING = PREFIX + Radicals.ENABLE_ANNOTATION_MAPPING;
+
+	/**
 	 * Provide a programmatic mapping model to Hibernate Search configuration
 	 * Accepts a {@link org.hibernate.search.v6poc.entity.orm.mapping.HibernateOrmSearchMappingContributor}
 	 * instance or the fully qualified class name of a HibernateOrmSearchMappingContributor subclass.
@@ -45,6 +52,7 @@ public final class SearchOrmSettings {
 		public static final String AUTOREGISTER_LISTENERS = "autoregister_listeners";
 		public static final String INDEXING_STRATEGY = "indexing_strategy";
 		public static final String ENABLE_DIRTY_CHECK = "enable_dirty_check";
+		public static final String ENABLE_ANNOTATION_MAPPING = "enable_annotation_mapping";
 		public static final String MAPPING_CONTRIBUTOR = "mapping_contributor";
 
 		private Radicals() {

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/mapping/HibernateOrmMappingContributor.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/mapping/HibernateOrmMappingContributor.java
@@ -29,14 +29,17 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.spi.PojoMappingContributor
 public class HibernateOrmMappingContributor extends PojoMappingContributorImpl<HibernateOrmMapping, HibernateOrmMappingImpl> {
 
 	public HibernateOrmMappingContributor(SearchMappingRepositoryBuilder mappingRepositoryBuilder,
-			Metadata metadata, SessionFactoryImplementor sessionFactoryImplementor) {
+			Metadata metadata, SessionFactoryImplementor sessionFactoryImplementor,
+			boolean annotatedTypeDiscoveryEnabled) {
 		this( mappingRepositoryBuilder, new HibernateOrmBootstrapIntrospector( metadata, sessionFactoryImplementor ),
-				sessionFactoryImplementor );
+				sessionFactoryImplementor, annotatedTypeDiscoveryEnabled );
 	}
 
 	private HibernateOrmMappingContributor(SearchMappingRepositoryBuilder mappingRepositoryBuilder,
-			HibernateOrmBootstrapIntrospector introspector, SessionFactoryImplementor sessionFactoryImplementor) {
-		super( mappingRepositoryBuilder, new HibernateOrmMapperFactory( introspector, sessionFactoryImplementor ), introspector );
+			HibernateOrmBootstrapIntrospector introspector, SessionFactoryImplementor sessionFactoryImplementor,
+			boolean annotatedTypeDiscoveryEnabled) {
+		super( mappingRepositoryBuilder, new HibernateOrmMapperFactory( introspector, sessionFactoryImplementor ),
+				introspector, annotatedTypeDiscoveryEnabled );
 	}
 
 	@Override


### PR DESCRIPTION
The previous implementation tried to be smart, discovering nested type
annotations when processing annotation mapping, and ignoring them when
processing programmatic mapping.

But the approach was fundamentally flawed: some of the discovered
metadata is cached, and shared between all the mappings. For instance
this is the case of markers. So with the previous approach, discovered
annotations could impact a programmatic mapping or not depending on
whether they were discovered before or after the programmatic mapping
was processed. Which can be terribly confusing.

Thus I gave up and made annotation discovery a global setting: either
you enable it everywhere (in annotation and programmatic mappings),
or you don't enable it at all.

The original goal of this switch was to allow people with annotated
classes to ignore the annotations and only rely on a programmatic
mapping, so I also added a setting in the ORM integration to disable
annotation mapping completely.