### PR TITLE
XML files cleanup

### DIFF
--- a/backend-elasticsearch/pom.xml
+++ b/backend-elasticsearch/pom.xml
@@ -15,6 +15,9 @@
     </parent>
     <artifactId>hibernate-search-backend-elasticsearch</artifactId>
 
+    <name>Hibernate Search Backend - Elasticsearch</name>
+    <description>Hibernate Search Backend relying on remote Elasticsearch clusters</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/backend-elasticsearch/pom.xml
+++ b/backend-elasticsearch/pom.xml
@@ -1,7 +1,12 @@
-<?xml version="1.0"?>
-<project
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search.v6poc</groupId>

--- a/backend-lucene/pom.xml
+++ b/backend-lucene/pom.xml
@@ -10,6 +10,9 @@
     </parent>
     <artifactId>hibernate-search-backend-lucene</artifactId>
 
+    <name>Hibernate Search Backend - Lucene</name>
+    <description>Hibernate Search Backend relying on embedded instances of Lucene</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -14,6 +14,9 @@
     </parent>
     <artifactId>hibernate-search-build-config</artifactId>
 
+    <name>Hibernate Search Build Config</name>
+    <description>Hibernate Search common build configuration files</description>
+
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/documentation/pom.xml
+++ b/documentation/pom.xml
@@ -16,7 +16,7 @@
     <packaging>pom</packaging>
 
     <name>Hibernate Search Documentation</name>
-    <description>The Hibernate Search reference documentation</description>
+    <description>Hibernate Search reference documentation</description>
 
     <properties>
         <asciidoctor.base-output-dir>${project.build.directory}/asciidoctor/en-US</asciidoctor.base-output-dir>

--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -8,6 +8,9 @@
     </parent>
     <artifactId>hibernate-search-engine</artifactId>
 
+    <name>Hibernate Search Engine</name>
+    <description>Hibernate Search engine, always required</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/integrationtest/backend-elasticsearch/pom.xml
+++ b/integrationtest/backend-elasticsearch/pom.xml
@@ -8,6 +8,9 @@
     </parent>
     <artifactId>hibernate-search-integrationtest-backend-elasticsearch</artifactId>
 
+    <name>Hibernate Search Integration Tests - Backend - Elasticsearch</name>
+    <description>Hibernate Search integration tests for the Elasticsearch backend, running the Backend TCK in particular</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/integrationtest/backend-lucene/pom.xml
+++ b/integrationtest/backend-lucene/pom.xml
@@ -8,6 +8,9 @@
     </parent>
     <artifactId>hibernate-search-integrationtest-backend-lucene</artifactId>
 
+    <name>Hibernate Search Integration Tests - Backend - Lucene</name>
+    <description>Hibernate Search integration tests for the Lucene backend, running the Backend TCK in particular</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/integrationtest/backend-tck/pom.xml
+++ b/integrationtest/backend-tck/pom.xml
@@ -8,6 +8,9 @@
     </parent>
     <artifactId>hibernate-search-integrationtest-backend-tck</artifactId>
 
+    <name>Hibernate Search Integration Tests - Backend TCK</name>
+    <description>Hibernate Search backend TCK, including tests for every feature common to all the backends</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/integrationtest/mapper-pojo/pom.xml
+++ b/integrationtest/mapper-pojo/pom.xml
@@ -1,5 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search.v6poc</groupId>

--- a/integrationtest/mapper-pojo/pom.xml
+++ b/integrationtest/mapper-pojo/pom.xml
@@ -15,6 +15,9 @@
     </parent>
     <artifactId>hibernate-search-integrationtest-mapper-pojo</artifactId>
 
+    <name>Hibernate Search Integration Tests - Mapper - POJO</name>
+    <description>Hibernate Search integration tests for the POJO Mapper</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/integrationtest/orm/pom.xml
+++ b/integrationtest/orm/pom.xml
@@ -8,6 +8,9 @@
     </parent>
     <artifactId>hibernate-search-integrationtest-orm</artifactId>
 
+    <name>Hibernate Search Integration Tests - ORM</name>
+    <description>Hibernate Search integration tests for the Hibernate ORM integration</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/integrationtest/pom.xml
+++ b/integrationtest/pom.xml
@@ -9,6 +9,9 @@
     <artifactId>hibernate-search-integrationtest</artifactId>
     <packaging>pom</packaging>
 
+    <name>Hibernate Search Integration Tests - Parent POM</name>
+    <description>Parent POM of Hibernate Search integration tests</description>
+
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/integrationtest/showcase/library/pom.xml
+++ b/integrationtest/showcase/library/pom.xml
@@ -9,6 +9,9 @@
     </parent>
     <artifactId>hibernate-search-integrationtest-showcase-library</artifactId>
 
+    <name>Hibernate Search Integration Tests - Showcase - Library</name>
+    <description>Hibernate Search showcase based on the ORM and Elasticsearch integrations, using libraries and books as business objects</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/jqassistant/rules.xml
+++ b/jqassistant/rules.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Hibernate Validator, declare and validate application constraints
-  ~
-  ~ License: Apache License, Version 2.0
-  ~ See the license.txt file in the root directory or <http://www.apache.org/licenses/LICENSE-2.0>.
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
   -->
 <jqa:jqassistant-rules xmlns:jqa="http://www.buschmais.com/jqassistant/core/analysis/rules/schema/v1.0">
 

--- a/mapper-javabean/pom.xml
+++ b/mapper-javabean/pom.xml
@@ -15,6 +15,9 @@
     </parent>
     <artifactId>hibernate-search-mapper-javabean</artifactId>
 
+    <name>Hibernate Search Mapper - JavaBean</name>
+    <description>Hibernate Search Mapper for POJOs following the JavaBean conventions</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mapper-javabean/pom.xml
+++ b/mapper-javabean/pom.xml
@@ -1,7 +1,12 @@
-<?xml version="1.0"?>
-<project
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search.v6poc</groupId>

--- a/mapper-pojo/pom.xml
+++ b/mapper-pojo/pom.xml
@@ -1,7 +1,12 @@
-<?xml version="1.0"?>
-<project
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search.v6poc</groupId>

--- a/mapper-pojo/pom.xml
+++ b/mapper-pojo/pom.xml
@@ -15,6 +15,9 @@
     </parent>
     <artifactId>hibernate-search-mapper-pojo</artifactId>
 
+    <name>Hibernate Search Mapper - POJO</name>
+    <description>Abstract base and common implementations for Hibernate Search Mappers for POJOs</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/mapper-protobuf/pom.xml
+++ b/mapper-protobuf/pom.xml
@@ -1,7 +1,12 @@
-<?xml version="1.0"?>
-<project
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd"
-    xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search.v6poc</groupId>

--- a/mapper-protobuf/pom.xml
+++ b/mapper-protobuf/pom.xml
@@ -15,6 +15,9 @@
     </parent>
     <artifactId>hibernate-search-mapper-protobuf</artifactId>
 
+    <name>Hibernate Search Mapper - Protobuf</name>
+    <description>Hibernate Search Mapper for Protobuf objects</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/orm/pom.xml
+++ b/orm/pom.xml
@@ -10,6 +10,9 @@
     </parent>
     <artifactId>hibernate-search-orm</artifactId>
 
+    <name>Hibernate Search ORM Integration</name>
+    <description>Hibernate Search integration to Hibernate ORM</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <version>6.0-SNAPSHOT</version>
     <packaging>pom</packaging>
 
-    <name>Hibernate Search 6 POC</name>
-    <description>Proof of concept for some of the heavy refactorings planned for Hibernate Search 6.0</description>
+    <name>Hibernate Search 6 POC Parent POM</name>
+    <description>Parent POM of a proof of concept for some of the heavy refactorings planned for Hibernate Search 6.0</description>
 
     <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -1,9 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- ~ Hibernate Search, full-text search for your domain model ~ ~ License: 
-    GNU Lesser General Public License (LGPL), version 2.1 or later ~ See the 
-    lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>. -->
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+        xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>org.hibernate.search.v6poc</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -523,6 +523,28 @@
                         </execution>
                     </executions>
                 </plugin>
+                <plugin>
+                    <groupId>org.asciidoctor</groupId>
+                    <artifactId>asciidoctor-maven-plugin</artifactId>
+                    <version>${version.asciidoctor.plugin}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.jruby</groupId>
+                            <artifactId>jruby-complete</artifactId>
+                            <version>${version.org.jruby}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj</artifactId>
+                            <version>${version.org.asciidoctor.asciidoctorj}</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj-pdf</artifactId>
+                            <version>${version.org.asciidoctor.asciidoctorj-pdf}</version>
+                        </dependency>
+                    </dependencies>
+                </plugin>
             </plugins>
         </pluginManagement>
     </build>

--- a/reports/pom.xml
+++ b/reports/pom.xml
@@ -14,6 +14,9 @@
     </parent>
     <artifactId>hibernate-search-reports</artifactId>
 
+    <name>Hibernate Search Reports</name>
+    <description>Hibernate Search build reports</description>
+
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/util/internal/common/pom.xml
+++ b/util/internal/common/pom.xml
@@ -9,6 +9,9 @@
     </parent>
     <artifactId>hibernate-search-util-internal-common</artifactId>
 
+    <name>Hibernate Search Utils - Internal - Common</name>
+    <description>Hibernate Search common internal utilities</description>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.logging</groupId>

--- a/util/internal/integrationtest/common/pom.xml
+++ b/util/internal/integrationtest/common/pom.xml
@@ -9,6 +9,9 @@
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-common</artifactId>
 
+    <name>Hibernate Search Utils - Internal - Integration Tests - Common</name>
+    <description>Hibernate Search common integration testing utilities</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/util/internal/integrationtest/orm/pom.xml
+++ b/util/internal/integrationtest/orm/pom.xml
@@ -1,5 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+ ~ Hibernate Search, full-text search for your domain model
+ ~
+ ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+  -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search.v6poc</groupId>

--- a/util/internal/integrationtest/orm/pom.xml
+++ b/util/internal/integrationtest/orm/pom.xml
@@ -16,6 +16,9 @@
     </parent>
     <artifactId>hibernate-search-util-internal-integrationtest-orm</artifactId>
 
+    <name>Hibernate Search Utils - Internal - Integration Tests - ORM</name>
+    <description>Hibernate Search integration testing utilities for tests involving Hibernate ORM</description>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/util/internal/integrationtest/pom.xml
+++ b/util/internal/integrationtest/pom.xml
@@ -10,6 +10,9 @@
     <artifactId>hibernate-search-util-internal-integrationtest-parent</artifactId>
     <packaging>pom</packaging>
 
+    <name>Hibernate Search Utils - Internal - Integration Tests - Parent POM</name>
+    <description>Parent POM of Hibernate Search integration testing utilities</description>
+
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>
         <maven.javadoc.skip>true</maven.javadoc.skip>

--- a/util/internal/integrationtest/sharedresources/pom.xml
+++ b/util/internal/integrationtest/sharedresources/pom.xml
@@ -4,8 +4,9 @@
  ~
  ~ License: GNU Lesser General Public License (LGPL), version 2.1 or later
  ~ See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
- -->
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <parent>
         <groupId>org.hibernate.search.v6poc</groupId>

--- a/util/internal/integrationtest/sharedresources/pom.xml
+++ b/util/internal/integrationtest/sharedresources/pom.xml
@@ -17,8 +17,8 @@
     <artifactId>hibernate-search-util-internal-integrationtest-sharedresources</artifactId>
     <packaging>pom</packaging>
 
-    <name>Shared test resources</name>
-    <description>Contains resources which we want to reuse across multiple modules for testing purposes</description>
+    <name>Hibernate Search Utils - Internal - Integration Tests - Shared Resources</name>
+    <description>Contains resources which we want to reuse across multiple modules for integration testing purposes</description>
 
     <properties>
         <maven.deploy.skip>true</maven.deploy.skip>


### PR DESCRIPTION
First fix some XML file headers, then add missing information to the POM files, and finally fix a missing plugin management entry.

The names are now displayed this way when building:

```
[INFO] Reactor Build Order:
[INFO] 
[INFO] Hibernate Search 6 POC Parent POM
[INFO] Hibernate Search Build Config
[INFO] Hibernate Search Utils - Internal - Common
[INFO] Hibernate Search Engine
[INFO] Hibernate Search Backend - Elasticsearch
[INFO] Hibernate Search Backend - Lucene
[INFO] Hibernate Search Mapper - POJO
[INFO] Hibernate Search Mapper - JavaBean
[INFO] Hibernate Search Mapper - Protobuf
[INFO] Hibernate Search ORM Integration
[INFO] Hibernate Search Utils - Internal - Integration Tests - Parent POM
[INFO] Hibernate Search Utils - Internal - Integration Tests - Common
[INFO] Hibernate Search Utils - Internal - Integration Tests - ORM
[INFO] Hibernate Search Utils - Internal - Integration Tests - Shared Resources
[INFO] Hibernate Search Integration Tests - Parent POM
[INFO] Hibernate Search Integration Tests - Backend TCK
[INFO] Hibernate Search Integration Tests - Backend - Elasticsearch
[INFO] Hibernate Search Integration Tests - Backend - Lucene
[INFO] Hibernate Search Integration Tests - Mapper - POJO
[INFO] Hibernate Search Integration Tests - ORM
[INFO] Hibernate Search Integration Tests - Showcase - Library
[INFO] Hibernate Search Documentation
[INFO] Hibernate Search Reports
```