### PR TITLE
Rename FunctionBridge to ValueBridge

### DIFF
--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanAnnotationMappingIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanAnnotationMappingIT.java
@@ -32,7 +32,7 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.PojoSearchManager;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ContainerValueExtractorBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.FunctionBridgeBeanReference;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IdentifierBridgeBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -40,8 +40,8 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.impl.PojoReferenceImpl;
 import org.hibernate.search.v6poc.entity.pojo.search.PojoReference;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomPropertyBridge;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomTypeBridge;
-import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.IntegerAsStringFunctionBridge;
-import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.OptionalIntAsStringFunctionBridge;
+import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.IntegerAsStringValueBridge;
+import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.OptionalIntAsStringValueBridge;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomPropertyBridgeAnnotation;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomTypeBridgeAnnotation;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.BackendMock;
@@ -177,10 +177,10 @@ public class JavaBeanAnnotationMappingIT {
 				- counters.get( CustomTypeBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 4, counters.get( CustomPropertyBridge.INSTANCE_COUNTER_KEY )
 				- counters.get( CustomPropertyBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 1, counters.get( IntegerAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( IntegerAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 1, counters.get( OptionalIntAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( OptionalIntAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 1, counters.get( IntegerAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( IntegerAsStringValueBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 1, counters.get( OptionalIntAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( OptionalIntAsStringValueBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 3, counters.get( StubIndexManager.INSTANCE_COUNTER_KEY ) );
 		mappingRepository.close();
 		mappingRepository = null;
@@ -189,10 +189,10 @@ public class JavaBeanAnnotationMappingIT {
 				- counters.get( CustomTypeBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 0, counters.get( CustomPropertyBridge.INSTANCE_COUNTER_KEY )
 				- counters.get( CustomPropertyBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 0, counters.get( IntegerAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( IntegerAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 0, counters.get( OptionalIntAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( OptionalIntAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 0, counters.get( IntegerAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( IntegerAsStringValueBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 0, counters.get( OptionalIntAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( OptionalIntAsStringValueBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 0, counters.get( StubIndexManager.INSTANCE_COUNTER_KEY )
 				- counters.get( StubIndexManager.CLOSE_COUNTER_KEY ) );
 	}
@@ -572,7 +572,7 @@ public class JavaBeanAnnotationMappingIT {
 		}
 
 		@Field
-		@Field(name = "numericAsString", functionBridge = @FunctionBridgeBeanReference(type = IntegerAsStringFunctionBridge.class))
+		@Field(name = "numericAsString", valueBridge = @ValueBridgeBeanReference(type = IntegerAsStringValueBridge.class))
 		public Integer getNumeric() {
 			return numeric;
 		}
@@ -636,7 +636,7 @@ public class JavaBeanAnnotationMappingIT {
 		@Field
 		@Field(
 				name = "optionalIntAsString",
-				functionBridge = @FunctionBridgeBeanReference(type = OptionalIntAsStringFunctionBridge.class),
+				valueBridge = @ValueBridgeBeanReference(type = OptionalIntAsStringValueBridge.class),
 				extractors = {} // Explicitly skip the default extractors
 		)
 		public OptionalInt getOptionalInt() {

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanProgrammaticMappingIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanProgrammaticMappingIT.java
@@ -32,8 +32,8 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.impl.PojoReferenceImpl;
 import org.hibernate.search.v6poc.entity.pojo.search.PojoReference;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomPropertyBridge;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomTypeBridge;
-import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.IntegerAsStringFunctionBridge;
-import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.OptionalIntAsStringFunctionBridge;
+import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.IntegerAsStringValueBridge;
+import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.OptionalIntAsStringValueBridge;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.BackendMock;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.StaticCounters;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.StubSearchWorkBehavior;
@@ -101,7 +101,7 @@ public class JavaBeanProgrammaticMappingIT {
 						.documentId().identifierBridge( DefaultIntegerIdentifierBridge.class )
 				.property( "numeric" )
 						.field()
-						.field( "numericAsString" ).functionBridge( IntegerAsStringFunctionBridge.class );
+						.field( "numericAsString" ).valueBridge( IntegerAsStringValueBridge.class );
 		secondMappingDefinition.type( YetAnotherIndexedEntity.class )
 				.indexed( YetAnotherIndexedEntity.INDEX )
 				.property( "id" )
@@ -113,7 +113,7 @@ public class JavaBeanProgrammaticMappingIT {
 				.property( "optionalInt" )
 						.field()
 						.field( "optionalIntAsString" )
-								.functionBridge( OptionalIntAsStringFunctionBridge.class )
+								.valueBridge( OptionalIntAsStringValueBridge.class )
 								.withoutExtractors()
 				.property( "numericArray" )
 						.field()
@@ -220,10 +220,10 @@ public class JavaBeanProgrammaticMappingIT {
 				- counters.get( CustomTypeBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 4, counters.get( CustomPropertyBridge.INSTANCE_COUNTER_KEY )
 				- counters.get( CustomPropertyBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 1, counters.get( IntegerAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( IntegerAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 1, counters.get( OptionalIntAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( OptionalIntAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 1, counters.get( IntegerAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( IntegerAsStringValueBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 1, counters.get( OptionalIntAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( OptionalIntAsStringValueBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 3, counters.get( StubIndexManager.INSTANCE_COUNTER_KEY ) );
 		mappingRepository.close();
 		mappingRepository = null;
@@ -232,10 +232,10 @@ public class JavaBeanProgrammaticMappingIT {
 				- counters.get( CustomTypeBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 0, counters.get( CustomPropertyBridge.INSTANCE_COUNTER_KEY )
 				- counters.get( CustomPropertyBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 0, counters.get( IntegerAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( IntegerAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 0, counters.get( OptionalIntAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( OptionalIntAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 0, counters.get( IntegerAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( IntegerAsStringValueBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 0, counters.get( OptionalIntAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( OptionalIntAsStringValueBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 0, counters.get( StubIndexManager.INSTANCE_COUNTER_KEY )
 				- counters.get( StubIndexManager.CLOSE_COUNTER_KEY ) );
 	}

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/IntegerAsStringValueBridge.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/IntegerAsStringValueBridge.java
@@ -4,27 +4,23 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.v6poc.integrationtest.orm.bridge;
+package org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge;
 
-import java.util.OptionalInt;
-
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.StaticCounters;
 
-public final class OptionalIntAsStringFunctionBridge implements FunctionBridge<OptionalInt, String> {
+public final class IntegerAsStringValueBridge implements ValueBridge<Integer, String> {
 
 	public static final StaticCounters.Key INSTANCE_COUNTER_KEY = StaticCounters.createKey();
 	public static final StaticCounters.Key CLOSE_COUNTER_KEY = StaticCounters.createKey();
 
-	public OptionalIntAsStringFunctionBridge() {
+	public IntegerAsStringValueBridge() {
 		StaticCounters.get().increment( INSTANCE_COUNTER_KEY );
 	}
 
 	@Override
-	public String toIndexedValue(OptionalInt propertyValue) {
-		return propertyValue == null || !propertyValue.isPresent()
-				? "empty"
-				: String.valueOf( propertyValue.getAsInt() );
+	public String toIndexedValue(Integer value) {
+		return value == null ? null : value.toString();
 	}
 
 	@Override

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/OptionalIntAsStringValueBridge.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/OptionalIntAsStringValueBridge.java
@@ -4,23 +4,27 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.v6poc.integrationtest.orm.bridge;
+package org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import java.util.OptionalInt;
+
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.StaticCounters;
 
-public final class IntegerAsStringFunctionBridge implements FunctionBridge<Integer, String> {
+public final class OptionalIntAsStringValueBridge implements ValueBridge<OptionalInt, String> {
 
 	public static final StaticCounters.Key INSTANCE_COUNTER_KEY = StaticCounters.createKey();
 	public static final StaticCounters.Key CLOSE_COUNTER_KEY = StaticCounters.createKey();
 
-	public IntegerAsStringFunctionBridge() {
+	public OptionalIntAsStringValueBridge() {
 		StaticCounters.get().increment( INSTANCE_COUNTER_KEY );
 	}
 
 	@Override
-	public String toIndexedValue(Integer propertyValue) {
-		return propertyValue == null ? null : propertyValue.toString();
+	public String toIndexedValue(OptionalInt value) {
+		return value == null || !value.isPresent()
+				? "empty"
+				: String.valueOf( value.getAsInt() );
 	}
 
 	@Override

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingIT.java
@@ -41,15 +41,15 @@ import org.hibernate.search.v6poc.entity.pojo.extractor.builtin.MapKeyExtractor;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ContainerValueExtractorBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.FunctionBridgeBeanReference;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IdentifierBridgeBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.entity.pojo.mapping.impl.PojoReferenceImpl;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomPropertyBridge;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomTypeBridge;
-import org.hibernate.search.v6poc.integrationtest.orm.bridge.IntegerAsStringFunctionBridge;
-import org.hibernate.search.v6poc.integrationtest.orm.bridge.OptionalIntAsStringFunctionBridge;
+import org.hibernate.search.v6poc.integrationtest.orm.bridge.IntegerAsStringValueBridge;
+import org.hibernate.search.v6poc.integrationtest.orm.bridge.OptionalIntAsStringValueBridge;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomPropertyBridgeAnnotation;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomTypeBridgeAnnotation;
 import org.hibernate.search.v6poc.integrationtest.orm.usertype.OptionalIntUserType;
@@ -181,10 +181,10 @@ public class OrmAnnotationMappingIT {
 				- counters.get( CustomTypeBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 3, counters.get( CustomPropertyBridge.INSTANCE_COUNTER_KEY )
 				- counters.get( CustomPropertyBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 1, counters.get( IntegerAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( IntegerAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 1, counters.get( OptionalIntAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( OptionalIntAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 1, counters.get( IntegerAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( IntegerAsStringValueBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 1, counters.get( OptionalIntAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( OptionalIntAsStringValueBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 3, counters.get( StubIndexManager.INSTANCE_COUNTER_KEY ) );
 		sessionFactory.close();
 		sessionFactory = null;
@@ -193,10 +193,10 @@ public class OrmAnnotationMappingIT {
 				- counters.get( CustomTypeBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 0, counters.get( CustomPropertyBridge.INSTANCE_COUNTER_KEY )
 				- counters.get( CustomPropertyBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 0, counters.get( IntegerAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( IntegerAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 0, counters.get( OptionalIntAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( OptionalIntAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 0, counters.get( IntegerAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( IntegerAsStringValueBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 0, counters.get( OptionalIntAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( OptionalIntAsStringValueBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 0, counters.get( StubIndexManager.INSTANCE_COUNTER_KEY )
 				- counters.get( StubIndexManager.CLOSE_COUNTER_KEY ) );
 	}
@@ -547,7 +547,7 @@ public class OrmAnnotationMappingIT {
 		@Id
 		private Integer id;
 
-		@Field(name = "numericAsString", functionBridge = @FunctionBridgeBeanReference(type = IntegerAsStringFunctionBridge.class))
+		@Field(name = "numericAsString", valueBridge = @ValueBridgeBeanReference(type = IntegerAsStringValueBridge.class))
 		private Integer numeric;
 
 		@DocumentId(identifierBridge = @IdentifierBridgeBeanReference(type = DefaultIntegerIdentifierBridge.class))
@@ -628,7 +628,7 @@ public class OrmAnnotationMappingIT {
 		@Field
 		@Field(
 				name = "optionalIntAsString",
-				functionBridge = @FunctionBridgeBeanReference(type = OptionalIntAsStringFunctionBridge.class),
+				valueBridge = @ValueBridgeBeanReference(type = OptionalIntAsStringValueBridge.class),
 				extractors = {} // Explicitly skip the default extractors
 		)
 		@Access( AccessType.PROPERTY )

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmProgrammaticMappingIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmProgrammaticMappingIT.java
@@ -44,8 +44,8 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.programmatic.Pr
 import org.hibernate.search.v6poc.entity.pojo.mapping.impl.PojoReferenceImpl;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomPropertyBridge;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomTypeBridge;
-import org.hibernate.search.v6poc.integrationtest.orm.bridge.IntegerAsStringFunctionBridge;
-import org.hibernate.search.v6poc.integrationtest.orm.bridge.OptionalIntAsStringFunctionBridge;
+import org.hibernate.search.v6poc.integrationtest.orm.bridge.IntegerAsStringValueBridge;
+import org.hibernate.search.v6poc.integrationtest.orm.bridge.OptionalIntAsStringValueBridge;
 import org.hibernate.search.v6poc.integrationtest.orm.usertype.OptionalIntUserType;
 import org.hibernate.search.v6poc.integrationtest.orm.usertype.OptionalStringUserType;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.BackendMock;
@@ -176,10 +176,10 @@ public class OrmProgrammaticMappingIT {
 				- counters.get( CustomTypeBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 3, counters.get( CustomPropertyBridge.INSTANCE_COUNTER_KEY )
 				- counters.get( CustomPropertyBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 1, counters.get( IntegerAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( IntegerAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 1, counters.get( OptionalIntAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( OptionalIntAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 1, counters.get( IntegerAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( IntegerAsStringValueBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 1, counters.get( OptionalIntAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( OptionalIntAsStringValueBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 3, counters.get( StubIndexManager.INSTANCE_COUNTER_KEY ) );
 		sessionFactory.close();
 		sessionFactory = null;
@@ -188,10 +188,10 @@ public class OrmProgrammaticMappingIT {
 				- counters.get( CustomTypeBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 0, counters.get( CustomPropertyBridge.INSTANCE_COUNTER_KEY )
 				- counters.get( CustomPropertyBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 0, counters.get( IntegerAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( IntegerAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
-		assertEquals( 0, counters.get( OptionalIntAsStringFunctionBridge.INSTANCE_COUNTER_KEY )
-				- counters.get( OptionalIntAsStringFunctionBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 0, counters.get( IntegerAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( IntegerAsStringValueBridge.CLOSE_COUNTER_KEY ) );
+		assertEquals( 0, counters.get( OptionalIntAsStringValueBridge.INSTANCE_COUNTER_KEY )
+				- counters.get( OptionalIntAsStringValueBridge.CLOSE_COUNTER_KEY ) );
 		assertEquals( 0, counters.get( StubIndexManager.INSTANCE_COUNTER_KEY )
 				- counters.get( StubIndexManager.CLOSE_COUNTER_KEY ) );
 	}
@@ -500,7 +500,7 @@ public class OrmProgrammaticMappingIT {
 							.documentId().identifierBridge( DefaultIntegerIdentifierBridge.class )
 					.property( "numeric" )
 							.field()
-							.field( "numericAsString" ).functionBridge( IntegerAsStringFunctionBridge.class );
+							.field( "numericAsString" ).valueBridge( IntegerAsStringValueBridge.class );
 			secondMapping.type( YetAnotherIndexedEntity.class )
 					.indexed( YetAnotherIndexedEntity.INDEX )
 					.property( "id" )
@@ -512,7 +512,7 @@ public class OrmProgrammaticMappingIT {
 					.property( "optionalInt" )
 							.field()
 							.field( "optionalIntAsString" )
-									.functionBridge( OptionalIntAsStringFunctionBridge.class )
+									.valueBridge( OptionalIntAsStringValueBridge.class )
 									.withoutExtractors()
 					.property( "numericArray" )
 							.field()

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/IntegerAsStringValueBridge.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/IntegerAsStringValueBridge.java
@@ -4,23 +4,23 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge;
+package org.hibernate.search.v6poc.integrationtest.orm.bridge;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.StaticCounters;
 
-public final class IntegerAsStringFunctionBridge implements FunctionBridge<Integer, String> {
+public final class IntegerAsStringValueBridge implements ValueBridge<Integer, String> {
 
 	public static final StaticCounters.Key INSTANCE_COUNTER_KEY = StaticCounters.createKey();
 	public static final StaticCounters.Key CLOSE_COUNTER_KEY = StaticCounters.createKey();
 
-	public IntegerAsStringFunctionBridge() {
+	public IntegerAsStringValueBridge() {
 		StaticCounters.get().increment( INSTANCE_COUNTER_KEY );
 	}
 
 	@Override
-	public String toIndexedValue(Integer propertyValue) {
-		return propertyValue == null ? null : propertyValue.toString();
+	public String toIndexedValue(Integer value) {
+		return value == null ? null : value.toString();
 	}
 
 	@Override

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/OptionalIntAsStringValueBridge.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/OptionalIntAsStringValueBridge.java
@@ -4,27 +4,27 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge;
+package org.hibernate.search.v6poc.integrationtest.orm.bridge;
 
 import java.util.OptionalInt;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.integrationtest.util.common.rule.StaticCounters;
 
-public final class OptionalIntAsStringFunctionBridge implements FunctionBridge<OptionalInt, String> {
+public final class OptionalIntAsStringValueBridge implements ValueBridge<OptionalInt, String> {
 
 	public static final StaticCounters.Key INSTANCE_COUNTER_KEY = StaticCounters.createKey();
 	public static final StaticCounters.Key CLOSE_COUNTER_KEY = StaticCounters.createKey();
 
-	public OptionalIntAsStringFunctionBridge() {
+	public OptionalIntAsStringValueBridge() {
 		StaticCounters.get().increment( INSTANCE_COUNTER_KEY );
 	}
 
 	@Override
-	public String toIndexedValue(OptionalInt propertyValue) {
-		return propertyValue == null || !propertyValue.isPresent()
+	public String toIndexedValue(OptionalInt value) {
+		return value == null || !value.isPresent()
 				? "empty"
-				: String.valueOf( propertyValue.getAsInt() );
+				: String.valueOf( value.getAsInt() );
 	}
 
 	@Override

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/BookMediumBridge.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/BookMediumBridge.java
@@ -6,17 +6,17 @@
  */
 package org.hibernate.search.v6poc.integrationtest.showcase.library.bridge;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.model.BookMedium;
 
-public class BookMediumBridge implements FunctionBridge<BookMedium, String> {
+public class BookMediumBridge implements ValueBridge<BookMedium, String> {
 	@Override
-	public String toIndexedValue(BookMedium propertyValue) {
-		return propertyValue == null ? null : propertyValue.name();
+	public String toIndexedValue(BookMedium value) {
+		return value == null ? null : value.name();
 	}
 
 	@Override
-	public Object fromIndexedValue(String fieldValue) {
-		return fieldValue == null ? null : BookMedium.valueOf( fieldValue );
+	public Object fromIndexedValue(String indexedValue) {
+		return indexedValue == null ? null : BookMedium.valueOf( indexedValue );
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/ISBNBridge.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/ISBNBridge.java
@@ -6,20 +6,20 @@
  */
 package org.hibernate.search.v6poc.integrationtest.showcase.library.bridge;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.model.ISBN;
 
-public class ISBNBridge implements FunctionBridge<ISBN, String> {
+public class ISBNBridge implements ValueBridge<ISBN, String> {
 
 	// TODO use a default normalizer that removes hyphens
 
 	@Override
-	public String toIndexedValue(ISBN propertyValue) {
-		return propertyValue == null ? null : propertyValue.getStringValue();
+	public String toIndexedValue(ISBN value) {
+		return value == null ? null : value.getStringValue();
 	}
 
 	@Override
-	public Object fromIndexedValue(String fieldValue) {
-		return fieldValue == null ? null : new ISBN( fieldValue );
+	public Object fromIndexedValue(String indexedValue) {
+		return indexedValue == null ? null : new ISBN( indexedValue );
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/LibraryServiceBridge.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/LibraryServiceBridge.java
@@ -6,17 +6,17 @@
  */
 package org.hibernate.search.v6poc.integrationtest.showcase.library.bridge;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.model.LibraryService;
 
-public class LibraryServiceBridge implements FunctionBridge<LibraryService, String> {
+public class LibraryServiceBridge implements ValueBridge<LibraryService, String> {
 	@Override
-	public String toIndexedValue(LibraryService propertyValue) {
-		return propertyValue == null ? null : propertyValue.name();
+	public String toIndexedValue(LibraryService value) {
+		return value == null ? null : value.name();
 	}
 
 	@Override
-	public Object fromIndexedValue(String fieldValue) {
-		return fieldValue == null ? null : LibraryService.valueOf( fieldValue );
+	public Object fromIndexedValue(String indexedValue) {
+		return indexedValue == null ? null : LibraryService.valueOf( indexedValue );
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/VideoMediumBridge.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/VideoMediumBridge.java
@@ -6,18 +6,18 @@
  */
 package org.hibernate.search.v6poc.integrationtest.showcase.library.bridge;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.model.BookMedium;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.model.VideoMedium;
 
-public class VideoMediumBridge implements FunctionBridge<VideoMedium, String> {
+public class VideoMediumBridge implements ValueBridge<VideoMedium, String> {
 	@Override
-	public String toIndexedValue(VideoMedium propertyValue) {
-		return propertyValue == null ? null : propertyValue.name();
+	public String toIndexedValue(VideoMedium value) {
+		return value == null ? null : value.name();
 	}
 
 	@Override
-	public Object fromIndexedValue(String fieldValue) {
-		return fieldValue == null ? null : BookMedium.valueOf( fieldValue );
+	public Object fromIndexedValue(String indexedValue) {
+		return indexedValue == null ? null : BookMedium.valueOf( indexedValue );
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/dao/syntax/fluidandlambda/FluidAndLambdaSyntaxDocumentDao.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/dao/syntax/fluidandlambda/FluidAndLambdaSyntaxDocumentDao.java
@@ -56,7 +56,7 @@ class FluidAndLambdaSyntaxDocumentDao extends DocumentDao {
 							}
 						} )
 						.must().nested().onObjectField( "copies" )
-								// Bridged query with function bridge: TODO rely on the bridge to convert to a String
+								// Bridged query with value bridge: TODO rely on the bridge to convert to a String
 								.match().onField( "copies.medium" ).matching( medium.name() )
 						.end()
 				.sort().byField( "title_sort" ).end()
@@ -118,7 +118,7 @@ class FluidAndLambdaSyntaxDocumentDao extends DocumentDao {
 											for ( LibraryService service : libraryServices ) {
 												c2.match()
 														.onField( "copies.library.services" )
-														// Bridged query with function bridge: TODO rely on the bridge to convert to a String
+														// Bridged query with value bridge: TODO rely on the bridge to convert to a String
 														.matching( service.name() );
 											}
 										} );

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/dao/syntax/fluidandobject/FluidAndObjectSyntaxDocumentDao.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/dao/syntax/fluidandobject/FluidAndObjectSyntaxDocumentDao.java
@@ -58,7 +58,7 @@ class FluidAndObjectSyntaxDocumentDao extends DocumentDao {
 		}
 
 		booleanBuilder.must().nested().onObjectField( "copies" )
-				// Bridged query with function bridge: TODO rely on the bridge to convert to a String
+				// Bridged query with value bridge: TODO rely on the bridge to convert to a String
 				.match().onField( "copies.medium" ).matching( medium.name() );
 
 		FullTextQuery<Book> query = entityManager.search( Book.class ).query()
@@ -118,7 +118,7 @@ class FluidAndObjectSyntaxDocumentDao extends DocumentDao {
 			for ( LibraryService service : libraryServices ) {
 				nestedBoolean.must().match()
 						.onField( "copies.library.services" )
-						// Bridged query with function bridge: TODO rely on the bridge to convert to a String
+						// Bridged query with value bridge: TODO rely on the bridge to convert to a String
 						.matching( service.name() );
 			}
 		}

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/dao/syntax/lambda/LambdaSyntaxDocumentDao.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/dao/syntax/lambda/LambdaSyntaxDocumentDao.java
@@ -56,7 +56,7 @@ class LambdaSyntaxDocumentDao extends DocumentDao {
 						}
 					} );
 					b.must( ctx -> ctx.nested().onObjectField( "copies" )
-							// Bridged query with function bridge: TODO rely on the bridge to convert to a String
+							// Bridged query with value bridge: TODO rely on the bridge to convert to a String
 							.match().onField( "copies.medium" ).matching( medium.name() )
 					);
 				} )
@@ -119,7 +119,7 @@ class LambdaSyntaxDocumentDao extends DocumentDao {
 								for ( LibraryService service : libraryServices ) {
 									c2.match()
 											.onField( "copies.library.services" )
-											// Bridged query with function bridge: TODO rely on the bridge to convert to a String
+											// Bridged query with value bridge: TODO rely on the bridge to convert to a String
 											.matching( service.name() );
 								}
 							} );

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/dao/syntax/object/ObjectSyntaxDocumentDao.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/dao/syntax/object/ObjectSyntaxDocumentDao.java
@@ -65,7 +65,7 @@ class ObjectSyntaxDocumentDao extends DocumentDao {
 
 		booleanBuilder.must(
 				target.predicate().nested().onObjectField( "copies" )
-				// Bridged query with function bridge: TODO rely on the bridge to convert to a String
+				// Bridged query with value bridge: TODO rely on the bridge to convert to a String
 				.match().onField( "copies.medium" ).matching( medium.name() )
 		);
 
@@ -133,7 +133,7 @@ class ObjectSyntaxDocumentDao extends DocumentDao {
 				nestedBoolean.must(
 						target.predicate().match()
 						.onField( "copies.library.services" )
-						// Bridged query with function bridge: TODO rely on the bridge to convert to a String
+						// Bridged query with value bridge: TODO rely on the bridge to convert to a String
 						.matching( service.name() )
 				);
 			}

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/Book.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/Book.java
@@ -11,7 +11,7 @@ import javax.persistence.Entity;
 
 import org.hibernate.annotations.Type;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.FunctionBridgeBeanReference;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.bridge.ISBNBridge;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.usertype.ISBNUserType;
@@ -29,7 +29,7 @@ public class Book extends Document<BookCopy> {
 
 	@Basic
 	@Type(type = ISBNUserType.NAME)
-	@Field(functionBridge = @FunctionBridgeBeanReference(type = ISBNBridge.class))
+	@Field(valueBridge = @ValueBridgeBeanReference(type = ISBNBridge.class))
 	private ISBN isbn;
 
 	public ISBN getIsbn() {

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/BookCopy.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/BookCopy.java
@@ -9,7 +9,7 @@ package org.hibernate.search.v6poc.integrationtest.showcase.library.model;
 import javax.persistence.Entity;
 
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.FunctionBridgeBeanReference;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.bridge.BookMediumBridge;
 
 /**
@@ -21,7 +21,7 @@ import org.hibernate.search.v6poc.integrationtest.showcase.library.bridge.BookMe
 public class BookCopy extends DocumentCopy<Book> {
 
 	// TODO add default bridge (and maybe field type?) for enums
-	@Field(functionBridge = @FunctionBridgeBeanReference(type = BookMediumBridge.class))
+	@Field(valueBridge = @ValueBridgeBeanReference(type = BookMediumBridge.class))
 	// TODO facet
 	private BookMedium medium;
 

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/Library.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/Library.java
@@ -20,7 +20,7 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.spatial.annotation.
 import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.spatial.annotation.Longitude;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.FunctionBridgeBeanReference;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.bridge.LibraryServiceBridge;
 
@@ -59,7 +59,7 @@ public class Library {
 
 	@ElementCollection
 	// TODO add default bridge (and maybe field type?) for enums
-	@Field(functionBridge = @FunctionBridgeBeanReference(type = LibraryServiceBridge.class))
+	@Field(valueBridge = @ValueBridgeBeanReference(type = LibraryServiceBridge.class))
 	private List<LibraryService> services;
 
 	@Override

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/ProgrammaticMappingContributor.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/ProgrammaticMappingContributor.java
@@ -42,7 +42,7 @@ public class ProgrammaticMappingContributor implements HibernateOrmSearchMapping
 				.property( "latitude" ).marker( new LatitudeMarker.Builder() )
 				.property( "longitude" ).marker( new LongitudeMarker.Builder() )
 				.property( "services" )
-						.field().functionBridge( LibraryServiceBridge.class );
+						.field().valueBridge( LibraryServiceBridge.class );
 
 		mapping.type( Document.class )
 				.property( "id" ).documentId()
@@ -62,7 +62,7 @@ public class ProgrammaticMappingContributor implements HibernateOrmSearchMapping
 								.storage( ObjectFieldStorage.NESTED );
 		mapping.type( Book.class ).indexed( Book.INDEX )
 				.property( "isbn" )
-						.field().functionBridge( ISBNBridge.class );
+						.field().valueBridge( ISBNBridge.class );
 		mapping.type( Video.class ).indexed( Video.INDEX );
 
 		mapping.type( DocumentCopy.class )
@@ -72,9 +72,9 @@ public class ProgrammaticMappingContributor implements HibernateOrmSearchMapping
 						.indexedEmbedded().maxDepth( 1 );
 		mapping.type( BookCopy.class )
 				.property( "medium" )
-						.field().functionBridge( BookMediumBridge.class );
+						.field().valueBridge( BookMediumBridge.class );
 		mapping.type( VideoCopy.class )
 				.property( "medium" )
-						.field().functionBridge( VideoMediumBridge.class );
+						.field().valueBridge( VideoMediumBridge.class );
 	}
 }

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/VideoCopy.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/VideoCopy.java
@@ -9,7 +9,7 @@ package org.hibernate.search.v6poc.integrationtest.showcase.library.model;
 import javax.persistence.Entity;
 
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.FunctionBridgeBeanReference;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.bridge.VideoMediumBridge;
 
 /**
@@ -21,7 +21,7 @@ import org.hibernate.search.v6poc.integrationtest.showcase.library.bridge.VideoM
 public class VideoCopy extends DocumentCopy<Video> {
 
 	// TODO add default bridge (and maybe field type?) for enums
-	@Field(functionBridge = @FunctionBridgeBeanReference(type = VideoMediumBridge.class))
+	@Field(valueBridge = @ValueBridgeBeanReference(type = VideoMediumBridge.class))
 	// TODO facet
 	private VideoMedium medium;
 

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/PropertyBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/PropertyBridge.java
@@ -15,7 +15,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoModelProperty;
 /**
  * A bridge between a POJO property and an element of the index schema.
  * <p>
- * The {@code PropertyBridge} interface is a more powerful version of {@link FunctionBridge}
+ * The {@code PropertyBridge} interface is a more powerful version of {@link ValueBridge}
  * that can use reflection to get information about the property being bridged,
  * and can contribute more than one index field, in particular.
  *

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/TypeBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/TypeBridge.java
@@ -15,7 +15,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoModelType;
 /**
  * A bridge between a POJO type and an element of the index schema.
  * <p>
- * The {@code TypeBridge} interface is a more powerful version of {@link FunctionBridge}
+ * The {@code TypeBridge} interface is a more powerful version of {@link ValueBridge}
  * that applies to a whole type instead of a single property,
  * and can contribute more than one index field, in particular.
  *

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/ValueBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/ValueBridge.java
@@ -10,17 +10,18 @@ import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldContext
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldTypedContext;
 
 /**
- * A bridge between a POJO property of type {@code T} and an index field of type {@code R}.
+ * A bridge between a POJO-extracted value of type {@code T} and an index field of type {@code R}.
  * <p>
- * The {@code FunctionBridge} interface is a simpler version of {@link PropertyBridge},
- * in which a given value can only be mapped to a single field, in particular.
+ * The {@code ValueBridge} interface is a simpler version of {@link PropertyBridge},
+ * in which no property metadata is available
+ * and a given input value can only be mapped to a single field, in particular.
  *
  * @param <T> The type of values on the POJO side of the bridge.
  * @param <R> The type of values on the index side of the bridge.
  *
  * @author Yoann Rodiere
  */
-public interface FunctionBridge<T, R> extends AutoCloseable {
+public interface ValueBridge<T, R> extends AutoCloseable {
 
 	/**
 	 * Bind this bridge instance to the given index field model.
@@ -31,32 +32,32 @@ public interface FunctionBridge<T, R> extends AutoCloseable {
 	 * @param context An entry point to declaring expectations and retrieving accessors to the index schema.
 	 * @return The result provided by {@code context} after setting the expectations regarding the index field
 	 * (for instance {@code return context.asString()}). {@code null} to let Hibernate Search derive the expectations
-	 * from the {@code FunctionBridge}'s generic type parameters.
+	 * from the {@code ValueBridge}'s generic type parameters.
 	 */
 	default IndexSchemaFieldTypedContext<R> bind(IndexSchemaFieldContext context) {
 		return null; // Auto-detect the return type and use default encoding
 	}
 
 	/**
-	 * Transform the given POJO property value to the value of the indexed field.
+	 * Transform the given POJO-extracted value to the value of the indexed field.
 	 *
-	 * @param propertyValue The POJO property value to be transformed.
+	 * @param value The POJO-extracted value to be transformed.
 	 * @return The value of the indexed field.
 	 */
-	R toIndexedValue(T propertyValue);
+	R toIndexedValue(T value);
 
 	/**
-	 * Transform the given indexed field value back to the value of the POJO property,
-	 * or to any implementation-defined value to be returned in projections on the POJO property.
+	 * Transform the given indexed field value back to the value initially extracted from the POJO,
+	 * or to any implementation-defined value to be returned in projections on the indexed field.
 	 * <p>
-	 * For instance, a {@code FunctionBridge} indexing JPA entities by putting their identifier in a field
-	 * might not be able to retrieve the entity, so it could just return the identifier as-is.
+	 * For instance, a {@code ValueBridge} indexing JPA entities by putting their identifier in a field
+	 * might not be able to resolve the identifier back to an entity, so it could just return the identifier as-is.
 	 *
-	 * @param fieldValue The field value to be transformed.
+	 * @param indexedValue The field value to be transformed.
 	 * @return The value returned in projections on the POJO property.
 	 */
-	default Object fromIndexedValue(R fieldValue) {
-		return fieldValue;
+	default Object fromIndexedValue(R indexedValue) {
+		return indexedValue;
 	}
 
 	/**

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/impl/DefaultIntegerValueBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/impl/DefaultIntegerValueBridge.java
@@ -6,22 +6,20 @@
  */
 package org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl;
 
-import java.time.LocalDate;
-
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldContext;
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldTypedContext;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 
-public final class DefaultLocalDateFunctionBridge implements FunctionBridge<LocalDate, LocalDate> {
+public final class DefaultIntegerValueBridge implements ValueBridge<Integer, Integer> {
 
 	@Override
-	public IndexSchemaFieldTypedContext<LocalDate> bind(IndexSchemaFieldContext context) {
-		return context.asLocalDate();
+	public IndexSchemaFieldTypedContext<Integer> bind(IndexSchemaFieldContext context) {
+		return context.asInteger();
 	}
 
 	@Override
-	public LocalDate toIndexedValue(LocalDate propertyValue) {
-		return propertyValue;
+	public Integer toIndexedValue(Integer value) {
+		return value;
 	}
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/impl/DefaultLocalDateValueBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/impl/DefaultLocalDateValueBridge.java
@@ -6,20 +6,22 @@
  */
 package org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl;
 
+import java.time.LocalDate;
+
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldContext;
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldTypedContext;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 
-public final class DefaultStringFunctionBridge implements FunctionBridge<String, String> {
+public final class DefaultLocalDateValueBridge implements ValueBridge<LocalDate, LocalDate> {
 
 	@Override
-	public IndexSchemaFieldTypedContext<String> bind(IndexSchemaFieldContext context) {
-		return context.asString();
+	public IndexSchemaFieldTypedContext<LocalDate> bind(IndexSchemaFieldContext context) {
+		return context.asLocalDate();
 	}
 
 	@Override
-	public String toIndexedValue(String propertyValue) {
-		return propertyValue;
+	public LocalDate toIndexedValue(LocalDate value) {
+		return value;
 	}
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/impl/DefaultStringValueBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/impl/DefaultStringValueBridge.java
@@ -8,18 +8,18 @@ package org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl;
 
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldContext;
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldTypedContext;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 
-public final class DefaultIntegerFunctionBridge implements FunctionBridge<Integer, Integer> {
+public final class DefaultStringValueBridge implements ValueBridge<String, String> {
 
 	@Override
-	public IndexSchemaFieldTypedContext<Integer> bind(IndexSchemaFieldContext context) {
-		return context.asInteger();
+	public IndexSchemaFieldTypedContext<String> bind(IndexSchemaFieldContext context) {
+		return context.asString();
 	}
 
 	@Override
-	public Integer toIndexedValue(Integer propertyValue) {
-		return propertyValue;
+	public String toIndexedValue(String value) {
+		return value;
 	}
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/impl/BridgeResolver.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/impl/BridgeResolver.java
@@ -11,12 +11,12 @@ import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.IdentifierBridge;
-import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl.DefaultIntegerFunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl.DefaultIntegerValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl.DefaultIntegerIdentifierBridge;
-import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl.DefaultLocalDateFunctionBridge;
-import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl.DefaultStringFunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl.DefaultLocalDateValueBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.impl.DefaultStringValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.logging.impl.Log;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
@@ -30,7 +30,7 @@ public final class BridgeResolver {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final Map<Class<?>, BridgeBuilder<? extends IdentifierBridge<?>>> defaultIdentifierBridgeBySourceType = new HashMap<>();
-	private final Map<Class<?>, BridgeBuilder<? extends FunctionBridge<?, ?>>> defaultFunctionBridgeBySourceType = new HashMap<>();
+	private final Map<Class<?>, BridgeBuilder<? extends ValueBridge<?, ?>>> defaultValueBridgeBySourceType = new HashMap<>();
 
 	public BridgeResolver() {
 		// TODO add an extension point to override these maps, or at least to add defaults for other types
@@ -38,9 +38,9 @@ public final class BridgeResolver {
 
 		addDefaultIdentifierBridge( Integer.class, ignored -> new DefaultIntegerIdentifierBridge() );
 
-		addDefaultFunctionBridge( Integer.class, ignored -> new DefaultIntegerFunctionBridge() );
-		addDefaultFunctionBridge( String.class, ignored -> new DefaultStringFunctionBridge() );
-		addDefaultFunctionBridge( LocalDate.class, ignored -> new DefaultLocalDateFunctionBridge() );
+		addDefaultValueBridge( Integer.class, ignored -> new DefaultIntegerValueBridge() );
+		addDefaultValueBridge( String.class, ignored -> new DefaultStringValueBridge() );
+		addDefaultValueBridge( LocalDate.class, ignored -> new DefaultLocalDateValueBridge() );
 	}
 
 	public BridgeBuilder<? extends IdentifierBridge<?>> resolveIdentifierBridgeForType(PojoTypeModel<?> sourceType) {
@@ -54,13 +54,13 @@ public final class BridgeResolver {
 		return result;
 	}
 
-	public BridgeBuilder<? extends FunctionBridge<?, ?>> resolveFunctionBridgeForType(PojoTypeModel<?> sourceType) {
+	public BridgeBuilder<? extends ValueBridge<?, ?>> resolveValueBridgeForType(PojoTypeModel<?> sourceType) {
 		// TODO handle non-raw types?
 		Class<?> rawType = sourceType.getRawType().getJavaClass();
 		@SuppressWarnings("unchecked")
-		BridgeBuilder<? extends FunctionBridge<?, ?>> result = defaultFunctionBridgeBySourceType.get( rawType );
+		BridgeBuilder<? extends ValueBridge<?, ?>> result = defaultValueBridgeBySourceType.get( rawType );
 		if ( result == null ) {
-			throw log.unableToResolveDefaultFunctionBridgeFromSourceType( rawType );
+			throw log.unableToResolveDefaultValueBridgeFromSourceType( rawType );
 		}
 		return result;
 	}
@@ -69,8 +69,8 @@ public final class BridgeResolver {
 		defaultIdentifierBridgeBySourceType.put( type, builder );
 	}
 
-	private <T> void addDefaultFunctionBridge(Class<T> type, BridgeBuilder<? extends FunctionBridge<? super T, ?>> builder) {
-		defaultFunctionBridgeBySourceType.put( type, builder );
+	private <T> void addDefaultValueBridge(Class<T> type, BridgeBuilder<? extends ValueBridge<? super T, ?>> builder) {
+		defaultValueBridgeBySourceType.put( type, builder );
 	}
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/Log.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/Log.java
@@ -10,7 +10,7 @@ package org.hibernate.search.v6poc.entity.pojo.logging.impl;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.extractor.ContainerValueExtractor;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoGenericTypeModel;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
@@ -26,8 +26,8 @@ public interface Log extends BasicLogger {
 	@Message(id = 1, value = "Unable to find a default identifier bridge implementation for type '%1$s'")
 	SearchException unableToResolveDefaultIdentifierBridgeFromSourceType(Class<?> sourceType);
 
-	@Message(id = 2, value = "Unable to find a default function bridge implementation for type '%1$s'")
-	SearchException unableToResolveDefaultFunctionBridgeFromSourceType(Class<?> sourceType);
+	@Message(id = 2, value = "Unable to find a default value bridge implementation for type '%1$s'")
+	SearchException unableToResolveDefaultValueBridgeFromSourceType(Class<?> sourceType);
 
 	@Message(id = 3, value = "Annotation type '%1$s' is annotated with @PropertyBridgeMapping,"
 			+ " but the bridge builder reference is empty.")
@@ -37,7 +37,7 @@ public interface Log extends BasicLogger {
 			+ " but the marker builder reference is empty.")
 	SearchException missingBuilderReferenceInMarkerMapping(Class<? extends Annotation> annotationType);
 
-	@Message(id = 5, value = "Annotation @Field on property '%1$s' defines both functionBridge and functionBridgeBuilder."
+	@Message(id = 5, value = "Annotation @Field on property '%1$s' defines both valueBridge and valueBridgeBuilder."
 			+ " Only one of those can be defined, not both."
 	)
 	SearchException invalidFieldDefiningBothBridgeReferenceAndBridgeBuilderReference(String property);
@@ -53,16 +53,16 @@ public interface Log extends BasicLogger {
 	)
 	SearchException cannotSearchOnEmptyTarget();
 
-	@Message(id = 8, value = "Could not auto-detect the input type for function bridge %1$s"
+	@Message(id = 8, value = "Could not auto-detect the input type for value bridge %1$s"
 			+ "; make sure the bridge uses generics.")
-	SearchException unableToInferFunctionBridgeInputType(FunctionBridge<?, ?> bridge);
+	SearchException unableToInferValueBridgeInputType(ValueBridge<?, ?> bridge);
 
-	@Message(id = 9, value = "Could not auto-detect the return type for function bridge %1$s"
+	@Message(id = 9, value = "Could not auto-detect the return type for value bridge %1$s"
 			+ "; make sure the bridge uses generics or configure the field explicitly in the bridge's bind() method.")
-	SearchException unableToInferFunctionBridgeIndexFieldType(FunctionBridge<?, ?> bridge);
+	SearchException unableToInferValueBridgeIndexFieldType(ValueBridge<?, ?> bridge);
 
-	@Message(id = 10, value = "Function bridge %1$s cannot be applied to input type %2$s.")
-	SearchException invalidInputTypeForFunctionBridge(FunctionBridge<?, ?> bridge, PojoTypeModel<?> typeModel);
+	@Message(id = 10, value = "Value bridge %1$s cannot be applied to input type %2$s.")
+	SearchException invalidInputTypeForValueBridge(ValueBridge<?, ?> bridge, PojoTypeModel<?> typeModel);
 
 	@Message(id = 11, value = "Missing field name for GeoPointBridge on type %1$s."
 			+ " The field name is mandatory when the bridge is applied on an type, optional when applied on a property.")

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexModelBinder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexModelBinder.java
@@ -15,7 +15,7 @@ import org.hibernate.search.v6poc.entity.mapping.building.spi.FieldModelContribu
 import org.hibernate.search.v6poc.entity.mapping.building.spi.IndexModelBindingContext;
 import org.hibernate.search.v6poc.entity.model.SearchModel;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.RoutingKeyBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
@@ -27,7 +27,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoModelProperty;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelType;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoGenericTypeModel;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
-import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessorFunctionBridgeNode;
+import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessorValueBridgeNode;
 
 /**
  * Binds a mapping to a given entity model and index model
@@ -36,7 +36,7 @@ import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProces
  * Also binds the bridges where appropriate:
  * {@link TypeBridge#bind(IndexSchemaElement, PojoModelType, SearchModel)},
  * {@link PropertyBridge#bind(IndexSchemaElement, PojoModelProperty, SearchModel)},
- * {@link FunctionBridge#bind(IndexSchemaFieldContext)}.
+ * {@link ValueBridge#bind(IndexSchemaFieldContext)}.
  * <p>
  * Incidentally, this will also generate the index model,
  * due to bridges contributing to the index model as we bind them.
@@ -64,8 +64,8 @@ public interface PojoIndexModelBinder {
 	Optional<PropertyBridge> addPropertyBridge(IndexModelBindingContext bindingContext,
 			PojoModelProperty pojoModelProperty, BridgeBuilder<? extends PropertyBridge> bridgeBuilder);
 
-	<T> Optional<PojoIndexingProcessorFunctionBridgeNode<T, ?>> addFunctionBridge(IndexModelBindingContext bindingContext,
-			PojoTypeModel<T> typeModel, BridgeBuilder<? extends FunctionBridge<?, ?>> bridgeBuilder,
+	<T> Optional<PojoIndexingProcessorValueBridgeNode<T, ?>> addValueBridge(IndexModelBindingContext bindingContext,
+			PojoTypeModel<T> typeModel, BridgeBuilder<? extends ValueBridge<?, ?>> bridgeBuilder,
 			String fieldName, FieldModelContributor contributor);
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexModelBinderImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexModelBinderImpl.java
@@ -18,7 +18,7 @@ import org.hibernate.search.v6poc.entity.mapping.building.spi.FieldModelContribu
 import org.hibernate.search.v6poc.entity.mapping.building.spi.IndexModelBindingContext;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.IndexSchemaContributionListener;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.RoutingKeyBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
@@ -34,7 +34,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoModelType;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoGenericTypeModel;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoBootstrapIntrospector;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
-import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessorFunctionBridgeNode;
+import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessorValueBridgeNode;
 import org.hibernate.search.v6poc.entity.pojo.util.impl.GenericTypeContext;
 import org.hibernate.search.v6poc.entity.pojo.util.impl.ReflectionUtils;
 import org.hibernate.search.v6poc.util.spi.LoggerFactory;
@@ -83,7 +83,7 @@ public class PojoIndexModelBinderImpl implements PojoIndexModelBinder {
 		}
 		/*
 		 * TODO check that the bridge is suitable for the given typeModel
-		 * (use introspection, similarly to what we do to detect the function bridges field type?)
+		 * (use introspection, similarly to what we do to detect the value bridge's field type?)
 		 */
 		IdentifierBridge<?> bridge = defaultedBuilder.build( buildContext );
 
@@ -140,33 +140,33 @@ public class PojoIndexModelBinderImpl implements PojoIndexModelBinder {
 	}
 
 	@Override
-	public <T> Optional<PojoIndexingProcessorFunctionBridgeNode<T, ?>> addFunctionBridge(IndexModelBindingContext bindingContext,
-			PojoTypeModel<T> typeModel, BridgeBuilder<? extends FunctionBridge<?, ?>> builder,
+	public <T> Optional<PojoIndexingProcessorValueBridgeNode<T, ?>> addValueBridge(IndexModelBindingContext bindingContext,
+			PojoTypeModel<T> typeModel, BridgeBuilder<? extends ValueBridge<?, ?>> builder,
 			String fieldName, FieldModelContributor contributor) {
-		BridgeBuilder<? extends FunctionBridge<?, ?>> defaultedBuilder = builder;
+		BridgeBuilder<? extends ValueBridge<?, ?>> defaultedBuilder = builder;
 		if ( builder == null ) {
-			defaultedBuilder = bridgeResolver.resolveFunctionBridgeForType( typeModel );
+			defaultedBuilder = bridgeResolver.resolveValueBridgeForType( typeModel );
 		}
 
-		FunctionBridge<?, ?> bridge = defaultedBuilder.build( buildContext );
+		ValueBridge<?, ?> bridge = defaultedBuilder.build( buildContext );
 
 		GenericTypeContext bridgeTypeContext = new GenericTypeContext( bridge.getClass() );
 
-		Class<?> bridgeParameterType = bridgeTypeContext.resolveTypeArgument( FunctionBridge.class, 0 )
+		Class<?> bridgeParameterType = bridgeTypeContext.resolveTypeArgument( ValueBridge.class, 0 )
 				.map( ReflectionUtils::getRawType )
-				.orElseThrow( () -> log.unableToInferFunctionBridgeInputType( bridge ) );
+				.orElseThrow( () -> log.unableToInferValueBridgeInputType( bridge ) );
 		if ( !typeModel.getSuperType( bridgeParameterType ).isPresent() ) {
-			throw log.invalidInputTypeForFunctionBridge( bridge, typeModel );
+			throw log.invalidInputTypeForValueBridge( bridge, typeModel );
 		}
 
 		@SuppressWarnings( "unchecked" ) // We checked just above that this cast is valid
-		FunctionBridge<? super T, ?> typedBridge = (FunctionBridge<? super T, ?>) bridge;
+				ValueBridge<? super T, ?> typedBridge = (ValueBridge<? super T, ?>) bridge;
 
-		return doAddFunctionBridge( bindingContext, typedBridge, bridgeTypeContext, fieldName, contributor );
+		return doAddValueBridge( bindingContext, typedBridge, bridgeTypeContext, fieldName, contributor );
 	}
 
-	private <T, R> Optional<PojoIndexingProcessorFunctionBridgeNode<T, ?>> doAddFunctionBridge(IndexModelBindingContext bindingContext,
-			FunctionBridge<? super T, R> bridge, GenericTypeContext bridgeTypeContext,
+	private <T, R> Optional<PojoIndexingProcessorValueBridgeNode<T, ?>> doAddValueBridge(IndexModelBindingContext bindingContext,
+			ValueBridge<? super T, R> bridge, GenericTypeContext bridgeTypeContext,
 			String fieldName, FieldModelContributor contributor) {
 		IndexSchemaContributionListenerImpl listener = new IndexSchemaContributionListenerImpl();
 
@@ -177,9 +177,9 @@ public class PojoIndexModelBinderImpl implements PojoIndexModelBinder {
 		if ( typedFieldContext == null ) {
 			@SuppressWarnings( "unchecked" ) // We ensure this cast is safe through reflection
 			Class<? super R> returnType =
-					(Class<? super R>) bridgeTypeContext.resolveTypeArgument( FunctionBridge.class, 1 )
+					(Class<? super R>) bridgeTypeContext.resolveTypeArgument( ValueBridge.class, 1 )
 					.map( ReflectionUtils::getRawType )
-					.orElseThrow( () -> log.unableToInferFunctionBridgeIndexFieldType( bridge ) );
+					.orElseThrow( () -> log.unableToInferValueBridgeIndexFieldType( bridge ) );
 			typedFieldContext = fieldContext.as( returnType );
 		}
 		// Then give the mapping a chance to override some of the model (add storage, ...)
@@ -189,7 +189,7 @@ public class PojoIndexModelBinderImpl implements PojoIndexModelBinder {
 
 		// If all fields are filtered out, we should ignore the bridge
 		if ( listener.schemaContributed ) {
-			return Optional.of( new PojoIndexingProcessorFunctionBridgeNode<>( bridge, indexFieldAccessor ) );
+			return Optional.of( new PojoIndexingProcessorValueBridgeNode<>( bridge, indexFieldAccessor ) );
 		}
 		else {
 			bridge.close();

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoMappingCollectorValueNode.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoMappingCollectorValueNode.java
@@ -10,12 +10,12 @@ import java.util.Set;
 
 import org.hibernate.search.v6poc.backend.document.model.ObjectFieldStorage;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.FieldModelContributor;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
 
 public interface PojoMappingCollectorValueNode extends PojoMappingCollector {
 
-	void functionBridge(BridgeBuilder<? extends FunctionBridge<?, ?>> builder,
+	void valueBridge(BridgeBuilder<? extends ValueBridge<?, ?>> builder,
 			String fieldName, FieldModelContributor fieldModelContributor);
 
 	void indexedEmbedded(String relativePrefix, ObjectFieldStorage storage, Integer maxDepth, Set<String> includePaths);

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/Field.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/Field.java
@@ -32,18 +32,18 @@ public @interface Field {
 	String name() default "";
 
 	/**
-	 * @return A reference to the function bridge to use for this field.
-	 * Cannot be used in the same {@code @Field} annotation as {@link #functionBridgeBuilder()}:
+	 * @return A reference to the value bridge to use for this field.
+	 * Cannot be used in the same {@code @Field} annotation as {@link #valueBridgeBuilder()}:
 	 * either a bridge or a bridge builder can be provided, but never both.
 	 */
-	FunctionBridgeBeanReference functionBridge() default @FunctionBridgeBeanReference;
+	ValueBridgeBeanReference valueBridge() default @ValueBridgeBeanReference;
 
 	/**
-	 * @return A reference to the builder to use to build a function bridge for this field.
-	 * Cannot be used in the same {@code @Field} annotation as {@link #functionBridge()}:
+	 * @return A reference to the builder to use to build a value bridge for this field.
+	 * Cannot be used in the same {@code @Field} annotation as {@link #valueBridge()}:
 	 * either a bridge or a bridge builder can be provided, but never both.
 	 */
-	FunctionBridgeBuilderBeanReference functionBridgeBuilder() default @FunctionBridgeBuilderBeanReference;
+	ValueBridgeBuilderBeanReference valueBridgeBuilder() default @ValueBridgeBuilderBeanReference;
 
 	String analyzer() default "";
 

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/ValueBridgeBeanReference.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/ValueBridgeBeanReference.java
@@ -11,8 +11,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 
 /**
  * @author Yoann Rodiere
@@ -21,17 +20,16 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
 @Target({}) // Only used as a component in other annotations
 @Retention(RetentionPolicy.RUNTIME)
 // TODO repeatable
-public @interface FunctionBridgeBuilderBeanReference {
+public @interface ValueBridgeBeanReference {
 
 	String name() default "";
 
-	Class<? extends BridgeBuilder<? extends FunctionBridge<?, ?>>> type()
-			default UndefinedImplementationType.class;
+	Class<? extends ValueBridge<?, ?>> type() default UndefinedImplementationType.class;
 
 	/**
 	 * Class used as a marker for the default value of the {@link #type()} attribute.
 	 */
-	abstract class UndefinedImplementationType implements BridgeBuilder<FunctionBridge<Object, Object>> {
+	abstract class UndefinedImplementationType implements ValueBridge<Object, Object> {
 		private UndefinedImplementationType() {
 		}
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/ValueBridgeBuilderBeanReference.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/ValueBridgeBuilderBeanReference.java
@@ -11,7 +11,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
 
 /**
  * @author Yoann Rodiere
@@ -20,16 +21,17 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
 @Target({}) // Only used as a component in other annotations
 @Retention(RetentionPolicy.RUNTIME)
 // TODO repeatable
-public @interface FunctionBridgeBeanReference {
+public @interface ValueBridgeBuilderBeanReference {
 
 	String name() default "";
 
-	Class<? extends FunctionBridge<?, ?>> type() default UndefinedImplementationType.class;
+	Class<? extends BridgeBuilder<? extends ValueBridge<?, ?>>> type()
+			default UndefinedImplementationType.class;
 
 	/**
 	 * Class used as a marker for the default value of the {@link #type()} attribute.
 	 */
-	abstract class UndefinedImplementationType implements FunctionBridge<Object, Object> {
+	abstract class UndefinedImplementationType implements BridgeBuilder<ValueBridge<Object, Object>> {
 		private UndefinedImplementationType() {
 		}
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorImpl.java
@@ -22,7 +22,7 @@ import org.hibernate.search.v6poc.engine.spi.BeanReference;
 import org.hibernate.search.v6poc.engine.spi.BeanResolver;
 import org.hibernate.search.v6poc.engine.spi.ImmutableBeanReference;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.FieldModelContributor;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.IdentifierBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
@@ -46,8 +46,8 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.building.impl.PojoMappingC
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ContainerValueExtractorBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.FunctionBridgeBeanReference;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.FunctionBridgeBuilderBeanReference;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBuilderBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IdentifierBridgeBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IdentifierBridgeBuilderBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -134,10 +134,10 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 			cleanedUpFieldName = null;
 		}
 
-		BridgeBuilder<? extends FunctionBridge<?, ?>> builder = createFunctionBridgeBuilder( annotation, propertyModel );
+		BridgeBuilder<? extends ValueBridge<?, ?>> builder = createValueBridgeBuilder( annotation, propertyModel );
 
 		getValueNode( collector, annotation.extractors(), Field.DefaultExtractors.class )
-				.functionBridge( builder, cleanedUpFieldName, new AnnotationFieldModelContributor( annotation ) );
+				.valueBridge( builder, cleanedUpFieldName, new AnnotationFieldModelContributor( annotation ) );
 	}
 
 	private void addIndexedEmbedded(PojoMappingCollectorPropertyNode collector, PojoPropertyModel<?> propertyModel,
@@ -196,7 +196,7 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 				)
 						.orElseThrow( () -> log.missingBuilderReferenceInBridgeMapping( annotation.annotationType() ) );
 
-		// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in FunctionBridgeUtil
+		// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in PojoIndexModelBinderImpl#addValueBridge
 		return beanResolver.resolve( markerBuilderReference, AnnotationMarkerBuilder.class );
 	}
 
@@ -219,14 +219,14 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 			throw log.invalidDocumentIdDefiningBothBridgeReferenceAndBridgeBuilderReference( propertyModel.getName() );
 		}
 		else if ( bridgeReference.isPresent() ) {
-			// The builder will return an object of some class T where T extends FunctionBridge<?, ?>, so this is safe
+			// The builder will return an object of some class T where T extends ValueBridge<?, ?>, so this is safe
 			@SuppressWarnings( "unchecked" )
 			BridgeBuilder<? extends IdentifierBridge<?>> castedBuilder =
 					new BeanResolverBridgeBuilder( IdentifierBridge.class, bridgeReference.get() );
 			return castedBuilder;
 		}
 		else if ( bridgeBuilderReference.isPresent() ) {
-			// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in FunctionBridgeUtil
+			// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in PojoIndexModelBinderImpl#addValueBridge
 			return beanResolver.resolve( bridgeBuilderReference.get(), BridgeBuilder.class );
 		}
 		else {
@@ -247,7 +247,7 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 				)
 						.orElseThrow( () -> log.missingBuilderReferenceInBridgeMapping( annotation.annotationType() ) );
 
-		// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in FunctionBridgeUtil
+		// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in PojoIndexModelBinderImpl#addValueBridge
 		return beanResolver.resolve( builderReference, AnnotationBridgeBuilder.class );
 	}
 
@@ -263,37 +263,37 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 				)
 						.orElseThrow( () -> log.missingBuilderReferenceInBridgeMapping( annotation.annotationType() ) );
 
-		// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in FunctionBridgeUtil
+		// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in PojoIndexModelBinderImpl#addValueBridge
 		return beanResolver.resolve( builderReference, AnnotationBridgeBuilder.class );
 	}
 
-	private BridgeBuilder<? extends FunctionBridge<?, ?>> createFunctionBridgeBuilder(
+	private BridgeBuilder<? extends ValueBridge<?, ?>> createValueBridgeBuilder(
 			Field annotation, PojoPropertyModel<?> propertyModel) {
-		FunctionBridgeBeanReference bridgeReferenceAnnotation = annotation.functionBridge();
+		ValueBridgeBeanReference bridgeReferenceAnnotation = annotation.valueBridge();
 		Optional<BeanReference> bridgeReference = toBeanReference(
 				bridgeReferenceAnnotation.name(),
 				bridgeReferenceAnnotation.type(),
-				FunctionBridgeBeanReference.UndefinedImplementationType.class
+				ValueBridgeBeanReference.UndefinedImplementationType.class
 		);
-		FunctionBridgeBuilderBeanReference bridgeBuilderReferenceAnnotation = annotation.functionBridgeBuilder();
+		ValueBridgeBuilderBeanReference bridgeBuilderReferenceAnnotation = annotation.valueBridgeBuilder();
 		Optional<BeanReference> bridgeBuilderReference = toBeanReference(
 				bridgeBuilderReferenceAnnotation.name(),
 				bridgeBuilderReferenceAnnotation.type(),
-				FunctionBridgeBuilderBeanReference.UndefinedImplementationType.class
+				ValueBridgeBuilderBeanReference.UndefinedImplementationType.class
 		);
 
 		if ( bridgeReference.isPresent() && bridgeBuilderReference.isPresent() ) {
 			throw log.invalidFieldDefiningBothBridgeReferenceAndBridgeBuilderReference( propertyModel.getName() );
 		}
 		else if ( bridgeReference.isPresent() ) {
-			// The builder will return an object of some class T where T extends FunctionBridge<?, ?>, so this is safe
+			// The builder will return an object of some class T where T extends ValueBridge<?, ?>, so this is safe
 			@SuppressWarnings( "unchecked" )
-			BridgeBuilder<? extends FunctionBridge<?, ?>> castedBuilder =
-					new BeanResolverBridgeBuilder( FunctionBridge.class, bridgeReference.get() );
+			BridgeBuilder<? extends ValueBridge<?, ?>> castedBuilder =
+					new BeanResolverBridgeBuilder( ValueBridge.class, bridgeReference.get() );
 			return castedBuilder;
 		}
 		else if ( bridgeBuilderReference.isPresent() ) {
-			// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in FunctionBridgeUtil
+			// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in PojoIndexModelBinderImpl#addValueBridge
 			return beanResolver.resolve( bridgeBuilderReference.get(), BridgeBuilder.class );
 		}
 		else {

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/programmatic/FieldMappingContext.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/programmatic/FieldMappingContext.java
@@ -6,7 +6,7 @@
  */
 package org.hibernate.search.v6poc.entity.pojo.mapping.definition.programmatic;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 
 /**
  * @author Yoann Rodiere
@@ -15,8 +15,8 @@ public interface FieldMappingContext<R extends FieldMappingContext<R>> {
 
 	R bridge(String bridgeName);
 
-	R bridge(Class<? extends FunctionBridge<?, ?>> bridgeClass);
+	R bridge(Class<? extends ValueBridge<?, ?>> bridgeClass);
 
-	R bridge(String bridgeName, Class<? extends FunctionBridge<?, ?>> bridgeClass);
+	R bridge(String bridgeName, Class<? extends ValueBridge<?, ?>> bridgeClass);
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/programmatic/PropertyFieldMappingContext.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/programmatic/PropertyFieldMappingContext.java
@@ -11,8 +11,8 @@ import java.util.List;
 
 import org.hibernate.search.v6poc.backend.document.model.Sortable;
 import org.hibernate.search.v6poc.backend.document.model.Store;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
 import org.hibernate.search.v6poc.entity.pojo.extractor.ContainerValueExtractor;
 
 /**
@@ -20,13 +20,13 @@ import org.hibernate.search.v6poc.entity.pojo.extractor.ContainerValueExtractor;
  */
 public interface PropertyFieldMappingContext extends PropertyMappingContext {
 
-	PropertyFieldMappingContext functionBridge(String bridgeName);
+	PropertyFieldMappingContext valueBridge(String bridgeName);
 
-	PropertyFieldMappingContext functionBridge(Class<? extends FunctionBridge<?, ?>> bridgeClass);
+	PropertyFieldMappingContext valueBridge(Class<? extends ValueBridge<?, ?>> bridgeClass);
 
-	PropertyFieldMappingContext functionBridge(String bridgeName, Class<? extends FunctionBridge<?, ?>> bridgeClass);
+	PropertyFieldMappingContext valueBridge(String bridgeName, Class<? extends ValueBridge<?, ?>> bridgeClass);
 
-	PropertyFieldMappingContext functionBridge(BridgeBuilder<? extends FunctionBridge<?, ?>> builder);
+	PropertyFieldMappingContext valueBridge(BridgeBuilder<? extends ValueBridge<?, ?>> builder);
 
 	PropertyFieldMappingContext analyzer(String analyzerName);
 

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/programmatic/impl/PropertyFieldMappingContextImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/programmatic/impl/PropertyFieldMappingContextImpl.java
@@ -13,9 +13,9 @@ import java.util.List;
 import org.hibernate.search.v6poc.backend.document.model.Sortable;
 import org.hibernate.search.v6poc.backend.document.model.Store;
 import org.hibernate.search.v6poc.backend.document.model.IndexSchemaFieldTypedContext;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.impl.BeanResolverBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
 import org.hibernate.search.v6poc.engine.spi.BeanReference;
 import org.hibernate.search.v6poc.engine.spi.ImmutableBeanReference;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.FieldModelContributor;
@@ -34,7 +34,7 @@ public class PropertyFieldMappingContextImpl extends DelegatingPropertyMappingCo
 
 	private final String fieldName;
 
-	private BridgeBuilder<? extends FunctionBridge<?, ?>> bridgeBuilder;
+	private BridgeBuilder<? extends ValueBridge<?, ?>> bridgeBuilder;
 
 	private final CompositeFieldModelContributor fieldModelContributor = new CompositeFieldModelContributor();
 
@@ -62,35 +62,35 @@ public class PropertyFieldMappingContextImpl extends DelegatingPropertyMappingCo
 		else {
 			valueNodeMappingCollector = collector.valueWithExtractors( extractorClasses );
 		}
-		valueNodeMappingCollector.functionBridge( bridgeBuilder, fieldName, fieldModelContributor );
+		valueNodeMappingCollector.valueBridge( bridgeBuilder, fieldName, fieldModelContributor );
 	}
 
 	@Override
-	public PropertyFieldMappingContext functionBridge(String bridgeName) {
-		return functionBridge( new ImmutableBeanReference( bridgeName ) );
+	public PropertyFieldMappingContext valueBridge(String bridgeName) {
+		return valueBridge( new ImmutableBeanReference( bridgeName ) );
 	}
 
 	@Override
-	public PropertyFieldMappingContext functionBridge(Class<? extends FunctionBridge<?, ?>> bridgeClass) {
-		return functionBridge( new ImmutableBeanReference( bridgeClass ) );
+	public PropertyFieldMappingContext valueBridge(Class<? extends ValueBridge<?, ?>> bridgeClass) {
+		return valueBridge( new ImmutableBeanReference( bridgeClass ) );
 	}
 
 	@Override
-	public PropertyFieldMappingContext functionBridge(String bridgeName, Class<? extends FunctionBridge<?, ?>> bridgeClass) {
-		return functionBridge( new ImmutableBeanReference( bridgeName, bridgeClass ) );
+	public PropertyFieldMappingContext valueBridge(String bridgeName, Class<? extends ValueBridge<?, ?>> bridgeClass) {
+		return valueBridge( new ImmutableBeanReference( bridgeName, bridgeClass ) );
 	}
 
-	// The builder will return an object of some class T where T extends FunctionBridge<?, ?>, so this is safe
+	// The builder will return an object of some class T where T extends ValueBridge<?, ?>, so this is safe
 	@SuppressWarnings( "unchecked" )
-	private PropertyFieldMappingContext functionBridge(BeanReference bridgeReference) {
-		return functionBridge(
-				(BeanResolverBridgeBuilder<? extends FunctionBridge<?, ?>>)
-						new BeanResolverBridgeBuilder( FunctionBridge.class, bridgeReference )
+	private PropertyFieldMappingContext valueBridge(BeanReference bridgeReference) {
+		return valueBridge(
+				(BeanResolverBridgeBuilder<? extends ValueBridge<?, ?>>)
+						new BeanResolverBridgeBuilder( ValueBridge.class, bridgeReference )
 		);
 	}
 
 	@Override
-	public PropertyFieldMappingContext functionBridge(BridgeBuilder<? extends FunctionBridge<?, ?>> builder) {
+	public PropertyFieldMappingContext valueBridge(BridgeBuilder<? extends ValueBridge<?, ?>> builder) {
 		this.bridgeBuilder = builder;
 		return this;
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/processing/building/impl/PojoIndexingProcessorValueNodeBuilderDelegate.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/processing/building/impl/PojoIndexingProcessorValueNodeBuilderDelegate.java
@@ -16,14 +16,14 @@ import org.hibernate.search.v6poc.backend.document.model.ObjectFieldStorage;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.FieldModelContributor;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.IndexModelBindingContext;
 import org.hibernate.search.v6poc.entity.mapping.building.spi.TypeMetadataContributorProvider;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.mapping.building.impl.PojoIndexModelBinder;
 import org.hibernate.search.v6poc.entity.pojo.mapping.building.impl.PojoIdentityMappingCollector;
 import org.hibernate.search.v6poc.entity.pojo.mapping.building.impl.PojoTypeMetadataContributor;
 import org.hibernate.search.v6poc.entity.pojo.mapping.building.impl.PojoMappingCollectorValueNode;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
-import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessorFunctionBridgeNode;
+import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessorValueBridgeNode;
 import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessor;
 
 public class PojoIndexingProcessorValueNodeBuilderDelegate<T> implements PojoMappingCollectorValueNode {
@@ -38,7 +38,7 @@ public class PojoIndexingProcessorValueNodeBuilderDelegate<T> implements PojoMap
 	private final String defaultName;
 	private final PojoTypeModel<T> valueTypeModel;
 
-	private final Collection<PojoIndexingProcessorFunctionBridgeNode<? super T, ?>> bridgeNodes = new ArrayList<>();
+	private final Collection<PojoIndexingProcessorValueBridgeNode<? super T, ?>> bridgeNodes = new ArrayList<>();
 
 	private final Collection<PojoIndexingProcessorTypeNodeBuilder<? super T>> typeNodeBuilders = new ArrayList<>();
 
@@ -63,14 +63,14 @@ public class PojoIndexingProcessorValueNodeBuilderDelegate<T> implements PojoMap
 	}
 
 	@Override
-	public void functionBridge(BridgeBuilder<? extends FunctionBridge<?, ?>> builder, String fieldName,
+	public void valueBridge(BridgeBuilder<? extends ValueBridge<?, ?>> builder, String fieldName,
 			FieldModelContributor fieldModelContributor) {
 		String defaultedFieldName = fieldName;
 		if ( defaultedFieldName == null ) {
 			defaultedFieldName = defaultName;
 		}
 
-		indexModelBinder.addFunctionBridge(
+		indexModelBinder.addValueBridge(
 				bindingContext, valueTypeModel, builder, defaultedFieldName,
 				fieldModelContributor
 		)

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/processing/impl/PojoIndexingProcessorValueBridgeNode.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/processing/impl/PojoIndexingProcessorValueBridgeNode.java
@@ -8,17 +8,17 @@ package org.hibernate.search.v6poc.entity.pojo.processing.impl;
 
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
 import org.hibernate.search.v6poc.backend.document.IndexFieldAccessor;
-import org.hibernate.search.v6poc.entity.pojo.bridge.FunctionBridge;
+import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 
 /**
- * A node inside a {@link PojoIndexingProcessor} responsible for applying a {@link FunctionBridge} to a value.
+ * A node inside a {@link PojoIndexingProcessor} responsible for applying a {@link ValueBridge} to a value.
  */
-public class PojoIndexingProcessorFunctionBridgeNode<T, R> implements PojoIndexingProcessor<T> {
+public class PojoIndexingProcessorValueBridgeNode<T, R> implements PojoIndexingProcessor<T> {
 
-	private final FunctionBridge<? super T, R> bridge;
+	private final ValueBridge<? super T, R> bridge;
 	private final IndexFieldAccessor<? super R> indexFieldAccessor;
 
-	public PojoIndexingProcessorFunctionBridgeNode(FunctionBridge<? super T, R> bridge,
+	public PojoIndexingProcessorValueBridgeNode(ValueBridge<? super T, R> bridge,
 			IndexFieldAccessor<? super R> indexFieldAccessor) {
 		this.bridge = bridge;
 		this.indexFieldAccessor = indexFieldAccessor;


### PR DESCRIPTION
The new name is more consistent with TypeBridge and PropertyBridge:
where TypeBridge works on a type and its metadata, and PropertyBridge
works on a property and its metadata, ValueBridge does not have access
to any metadata, only the value, and it works on that value.