### PR TITLE
HSEARCH-3061 Test query execution more extensively

### DIFF
--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/work/impl/StubElasticsearchWorkFactory.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/work/impl/StubElasticsearchWorkFactory.java
@@ -127,8 +127,10 @@ public class StubElasticsearchWorkFactory implements ElasticsearchWorkFactory {
 				.pathComponent( Paths._SEARCH )
 				.body( payload );
 
-		if ( offset != null && limit != null ) {
+		if ( offset != null ) {
 			builder.param( "from", offset );
+		}
+		if ( limit != null ) {
 			builder.param( "size", limit );
 		}
 

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/query/impl/LuceneSearcher.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/query/impl/LuceneSearcher.java
@@ -28,7 +28,7 @@ public class LuceneSearcher<T> implements AutoCloseable {
 	private final Query luceneQuery;
 	private final Sort luceneSort;
 
-	private final Long firstResultIndex;
+	private final long firstResultIndex;
 	private final Long maxResultsCount;
 
 	private final HitExtractor<?> hitExtractor;
@@ -46,7 +46,7 @@ public class LuceneSearcher<T> implements AutoCloseable {
 		this.indexSearcher = new IndexSearcher( MultiReaderFactory.openReader( indexNames, readerProviders ) );
 		this.luceneQuery = luceneQuery;
 		this.luceneSort = luceneSort;
-		this.firstResultIndex = firstResultIndex;
+		this.firstResultIndex = firstResultIndex == null ? 0L : firstResultIndex.longValue();
 		this.maxResultsCount = maxResultsCount;
 		this.hitExtractor = hitExtractor;
 		this.searchResultExtractor = searchResultExtractor;
@@ -94,10 +94,10 @@ public class LuceneSearcher<T> implements AutoCloseable {
 
 	private TopDocs getTopDocs(LuceneCollectors luceneCollectors) {
 		if ( maxResultsCount == null ) {
-			return luceneCollectors.getTopDocsCollector().topDocs( firstResultIndex.intValue() );
+			return luceneCollectors.getTopDocsCollector().topDocs( (int) firstResultIndex );
 		}
 		else {
-			return luceneCollectors.getTopDocsCollector().topDocs( firstResultIndex.intValue(), maxResultsCount.intValue() );
+			return luceneCollectors.getTopDocsCollector().topDocs( (int) firstResultIndex, maxResultsCount.intValue() );
 		}
 	}
 }

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchQueryIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchQueryIT.java
@@ -6,9 +6,220 @@
  */
 package org.hibernate.search.v6poc.integrationtest.backend.tck.search;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
+
+import org.hibernate.search.v6poc.backend.document.DocumentElement;
+import org.hibernate.search.v6poc.backend.document.IndexFieldAccessor;
+import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaElement;
+import org.hibernate.search.v6poc.backend.document.model.dsl.Sortable;
+import org.hibernate.search.v6poc.backend.index.spi.ChangesetIndexWorker;
+import org.hibernate.search.v6poc.backend.index.spi.IndexManager;
+import org.hibernate.search.v6poc.backend.index.spi.IndexSearchTarget;
+import org.hibernate.search.v6poc.engine.spi.SessionContext;
+import org.hibernate.search.v6poc.integrationtest.backend.tck.util.rule.SearchSetupHelper;
+import org.hibernate.search.v6poc.search.DocumentReference;
+import org.hibernate.search.v6poc.search.SearchQuery;
+import org.hibernate.search.v6poc.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
+import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.StubSessionContext;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
 public class SearchQueryIT {
 
-	// TODO tests related to search queries: query wrapping, setFirstResult, setMaxResult, getQueryString, ...
-	// Does not include predicates and search results, which should be addressed in SearchPredicateIT and SearchResultIT
+	private static final String DOCUMENT_1 = "1";
+	private static final String STRING_1 = "aaa";
 
+	private static final String DOCUMENT_2 = "2";
+	private static final String STRING_2 = "bbb";
+
+	private static final String DOCUMENT_3 = "3";
+	private static final String STRING_3 = "ccc";
+
+	@Rule
+	public SearchSetupHelper setupHelper = new SearchSetupHelper();
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	private IndexAccessors indexAccessors;
+	private IndexManager<?> indexManager;
+	private String indexName;
+	private SessionContext sessionContext = new StubSessionContext();
+
+	@Before
+	public void setup() {
+		setupHelper.withDefaultConfiguration()
+				.withIndex(
+						"MappedType", "IndexName",
+						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
+						(indexManager, indexName) -> {
+							this.indexManager = indexManager;
+							this.indexName = indexName;
+						}
+				)
+				.setup();
+
+		initData();
+	}
+
+	@Test
+	public void paging() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().all().end()
+				.sort().byField( "string" ).asc().end()
+				.build();
+		query.setFirstResult( 1L );
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasHitCount( 3 )
+				.hasReferencesHitsExactOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().all().end()
+				.sort().byField( "string" ).asc().end()
+				.build();
+		query.setFirstResult( 1L );
+		query.setMaxResults( 1L );
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasHitCount( 3 )
+				.hasReferencesHitsExactOrder( indexName, DOCUMENT_2 );
+
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().all().end()
+				.sort().byField( "string" ).asc().end()
+				.build();
+		query.setMaxResults( 2L );
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasHitCount( 3 )
+				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().all().end()
+				.sort().byField( "string" ).asc().end()
+				.build();
+		query.setFirstResult( null );
+		query.setMaxResults( null );
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasHitCount( 3 )
+				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+	}
+
+	@Test
+	public void paging_reuse_query() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().all().end()
+				.sort().byField( "string" ).asc().end()
+				.build();
+		query.setFirstResult( 1L );
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasHitCount( 3 )
+				.hasReferencesHitsExactOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+
+		query.setFirstResult( 1L );
+		query.setMaxResults( 1L );
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasHitCount( 3 )
+				.hasReferencesHitsExactOrder( indexName, DOCUMENT_2 );
+
+		query.setFirstResult( null );
+		query.setMaxResults( 2L );
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasHitCount( 3 )
+				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().all().end()
+				.sort().byField( "string" ).asc().end()
+				.build();
+		query.setFirstResult( null );
+		query.setMaxResults( null );
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasHitCount( 3 )
+				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+	}
+
+	@Test
+	public void getQueryString() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().match().onField( "string" ).matching( "platypus" )
+				.build();
+
+		assertThat( query.getQueryString() ).contains( "platypus" );
+	}
+
+	@Test
+	public void asWrappedQuery() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		QueryWrapper queryWrapper = searchTarget.query( sessionContext )
+				.asReferences()
+				.asWrappedQuery( q -> new QueryWrapper( q ) )
+				.predicate().match().onField( "string" ).matching( "platypus" )
+				.build();
+
+		assertThat( queryWrapper.query.getQueryString() ).contains( "platypus" );
+	}
+
+	private void initData() {
+		ChangesetIndexWorker<? extends DocumentElement> worker = indexManager.createWorker( sessionContext );
+		worker.add( referenceProvider( DOCUMENT_1 ), document -> {
+			indexAccessors.string.write( document, STRING_1 );
+		} );
+		worker.add( referenceProvider( DOCUMENT_2 ), document -> {
+			indexAccessors.string.write( document, STRING_2 );
+		} );
+		worker.add( referenceProvider( DOCUMENT_3 ), document -> {
+			indexAccessors.string.write( document, STRING_3 );
+		} );
+
+		worker.execute().join();
+
+		// Check that all documents are searchable
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().all().end()
+				.build();
+		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+	}
+
+	private static class IndexAccessors {
+		final IndexFieldAccessor<String> string;
+
+		IndexAccessors(IndexSchemaElement root) {
+			string = root.field( "string" ).asString().sortable( Sortable.YES ).createAccessor();
+		}
+	}
+
+	private static class QueryWrapper {
+
+		private SearchQuery<?> query;
+
+		private QueryWrapper(SearchQuery<?> query) {
+			this.query = query;
+		}
+	}
 }


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-3061

As for the `getQueryString()` test, I think it's as good as it can be in the backend TCK. Not sure it's worth it to implement specific things in the backends' tests, considering the output might not be very stable. I consider having the search term in the query is something we can expect from every backend.