### PR TITLE
HSEARCH-3167 Exceptions may not be reported in the right order when internals use Closer.split

### DIFF
--- a/engine/pom.xml
+++ b/engine/pom.xml
@@ -30,18 +30,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-util-internal-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanAnnotationMappingDiscoveryIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanAnnotationMappingDiscoveryIT.java
@@ -17,7 +17,7 @@ import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomMarke
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomMarkerAnnotation;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomMarkerConsumingPropertyBridgeAnnotation;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 
 import org.junit.After;

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanAnnotationMappingIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanAnnotationMappingIT.java
@@ -45,7 +45,7 @@ import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.OptionalInt
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomPropertyBridgeAnnotation;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomTypeBridgeAnnotation;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubIndexManager;

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanGenericPropertyIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanGenericPropertyIT.java
@@ -16,7 +16,7 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Fiel
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 
 import org.junit.After;

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanProgrammaticMappingIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanProgrammaticMappingIT.java
@@ -35,7 +35,7 @@ import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomTypeB
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.IntegerAsStringValueBridge;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.OptionalIntAsStringValueBridge;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubIndexManager;

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanPropertyInheritanceIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanPropertyInheritanceIT.java
@@ -16,7 +16,7 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Fiel
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 
 import org.junit.After;

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/CustomPropertyBridge.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/CustomPropertyBridge.java
@@ -21,7 +21,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelElementAccessor;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelProperty;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomPropertyBridgeAnnotation;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 
 public final class CustomPropertyBridge implements PropertyBridge {
 

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/CustomTypeBridge.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/CustomTypeBridge.java
@@ -21,7 +21,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelElementAccessor;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelType;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomTypeBridgeAnnotation;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 
 public final class CustomTypeBridge implements TypeBridge {
 

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/IntegerAsStringValueBridge.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/IntegerAsStringValueBridge.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 
 public final class IntegerAsStringValueBridge implements ValueBridge<Integer, String> {
 

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/OptionalIntAsStringValueBridge.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/OptionalIntAsStringValueBridge.java
@@ -9,7 +9,7 @@ package org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge;
 import java.util.OptionalInt;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 
 public final class OptionalIntAsStringValueBridge implements ValueBridge<OptionalInt, String> {
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingDiscoveryIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingDiscoveryIT.java
@@ -27,7 +27,7 @@ import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomMarkerConsumi
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomMarkerAnnotation;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomMarkerConsumingPropertyBridgeAnnotation;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.service.ServiceRegistry;
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingIT.java
@@ -57,7 +57,7 @@ import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomTy
 import org.hibernate.search.v6poc.integrationtest.orm.usertype.OptionalIntUserType;
 import org.hibernate.search.v6poc.integrationtest.orm.usertype.OptionalStringUserType;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubIndexManager;

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmGenericPropertyIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmGenericPropertyIT.java
@@ -26,7 +26,7 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Fiel
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
 import org.hibernate.service.ServiceRegistry;

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmProgrammaticMappingIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmProgrammaticMappingIT.java
@@ -51,7 +51,7 @@ import org.hibernate.search.v6poc.integrationtest.orm.bridge.OptionalIntAsString
 import org.hibernate.search.v6poc.integrationtest.orm.usertype.OptionalIntUserType;
 import org.hibernate.search.v6poc.integrationtest.orm.usertype.OptionalStringUserType;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StubSearchWorkBehavior;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubIndexManager;

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmPropertyInheritanceIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmPropertyInheritanceIT.java
@@ -24,7 +24,7 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Fiel
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
 import org.hibernate.service.ServiceRegistry;

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmUnusedPropertiesIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmUnusedPropertiesIT.java
@@ -21,7 +21,7 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Docu
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.ExpectedLog4jLog;
+import org.hibernate.search.v6poc.util.impl.test.rule.ExpectedLog4jLog;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.service.ServiceRegistry;
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/CustomPropertyBridge.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/CustomPropertyBridge.java
@@ -21,7 +21,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelElementAccessor;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelProperty;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomPropertyBridgeAnnotation;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 
 public final class CustomPropertyBridge implements PropertyBridge {
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/CustomTypeBridge.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/CustomTypeBridge.java
@@ -21,7 +21,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelElementAccessor;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelType;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomTypeBridgeAnnotation;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 
 public final class CustomTypeBridge implements TypeBridge {
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/IntegerAsStringValueBridge.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/IntegerAsStringValueBridge.java
@@ -7,7 +7,7 @@
 package org.hibernate.search.v6poc.integrationtest.orm.bridge;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 
 public final class IntegerAsStringValueBridge implements ValueBridge<Integer, String> {
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/OptionalIntAsStringValueBridge.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/OptionalIntAsStringValueBridge.java
@@ -9,7 +9,7 @@ package org.hibernate.search.v6poc.integrationtest.orm.bridge;
 import java.util.OptionalInt;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 
 public final class OptionalIntAsStringValueBridge implements ValueBridge<OptionalInt, String> {
 

--- a/mapper-pojo/pom.xml
+++ b/mapper-pojo/pom.xml
@@ -33,18 +33,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-util-internal-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
     <modules>
         <module>build-config</module>
         <module>util/internal/common</module>
+        <module>util/internal/test</module>
         <module>engine</module>
         <module>backend-elasticsearch</module>
         <module>backend-lucene</module>
@@ -182,6 +183,7 @@
          -->
         <sonar.coverage.exclusions>
             **/org/hibernate/checkstyle/**,
+            **/org/hibernate/search/v6poc/util/impl/test/**,
             **/org/hibernate/search/v6poc/util/impl/integrationtest/**,
             **/org/hibernate/search/v6poc/integrationtest/**
         </sonar.coverage.exclusions>
@@ -192,6 +194,11 @@
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>hibernate-search-util-internal-common</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>${project.groupId}</groupId>
+                <artifactId>hibernate-search-util-internal-test</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/Closer.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/Closer.java
@@ -183,7 +183,7 @@ public final class Closer<E extends Exception> implements AutoCloseable {
 					else if ( firstThrowable instanceof Error ) {
 						throw (Error) firstThrowable;
 					}
-					else if ( firstThrowable != null ) {
+					else {
 						/*
 						 * At this point we know that throwable is an instance of E,
 						 * because that's the only checked exception that the source

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/Closer.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/Closer.java
@@ -142,7 +142,7 @@ public final class Closer<E extends Exception> implements AutoCloseable {
 	 * @see <a href="#splitting">splitting</a>
 	 */
 	public <E2 extends Exception> Closer<E2> split() {
-		return new Closer<>();
+		return new Closer<>( state );
 	}
 
 	/**

--- a/util/internal/common/src/test/java/org/hibernate/search/v6poc/util/impl/common/CloserTest.java
+++ b/util/internal/common/src/test/java/org/hibernate/search/v6poc/util/impl/common/CloserTest.java
@@ -1,0 +1,237 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.util.impl.common;
+
+import static org.hibernate.search.v6poc.util.impl.test.ExceptionMatcherBuilder.isException;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class CloserTest {
+
+	@Rule
+	public ExpectedException thrown = ExpectedException.none();
+
+	@Test
+	public void javaIOCloseable() throws IOException {
+		IOException exception1 = new IOException();
+		RuntimeException exception2 = new IllegalStateException();
+		@SuppressWarnings("resource")
+		Closeable closeable = new Closeable() {
+			@Override
+			public void close() throws IOException {
+				throw exception1;
+			}
+		};
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.build()
+		);
+
+		try ( Closer<IOException> closer = new Closer<>() ) {
+			closer.push( closeable::close );
+			closer.push( () -> { throw exception2; } );
+		}
+	}
+
+	@Test
+	public void autoCloseable() throws Exception {
+		Exception exception1 = new Exception();
+		RuntimeException exception2 = new IllegalStateException();
+		@SuppressWarnings("resource")
+		AutoCloseable closeable = new AutoCloseable() {
+			@Override
+			public void close() throws Exception {
+				throw exception1;
+			}
+		};
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.build()
+		);
+
+		try ( Closer<Exception> closer = new Closer<>() ) {
+			closer.push( closeable::close );
+			closer.push( () -> { throw exception2; } );
+		}
+	}
+
+	@Test
+	public void runtimeException() {
+		RuntimeException exception1 = new RuntimeException();
+		RuntimeException exception2 = new IllegalStateException();
+		RuntimeException exception3 = new UnsupportedOperationException();
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.build()
+		);
+
+		try ( Closer<RuntimeException> closer = new Closer<>() ) {
+			closer.push( () -> { throw exception1; } );
+			closer.push( () -> { throw exception2; } );
+			closer.push( () -> { throw exception3; } );
+		}
+	}
+
+	@Test
+	public void nonFailingCloseables() {
+		RuntimeException exception1 = new RuntimeException();
+		RuntimeException exception2 = new RuntimeException();
+		RuntimeException exception3 = new RuntimeException();
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.build()
+		);
+
+		try ( Closer<RuntimeException> closer = new Closer<>() ) {
+			closer.push( () -> { /* Do not fail */ } );
+			closer.push( () -> { throw exception1; } );
+			closer.push( () -> { throw exception2; } );
+			closer.push( () -> { /* Do not fail */ } );
+			closer.push( () -> { throw exception3; } );
+			closer.push( () -> { /* Do not fail */ } );
+		}
+	}
+
+	@Test
+	public void customCloseable() throws MyException1 {
+		MyException1 exception1 = new MyException1();
+		RuntimeException exception2 = new IllegalStateException();
+		@SuppressWarnings("resource")
+		MyException1Closeable closeable = new MyException1Closeable() {
+			@Override
+			public void close() throws MyException1 {
+				throw exception1;
+			}
+		};
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.build()
+		);
+
+		try ( Closer<MyException1> closer = new Closer<>() ) {
+			closer.push( closeable::close );
+			closer.push( () -> { throw exception2; } );
+		}
+	}
+
+	@Test
+	public void iterable() throws IOException {
+		IOException exception1 = new IOException();
+		RuntimeException exception2 = new IllegalStateException();
+		IOException exception3 = new IOException();
+		RuntimeException exception4 = new UnsupportedOperationException();
+		List<Closeable> closeables = Arrays.asList(
+				() -> { throw exception1; },
+				() -> { throw exception2; },
+				() -> { throw exception3; },
+				() -> { throw exception4; }
+				);
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.withSuppressed( exception4 )
+				.build()
+		);
+
+		try ( Closer<IOException> closer = new Closer<>() ) {
+			closer.pushAll( Closeable::close, closeables );
+		}
+	}
+
+	@Test
+	public void split() throws IOException, MyException1, MyException2 {
+		MyException2 exception1 = new MyException2();
+		MyException1 exception2 = new MyException1();
+		IOException exception3 = new IOException();
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.build()
+		);
+
+		try ( Closer<IOException> closer1 = new Closer<>();
+				Closer<MyException1> closer2 = closer1.split();
+				Closer<MyException2> closer3 = closer1.split() ) {
+			/*
+			 * The first exception is caught by closer3,
+			 * but regardless of the fact that closer3 is the third
+			 * closer in the resource list, this exception should be
+			 * the one that is rethrown.
+			 */
+			closer3.push( () -> { throw exception1; } );
+			closer2.push( () -> { throw exception2; } );
+			closer1.push( () -> { throw exception3; } );
+		}
+	}
+
+	@Test
+	public void split_transitive() throws IOException, MyException1, MyException2 {
+		MyException2 exception1 = new MyException2();
+		MyException1 exception2 = new MyException1();
+		IOException exception3 = new IOException();
+
+		thrown.expect(
+				isException( exception1 )
+				.withSuppressed( exception2 )
+				.withSuppressed( exception3 )
+				.build()
+		);
+
+		try ( Closer<IOException> closer1 = new Closer<>();
+				Closer<MyException1> closer2 = closer1.split();
+				// splitting on closer2 should be the same as splitting on closer1
+				Closer<MyException2> closer3 = closer2.split() ) {
+			/*
+			 * The first exception is caught by closer3,
+			 * but regardless of the fact that closer3 is the third
+			 * closer in the resource list, this exception should be
+			 * the one that is rethrown.
+			 */
+			closer3.push( () -> { throw exception1; } );
+			closer2.push( () -> { throw exception2; } );
+			closer1.push( () -> { throw exception3; } );
+		}
+	}
+
+	private static class MyException1 extends Exception {
+	}
+
+	private interface MyException1Closeable extends AutoCloseable {
+		@Override
+		void close() throws MyException1;
+	}
+
+	private static class MyException2 extends Exception {
+	}
+
+}

--- a/util/internal/common/src/test/java/org/hibernate/search/v6poc/util/impl/common/CloserTest.java
+++ b/util/internal/common/src/test/java/org/hibernate/search/v6poc/util/impl/common/CloserTest.java
@@ -168,8 +168,8 @@ public class CloserTest {
 
 	@Test
 	public void split() throws IOException, MyException1, MyException2 {
-		MyException2 exception1 = new MyException2();
-		MyException1 exception2 = new MyException1();
+		MyException1 exception1 = new MyException1();
+		MyException2 exception2 = new MyException2();
 		IOException exception3 = new IOException();
 
 		thrown.expect(
@@ -183,21 +183,21 @@ public class CloserTest {
 				Closer<MyException1> closer2 = closer1.split();
 				Closer<MyException2> closer3 = closer1.split() ) {
 			/*
-			 * The first exception is caught by closer3,
-			 * but regardless of the fact that closer3 is the third
+			 * The first exception is caught by closer2,
+			 * so regardless of the fact that closer2 is the second
 			 * closer in the resource list, this exception should be
 			 * the one that is rethrown.
 			 */
-			closer3.push( () -> { throw exception1; } );
-			closer2.push( () -> { throw exception2; } );
+			closer2.push( () -> { throw exception1; } );
+			closer3.push( () -> { throw exception2; } );
 			closer1.push( () -> { throw exception3; } );
 		}
 	}
 
 	@Test
 	public void split_transitive() throws IOException, MyException1, MyException2 {
-		MyException2 exception1 = new MyException2();
-		MyException1 exception2 = new MyException1();
+		MyException1 exception1 = new MyException1();
+		MyException2 exception2 = new MyException2();
 		IOException exception3 = new IOException();
 
 		thrown.expect(
@@ -212,13 +212,13 @@ public class CloserTest {
 				// splitting on closer2 should be the same as splitting on closer1
 				Closer<MyException2> closer3 = closer2.split() ) {
 			/*
-			 * The first exception is caught by closer3,
-			 * but regardless of the fact that closer3 is the third
+			 * The first exception is caught by closer2,
+			 * so regardless of the fact that closer2 is the second
 			 * closer in the resource list, this exception should be
 			 * the one that is rethrown.
 			 */
-			closer3.push( () -> { throw exception1; } );
-			closer2.push( () -> { throw exception2; } );
+			closer2.push( () -> { throw exception1; } );
+			closer3.push( () -> { throw exception2; } );
 			closer1.push( () -> { throw exception3; } );
 		}
 	}

--- a/util/internal/integrationtest/common/pom.xml
+++ b/util/internal/integrationtest/common/pom.xml
@@ -19,24 +19,8 @@
         </dependency>
 
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>log4j</groupId>
-            <artifactId>log4j</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.skyscreamer</groupId>
-            <artifactId>jsonassert</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.easymock</groupId>
-            <artifactId>easymock</artifactId>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>hibernate-search-util-internal-test</artifactId>
         </dependency>
     </dependencies>
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/index/impl/StubIndexManager.java
@@ -14,7 +14,7 @@ import org.hibernate.search.v6poc.backend.index.spi.IndexManager;
 import org.hibernate.search.v6poc.backend.index.spi.IndexSearchTargetBuilder;
 import org.hibernate.search.v6poc.backend.index.spi.StreamIndexWorker;
 import org.hibernate.search.v6poc.engine.spi.SessionContext;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.StaticCounters;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.StubIndexWork;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.document.impl.StubDocumentElement;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.document.model.StubIndexSchemaNode;

--- a/util/internal/test/pom.xml
+++ b/util/internal/test/pom.xml
@@ -7,25 +7,36 @@
         <version>6.0-SNAPSHOT</version>
         <relativePath>../../..</relativePath>
     </parent>
-    <artifactId>hibernate-search-util-internal-common</artifactId>
+    <artifactId>hibernate-search-util-internal-test</artifactId>
 
-    <name>Hibernate Search Utils - Internal - Common</name>
-    <description>Hibernate Search common internal utilities</description>
+    <name>Hibernate Search Utils - Internal - Test</name>
+    <description>Hibernate Search common test utilities</description>
+
+    <properties>
+        <maven.deploy.skip>true</maven.deploy.skip>
+        <maven.javadoc.skip>true</maven.javadoc.skip>
+    </properties>
 
     <dependencies>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging</artifactId>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.jboss.logging</groupId>
-            <artifactId>jboss-logging-annotations</artifactId>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>${project.groupId}</groupId>
-            <artifactId>hibernate-search-util-internal-test</artifactId>
-            <scope>test</scope>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.skyscreamer</groupId>
+            <artifactId>jsonassert</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.easymock</groupId>
+            <artifactId>easymock</artifactId>
         </dependency>
     </dependencies>
 
@@ -34,10 +45,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-            </plugin>
-            <plugin>
-                <groupId>org.bsc.maven</groupId>
-                <artifactId>maven-processor-plugin</artifactId>
             </plugin>
         </plugins>
     </build>

--- a/util/internal/test/src/main/java/org/hibernate/search/v6poc/util/impl/test/ExceptionMatcherBuilder.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/v6poc/util/impl/test/ExceptionMatcherBuilder.java
@@ -1,0 +1,259 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.util.impl.test;
+
+import static org.hamcrest.CoreMatchers.containsString;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * @author Yoann Rodiere
+ */
+public class ExceptionMatcherBuilder {
+
+	public static ExceptionMatcherBuilder isException(Class<? extends Throwable> clazz) {
+		return new ExceptionMatcherBuilder( CoreMatchers.<Throwable>instanceOf( clazz ) );
+	}
+
+	public static ExceptionMatcherBuilder isException(Throwable throwable) {
+		return new ExceptionMatcherBuilder( CoreMatchers.sameInstance( throwable ) );
+	}
+
+	private final List<Matcher<?>> matchers = new ArrayList<>();
+
+	private final List<Matcher<?>> suppressedMatchers = new ArrayList<>();
+
+	private ExceptionMatcherBuilder(Matcher<? extends Throwable> matcher) {
+		matchers.add( matcher );
+	}
+
+	public ExceptionMatcherBuilder withMainOrSuppressed(Throwable throwable) {
+		return withMainOrSuppressed( CoreMatchers.sameInstance( throwable ) );
+	}
+
+	public ExceptionMatcherBuilder withSuppressed(Throwable throwable) {
+		return withSuppressed( CoreMatchers.sameInstance( throwable ) );
+	}
+
+	public ExceptionMatcherBuilder withMainOrSuppressed(Matcher<?> matcher) {
+		return matching( mainOrSuppressed( matcher ) );
+	}
+
+	public ExceptionMatcherBuilder withSuppressed(Matcher<?> matcher) {
+		suppressedMatchers.add( matcher );
+		return this;
+	}
+
+	public ExceptionMatcherBuilder causedBy(Class<? extends Throwable> clazz) {
+		return new NestedExceptionCauseMatcherBuilder( CoreMatchers.<Throwable>instanceOf( clazz ) );
+	}
+
+	public ExceptionMatcherBuilder causedBy(Throwable throwable) {
+		return new NestedExceptionCauseMatcherBuilder( CoreMatchers.sameInstance( throwable ) );
+	}
+
+	public Matcher<? super Throwable> build() {
+		if ( !suppressedMatchers.isEmpty() ) {
+			@SuppressWarnings("unchecked")
+			Matcher<? super Throwable>[] suppressedMatchersAsArray = castedSuppressedMatchers().toArray( new Matcher[suppressedMatchers.size()] );
+			ExceptionMatcherBuilder.this.matching( hasSuppressed( CoreMatchers.hasItems( suppressedMatchersAsArray ) ) );
+			suppressedMatchers.clear();
+		}
+		if ( matchers.size() == 1 ) {
+			return castedMatchers().get( 0 );
+		}
+		else {
+			return CoreMatchers.allOf( castedMatchers() );
+		}
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" }) // Same hack as in JUnit's internal ExpectedExceptionMatcherBuilder
+	private List<Matcher<? super Throwable>> castedMatchers() {
+		return new ArrayList<Matcher<? super Throwable>>( (List) matchers );
+	}
+
+	@SuppressWarnings({ "unchecked", "rawtypes" }) // Same hack as in JUnit's internal ExpectedExceptionMatcherBuilder
+	private List<Matcher<? super Throwable>> castedSuppressedMatchers() {
+		return new ArrayList<Matcher<? super Throwable>>( (List) suppressedMatchers );
+	}
+
+	public ExceptionMatcherBuilder matching(final Matcher<?> throwableMatcher) {
+		matchers.add( throwableMatcher );
+		return this;
+	}
+
+	public ExceptionMatcherBuilder withMessage(String contained) {
+		return withMessage( containsString( contained ) );
+	}
+
+	public ExceptionMatcherBuilder withMessage(final Matcher<String> messageMatcher) {
+		return matching( hasMessage( messageMatcher ) );
+	}
+
+	/**
+	 * @author Yoann Rodiere
+	 */
+	private class NestedExceptionCauseMatcherBuilder extends ExceptionMatcherBuilder {
+		public NestedExceptionCauseMatcherBuilder(Matcher<? extends Throwable> matcher) {
+			super( matcher );
+		}
+
+		@Override
+		public Matcher<? super Throwable> build() {
+			Matcher<? super Throwable> myMatcher = super.build();
+			ExceptionMatcherBuilder.this.matching( hasCause( myMatcher ) );
+			return ExceptionMatcherBuilder.this.build();
+		}
+	}
+
+	/**
+	 * Copied from the internal class from JUnit 4.11, itself licensed under EPL.
+	 * Altered to fix the uselessly precise generic type parameter.
+	 */
+	public static class ThrowableMessageMatcher extends TypeSafeMatcher<Throwable> {
+
+		private final Matcher<String> fMatcher;
+
+		public ThrowableMessageMatcher(Matcher<String> matcher) {
+			fMatcher = matcher;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText( "exception with message " );
+			description.appendDescriptionOf( fMatcher );
+		}
+
+		@Override
+		protected boolean matchesSafely(Throwable item) {
+			return fMatcher.matches( item.getMessage() );
+		}
+
+		@Override
+		protected void describeMismatchSafely(Throwable item, Description description) {
+			description.appendText( "message " );
+			fMatcher.describeMismatch( item.getMessage(), description );
+		}
+	}
+
+	private static Matcher<Throwable> hasMessage(final Matcher<String> matcher) {
+		return new ThrowableMessageMatcher( matcher );
+	}
+
+	/**
+	 * Copied from the internal class from JUnit 4.11, itself licensed under EPL.
+	 * Altered to fix the incorrect generic type parameter.
+	 */
+	public static class ThrowableCauseMatcher extends TypeSafeMatcher<Throwable> {
+
+		private final Matcher<?> causeMatcher;
+
+		public ThrowableCauseMatcher(Matcher<?> causeMatcher) {
+			this.causeMatcher = causeMatcher;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText( "exception with cause " );
+			description.appendDescriptionOf( causeMatcher );
+		}
+
+		@Override
+		protected boolean matchesSafely(Throwable item) {
+			return causeMatcher.matches( item.getCause() );
+		}
+
+		@Override
+		protected void describeMismatchSafely(Throwable item, Description description) {
+			description.appendText( "cause " );
+			causeMatcher.describeMismatch( item.getCause(), description );
+		}
+	}
+
+	private static Matcher<Throwable> hasCause(final Matcher<?> matcher) {
+		return new ThrowableCauseMatcher( matcher );
+	}
+
+	public static class ThrowableSuppressedMatcher extends TypeSafeMatcher<Throwable> {
+
+		private final Matcher<?> suppressedMatcher;
+
+		public ThrowableSuppressedMatcher(Matcher<?> suppressedMatcher) {
+			this.suppressedMatcher = suppressedMatcher;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText( "exception with suppressed " );
+			description.appendDescriptionOf( suppressedMatcher );
+		}
+
+		@Override
+		protected boolean matchesSafely(Throwable item) {
+			return suppressedMatcher.matches( Arrays.asList( item.getSuppressed() ) );
+		}
+
+		@Override
+		protected void describeMismatchSafely(Throwable item, Description description) {
+			description.appendText( "suppressed " );
+			suppressedMatcher.describeMismatch( Arrays.asList( item.getSuppressed() ), description );
+		}
+	}
+
+	private static Matcher<Throwable> hasSuppressed(Matcher<?> suppressedMatcher) {
+		return new ThrowableSuppressedMatcher( suppressedMatcher );
+	}
+
+	public static class ThrowableMainOrSuppressedMatcher extends TypeSafeDiagnosingMatcher<Throwable> {
+
+		private final Matcher<?> mainOrSuppressedMatcher;
+
+		public ThrowableMainOrSuppressedMatcher(Matcher<?> suppressedMatcher) {
+			this.mainOrSuppressedMatcher = suppressedMatcher;
+		}
+
+		@Override
+		public void describeTo(Description description) {
+			description.appendText( "exception (or one of its suppressed exceptions) " );
+			description.appendDescriptionOf( mainOrSuppressedMatcher );
+		}
+
+		@Override
+		protected boolean matchesSafely(Throwable item, Description mismatchDescription) {
+			Throwable[] suppressedArray = item.getSuppressed();
+			List<Throwable> mainAndSuppressed = new ArrayList<>();
+			mainAndSuppressed.add( item );
+			Collections.addAll( mainAndSuppressed, suppressedArray );
+
+			boolean first = true;
+			for ( Throwable element : mainAndSuppressed ) {
+				if ( mainOrSuppressedMatcher.matches( element ) ) {
+					return true;
+				}
+				if ( !first ) {
+					mismatchDescription.appendText( ", " );
+				}
+				mainOrSuppressedMatcher.describeMismatch( element, mismatchDescription );
+				first = false;
+			}
+			return false;
+		}
+	}
+
+	private static Matcher<Throwable> mainOrSuppressed(Matcher<?> mainOrSuppressedMatcher) {
+		return new ThrowableMainOrSuppressedMatcher( mainOrSuppressedMatcher );
+	}
+}

--- a/util/internal/test/src/main/java/org/hibernate/search/v6poc/util/impl/test/rule/ExpectedLog4jLog.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/v6poc/util/impl/test/rule/ExpectedLog4jLog.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.v6poc.util.impl.integrationtest.common.rule;
+package org.hibernate.search.v6poc.util.impl.test.rule;
 
 import static org.junit.Assert.fail;
 

--- a/util/internal/test/src/main/java/org/hibernate/search/v6poc/util/impl/test/rule/StaticCounters.java
+++ b/util/internal/test/src/main/java/org/hibernate/search/v6poc/util/impl/test/rule/StaticCounters.java
@@ -4,7 +4,7 @@
  * License: GNU Lesser General Public License (LGPL), version 2.1 or later
  * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
  */
-package org.hibernate.search.v6poc.util.impl.integrationtest.common.rule;
+package org.hibernate.search.v6poc.util.impl.test.rule;
 
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;


### PR DESCRIPTION
**WARNING**: this PR is based on #58, which should be merged first.

https://hibernate.atlassian.net//browse/HSEARCH-3167
