### PR TITLE
HSEARCH-3145 Rename all() predicate to matchAll()

### DIFF
--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/SearchPredicateContainerContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/SearchPredicateContainerContext.java
@@ -20,7 +20,7 @@ import org.hibernate.search.v6poc.search.dsl.predicate.spi.SearchPredicateContai
  */
 public interface SearchPredicateContainerContext<N> {
 
-	MatchAllPredicateContext<N> all();
+	MatchAllPredicateContext<N> matchAll();
 
 	/*
 	 * Fully fluid syntax, without lambdas but requiring an .end()

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/SearchPredicateContainerContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/SearchPredicateContainerContextImpl.java
@@ -33,7 +33,7 @@ public class SearchPredicateContainerContextImpl<N, C> implements SearchPredicat
 	}
 
 	@Override
-	public MatchAllPredicateContext<N> all() {
+	public MatchAllPredicateContext<N> matchAll() {
 		MatchAllPredicateContextImpl<N, C> child = new MatchAllPredicateContextImpl<>( factory, dslContext::getNextContext );
 		dslContext.addContributor( child );
 		return child;

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/spi/DelegatingSearchPredicateContainerContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/spi/DelegatingSearchPredicateContainerContextImpl.java
@@ -30,8 +30,8 @@ public class DelegatingSearchPredicateContainerContextImpl<N> implements SearchP
 	}
 
 	@Override
-	public MatchAllPredicateContext<N> all() {
-		return delegate.all();
+	public MatchAllPredicateContext<N> matchAll() {
+		return delegate.matchAll();
 	}
 
 	@Override

--- a/integrationtest/backend-elasticsearch/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/elasticsearch/ExtensionIT.java
+++ b/integrationtest/backend-elasticsearch/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/elasticsearch/ExtensionIT.java
@@ -167,7 +167,7 @@ public class ExtensionIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort( c -> c
 						.withExtensionOptional(
 								ElasticsearchExtension.get(),
@@ -192,7 +192,7 @@ public class ExtensionIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort( c -> c
 						.withExtensionOptional(
 								ElasticsearchExtension.get(),
@@ -243,7 +243,7 @@ public class ExtensionIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().by( sort1 ).then().by( sort2 ).then().by( sort3 ).then().by( sort4 ).end()
 				.build();
 		assertThat( query )
@@ -272,7 +272,7 @@ public class ExtensionIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().by( sort1 ).then().by( sort2 ).then().by( sort3 ).then().by( sort4 ).end()
 				.build();
 		assertThat( query )
@@ -358,7 +358,7 @@ public class ExtensionIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder(
 				indexName,

--- a/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/ExtensionIT.java
+++ b/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/ExtensionIT.java
@@ -135,7 +135,7 @@ public class ExtensionIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort( c -> c
 						.withExtensionOptional(
 								LuceneExtension.get(),
@@ -157,7 +157,7 @@ public class ExtensionIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort( c -> c
 						.withExtensionOptional(
 								LuceneExtension.get(),
@@ -199,7 +199,7 @@ public class ExtensionIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().by( sort1 ).then().by( sort2 ).then().by( sort3 ).end()
 				.build();
 		assertThat( query )
@@ -219,7 +219,7 @@ public class ExtensionIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().by( sort ).end()
 				.build();
 		assertThat( query )
@@ -271,7 +271,7 @@ public class ExtensionIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder(
 				indexName,

--- a/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
+++ b/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
@@ -100,7 +100,7 @@ public class LuceneSearchMultiIndexIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "additionalField" ).asc().onMissingValue().sortLast().end()
 				.build();
 
@@ -111,7 +111,7 @@ public class LuceneSearchMultiIndexIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "additionalField" ).desc().onMissingValue().sortLast().end()
 				.build();
 
@@ -140,7 +140,7 @@ public class LuceneSearchMultiIndexIT {
 		IndexSearchTarget searchTarget = indexManager_1_1.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
 
@@ -157,7 +157,7 @@ public class LuceneSearchMultiIndexIT {
 		searchTarget = indexManager_1_2.createSearchTarget().build();
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_2, DOCUMENT_1_2_1 );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/MultiTenancyIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/MultiTenancyIT.java
@@ -125,14 +125,14 @@ public class MultiTenancyIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( tenant2SessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 
 		SearchQuery<List<?>> projectionQuery = searchTarget.query( tenant2SessionContext )
 				.asProjections( "string", "integer" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( projectionQuery ).hasProjectionsHitsAnyOrder( b -> {
 				b.projection( STRING_VALUE_1, INTEGER_VALUE_3 );
@@ -147,7 +147,7 @@ public class MultiTenancyIT {
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_2 );
 		projectionQuery = searchTarget.query( tenant2SessionContext )
 				.asProjections( "string", "integer" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( projectionQuery ).hasProjectionsHitsAnyOrder( b -> {
 				b.projection( STRING_VALUE_2, INTEGER_VALUE_4 );
@@ -155,7 +155,7 @@ public class MultiTenancyIT {
 
 		query = searchTarget.query( tenant1SessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
@@ -168,7 +168,7 @@ public class MultiTenancyIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> checkQuery = searchTarget.query( tenant2SessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( checkQuery )
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
@@ -267,7 +267,7 @@ public class MultiTenancyIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( tenant1SessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
@@ -366,7 +366,7 @@ public class MultiTenancyIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( new StubSessionContext() )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
@@ -470,14 +470,14 @@ public class MultiTenancyIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( tenant1SessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 
 		SearchQuery<List<?>> projectionQuery = searchTarget.query( tenant1SessionContext )
 				.asProjections( "string", "integer" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( projectionQuery ).hasProjectionsHitsAnyOrder( b -> {
 				b.projection( STRING_VALUE_1, INTEGER_VALUE_1 );
@@ -486,14 +486,14 @@ public class MultiTenancyIT {
 
 		query = searchTarget.query( tenant2SessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 
 		projectionQuery = searchTarget.query( tenant2SessionContext )
 				.asProjections( "string", "integer" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( projectionQuery ).hasProjectionsHitsAnyOrder( b -> {
 				b.projection( STRING_VALUE_1, INTEGER_VALUE_3 );

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/ObjectFieldStorageIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/ObjectFieldStorageIT.java
@@ -441,7 +441,7 @@ public class ObjectFieldStorageIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder(

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/SmokeIT.java
@@ -343,7 +343,7 @@ public class SmokeIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, "1", "2", "3", "neverMatching", "empty" );

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -148,7 +148,7 @@ public class SearchMultiIndexIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "sortField" ).asc().end()
 				.build();
 
@@ -160,7 +160,7 @@ public class SearchMultiIndexIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "sortField" ).desc().end()
 				.build();
 
@@ -179,7 +179,7 @@ public class SearchMultiIndexIT {
 
 		SearchQuery<List<?>> query = searchTarget.query( sessionContext )
 				.asProjections( "sortField" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 
 		ProjectionsSearchResultAssert.assertThat( query ).hasProjectionsHitsAnyOrder( c -> {
@@ -213,7 +213,7 @@ public class SearchMultiIndexIT {
 
 		SearchQuery<List<?>> projectionQuery = searchTarget.query( sessionContext )
 				.asProjections( "additionalField" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 
 		ProjectionsSearchResultAssert.assertThat( projectionQuery ).hasProjectionsHitsAnyOrder( c -> {
@@ -248,7 +248,7 @@ public class SearchMultiIndexIT {
 		try {
 			searchTarget.query( sessionContext )
 					.asReferences()
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.sort().byField( "unknownField" ).asc().end()
 					.build();
 		}
@@ -264,7 +264,7 @@ public class SearchMultiIndexIT {
 		try {
 			searchTarget.query( sessionContext )
 					.asProjections( "unknownField" )
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 		}
 		catch (Exception e) {
@@ -335,7 +335,7 @@ public class SearchMultiIndexIT {
 		IndexSearchTarget searchTarget = indexManager_1_1.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
 
@@ -354,7 +354,7 @@ public class SearchMultiIndexIT {
 		searchTarget = indexManager_1_2.createSearchTarget().build();
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_2, DOCUMENT_1_2_1 );
 
@@ -374,7 +374,7 @@ public class SearchMultiIndexIT {
 		searchTarget = indexManager_2_1.createSearchTarget().build();
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName_2_1, DOCUMENT_2_1_1, DOCUMENT_2_1_2 );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchQueryIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchQueryIT.java
@@ -71,7 +71,7 @@ public class SearchQueryIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "string" ).asc().end()
 				.build();
 		query.setFirstResult( 1L );
@@ -82,7 +82,7 @@ public class SearchQueryIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "string" ).asc().end()
 				.build();
 		query.setFirstResult( 1L );
@@ -94,7 +94,7 @@ public class SearchQueryIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "string" ).asc().end()
 				.build();
 		query.setMaxResults( 2L );
@@ -105,7 +105,7 @@ public class SearchQueryIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "string" ).asc().end()
 				.build();
 		query.setFirstResult( null );
@@ -122,7 +122,7 @@ public class SearchQueryIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "string" ).asc().end()
 				.build();
 		query.setFirstResult( 1L );
@@ -147,7 +147,7 @@ public class SearchQueryIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "string" ).asc().end()
 				.build();
 		query.setFirstResult( null );
@@ -201,7 +201,7 @@ public class SearchQueryIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchResultIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchResultIT.java
@@ -96,7 +96,7 @@ public class SearchResultIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, MAIN_ID, EMPTY_ID );
@@ -108,7 +108,7 @@ public class SearchResultIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asObjects()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, MAIN_ID, EMPTY_ID );
@@ -120,7 +120,7 @@ public class SearchResultIT {
 
 		SearchQuery<List<?>> query = searchTarget.query( sessionContext )
 				.asProjections( "string", "string_analyzed", "integer", "localDate", "geoPoint" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasProjectionsHitsAnyOrder( b -> {
 			b.projection( STRING_VALUE, STRING_ANALYZED_VALUE, INTEGER_VALUE, LOCAL_DATE_VALUE, GEO_POINT_VALUE );
@@ -130,7 +130,7 @@ public class SearchResultIT {
 		// Project twice on the same field
 		query = searchTarget.query( sessionContext )
 				.asProjections( "string", "integer", "string" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasProjectionsHitsAnyOrder( b -> {
 			b.projection( STRING_VALUE, INTEGER_VALUE, STRING_VALUE );
@@ -142,7 +142,7 @@ public class SearchResultIT {
 		DocumentReference emptyReference = reference( indexName, EMPTY_ID );
 		query = searchTarget.query( sessionContext )
 				.asProjections( ProjectionConstants.DOCUMENT_REFERENCE, ProjectionConstants.REFERENCE, ProjectionConstants.OBJECT )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasProjectionsHitsAnyOrder( b -> {
 			b.projection( mainReference, mainReference, mainReference );
@@ -161,7 +161,7 @@ public class SearchResultIT {
 
 		searchTarget.query( sessionContext )
 				.asProjections( "unknownField" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 	}
 
@@ -176,7 +176,7 @@ public class SearchResultIT {
 
 		searchTarget.query( sessionContext )
 				.asProjections( "nestedObject" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 	}
 
@@ -191,7 +191,7 @@ public class SearchResultIT {
 
 		searchTarget.query( sessionContext )
 				.asProjections( "flattenedObject" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 	}
 
@@ -205,7 +205,7 @@ public class SearchResultIT {
 		// Project on fields within a flattened object
 		SearchQuery<List<?>> query = searchTarget.query( sessionContext )
 				.asProjections( "flattenedObject.string", "flattenedObject.integer" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasProjectionsHitsAnyOrder( b -> {
 			b.projection( FLATTENED_OBJECT_STRING_VALUE, FLATTENED_OBJECT_INTEGER_VALUE );
@@ -215,7 +215,7 @@ public class SearchResultIT {
 		// Project on fields within a nested object
 		query = searchTarget.query( sessionContext )
 				.asProjections( "nestedObject.string", "nestedObject.integer" )
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasProjectionsHitsAnyOrder( b -> {
 			b.projection( NESTED_OBJECT_STRING_VALUE, NESTED_OBJECT_INTEGER_VALUE );
@@ -253,7 +253,7 @@ public class SearchResultIT {
 				sessionContext, referenceTransformerMock, objectLoaderMock
 		)
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 
 		EasyMock.expect( referenceTransformerMock.apply( referenceMatcher( mainReference ) ) )
@@ -284,7 +284,7 @@ public class SearchResultIT {
 		SearchQuery<StubLoadedObject> objectsQuery =
 				searchTarget.query( sessionContext, referenceTransformerMock, objectLoaderMock )
 						.asObjects()
-						.predicate().all().end()
+						.predicate().matchAll().end()
 						.build();
 
 		EasyMock.expect( referenceTransformerMock.apply( referenceMatcher( mainReference ) ) )
@@ -325,7 +325,7 @@ public class SearchResultIT {
 								"string", ProjectionConstants.DOCUMENT_REFERENCE,
 								ProjectionConstants.REFERENCE, ProjectionConstants.OBJECT
 						)
-						.predicate().all().end()
+						.predicate().matchAll().end()
 						.build();
 
 		EasyMock.expect( referenceTransformerMock.apply( referenceMatcher( mainReference ) ) )
@@ -367,7 +367,7 @@ public class SearchResultIT {
 						ProjectionConstants.DOCUMENT_REFERENCE, ProjectionConstants.DOCUMENT_REFERENCE,
 						ProjectionConstants.OBJECT
 				)
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 
 		EasyMock.expect( hitTransformerMock.apply( projectionMatcher(
@@ -411,7 +411,7 @@ public class SearchResultIT {
 								"string", ProjectionConstants.DOCUMENT_REFERENCE,
 								ProjectionConstants.REFERENCE, ProjectionConstants.OBJECT
 						)
-						.predicate().all().end()
+						.predicate().matchAll().end()
 						.build();
 
 		EasyMock.expect( referenceTransformerMock.apply( referenceMatcher( mainReference ) ) )
@@ -468,7 +468,7 @@ public class SearchResultIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder( indexName, MAIN_ID, EMPTY_ID );

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchSortIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchSortIT.java
@@ -83,7 +83,7 @@ public class SearchSortIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		return searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort( sortContributor )
 				.build();
 	}
@@ -220,7 +220,7 @@ public class SearchSortIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort( sort )
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -228,7 +228,7 @@ public class SearchSortIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().by( sort ).end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -240,7 +240,7 @@ public class SearchSortIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort( sort )
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -248,7 +248,7 @@ public class SearchSortIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().by( sort ).end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -275,7 +275,7 @@ public class SearchSortIT {
 
 		searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "unknownField" ).end()
 				.build();
 	}
@@ -294,7 +294,7 @@ public class SearchSortIT {
 
 		searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "nestedObject" ).end()
 				.build();
 	}
@@ -313,7 +313,7 @@ public class SearchSortIT {
 
 		searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.sort().byField( "flattenedObject" ).end()
 				.build();
 	}
@@ -392,7 +392,7 @@ public class SearchSortIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -356,7 +356,7 @@ public class BoolSearchPredicateIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
@@ -66,7 +66,7 @@ public class MatchAllSearchPredicateIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -79,7 +79,7 @@ public class MatchAllSearchPredicateIT {
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().except().match().onField( "string" ).matching( STRING_1 ).end()
+				.predicate().matchAll().except().match().onField( "string" ).matching( STRING_1 ).end()
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -87,7 +87,7 @@ public class MatchAllSearchPredicateIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().except( c -> c.match().onField( "string" ).matching( STRING_2 ) ).end()
+				.predicate().matchAll().except( c -> c.match().onField( "string" ).matching( STRING_2 ) ).end()
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -97,7 +97,7 @@ public class MatchAllSearchPredicateIT {
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().except( searchPredicate ).end()
+				.predicate().matchAll().except( searchPredicate ).end()
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
@@ -122,7 +122,7 @@ public class MatchAllSearchPredicateIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -339,7 +339,7 @@ public class MatchSearchPredicateIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName, MATCHING_ID, NON_MATCHING_ID, EMPTY_ID, ADDITIONAL_MATCHING_ID );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
@@ -568,7 +568,7 @@ public class RangeSearchPredicateIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY_ID );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -117,7 +117,7 @@ public class SearchPredicateIT {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
-				.predicate().all().end()
+				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder( indexName, MATCHING_ID, NON_MATCHING_ID, EMPTY_ID );
 	}

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanAnnotationMappingIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanAnnotationMappingIT.java
@@ -398,7 +398,7 @@ public class JavaBeanAnnotationMappingIT {
 			)
 					.query()
 					.asReferences()
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 			query.setFirstResult( 3L );
 			query.setMaxResults( 2L );
@@ -439,7 +439,7 @@ public class JavaBeanAnnotationMappingIT {
 							ProjectionConstants.DOCUMENT_REFERENCE,
 							"customBridgeOnClass.text"
 					)
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 			query.setFirstResult( 3L );
 			query.setMaxResults( 2L );

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanProgrammaticMappingIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanProgrammaticMappingIT.java
@@ -441,7 +441,7 @@ public class JavaBeanProgrammaticMappingIT {
 			)
 					.query()
 					.asReferences()
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 			query.setFirstResult( 3L );
 			query.setMaxResults( 2L );
@@ -482,7 +482,7 @@ public class JavaBeanProgrammaticMappingIT {
 							ProjectionConstants.DOCUMENT_REFERENCE,
 							"customBridgeOnClass.text"
 					)
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 			query.setFirstResult( 3L );
 			query.setMaxResults( 2L );

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingIT.java
@@ -381,7 +381,7 @@ public class OrmAnnotationMappingIT {
 					)
 					.query()
 					.asEntities()
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 			query.setFirstResult( 3 );
 			query.setMaxResults( 2 );
@@ -425,7 +425,7 @@ public class OrmAnnotationMappingIT {
 							ProjectionConstants.OBJECT,
 							"customBridgeOnClass.text"
 					)
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 			query.setFirstResult( 3 );
 			query.setMaxResults( 2 );

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmProgrammaticMappingIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmProgrammaticMappingIT.java
@@ -376,7 +376,7 @@ public class OrmProgrammaticMappingIT {
 					)
 					.query()
 					.asEntities()
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 			query.setFirstResult( 3 );
 			query.setMaxResults( 2 );
@@ -420,7 +420,7 @@ public class OrmProgrammaticMappingIT {
 							ProjectionConstants.OBJECT,
 							"customBridgeOnClass.text"
 					)
-					.predicate().all().end()
+					.predicate().matchAll().end()
 					.build();
 			query.setFirstResult( 3 );
 			query.setMaxResults( 2 );


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-3145

Wanted to do that for a while but there was always ongoing PRs in the way.