### PR TITLE
HSEARCH-3197 + HSEARCH-3208 Add advanced, conditional syntax to set the minimum number of should clauses required to match for boolean predicates in the DSL

### DIFF
--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/logging/impl/Log.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/logging/impl/Log.java
@@ -153,4 +153,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 528, value = "Distance related operations are not supported by the type of field '%1$s'.")
 	SearchException distanceOperationsNotSupportedByFieldType(String absoluteFieldPath);
+
+	@Message(id = 529, value = "Multiple conflicting minimumShouldMatch constraints for ceiling '%1$s'")
+	SearchException minimumShouldMatchConflictingConstraints(int ceiling);
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/predicate/impl/BooleanJunctionPredicateBuilderImpl.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/predicate/impl/BooleanJunctionPredicateBuilderImpl.java
@@ -6,8 +6,15 @@
  */
 package org.hibernate.search.v6poc.backend.elasticsearch.search.predicate.impl;
 
+import java.lang.invoke.MethodHandles;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.TreeMap;
+
 import org.hibernate.search.v6poc.backend.elasticsearch.gson.impl.JsonAccessor;
+import org.hibernate.search.v6poc.backend.elasticsearch.logging.impl.Log;
 import org.hibernate.search.v6poc.search.predicate.spi.BooleanJunctionPredicateBuilder;
+import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 
 import com.google.gson.JsonObject;
 
@@ -18,10 +25,17 @@ import com.google.gson.JsonObject;
 class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 		implements BooleanJunctionPredicateBuilder<ElasticsearchSearchPredicateCollector> {
 
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
 	private static final JsonAccessor<JsonObject> MUST = JsonAccessor.root().property( "must" ).asObject();
 	private static final JsonAccessor<JsonObject> MUST_NOT = JsonAccessor.root().property( "must_not" ).asObject();
 	private static final JsonAccessor<JsonObject> SHOULD = JsonAccessor.root().property( "should" ).asObject();
 	private static final JsonAccessor<JsonObject> FILTER = JsonAccessor.root().property( "filter" ).asObject();
+
+	private static final JsonAccessor<String> MINIMUM_SHOULD_MATCH =
+			JsonAccessor.root().property( "minimum_should_match" ).asString();
+
+	private Map<Integer, MinimumShouldMatchConstraint> minimumShouldMatchConstraints;
 
 	@Override
 	public ElasticsearchSearchPredicateCollector getMustCollector() {
@@ -43,6 +57,34 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 		return this::filter;
 	}
 
+	@Override
+	public void minimumShouldMatchNumber(int ignoreConstraintCeiling, int matchingClausesNumber) {
+		addMinimumShouldMatchConstraint(
+				ignoreConstraintCeiling,
+				new MinimumShouldMatchConstraint( matchingClausesNumber, null )
+		);
+	}
+
+	@Override
+	public void minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio) {
+		addMinimumShouldMatchConstraint(
+				ignoreConstraintCeiling,
+				new MinimumShouldMatchConstraint( null, matchingClausesRatio )
+		);
+	}
+
+	private void addMinimumShouldMatchConstraint(int ignoreConstraintCeiling,
+			MinimumShouldMatchConstraint constraint) {
+		if ( minimumShouldMatchConstraints == null ) {
+			// We'll need to go through the data in ascending order, so use a TreeMap
+			minimumShouldMatchConstraints = new TreeMap<>();
+		}
+		Object previous = minimumShouldMatchConstraints.put( ignoreConstraintCeiling, constraint );
+		if ( previous != null ) {
+			throw log.minimumShouldMatchConflictingConstraints( ignoreConstraintCeiling );
+		}
+	}
+
 	private void must(JsonObject query) {
 		MUST.add( getInnerObject(), query );
 	}
@@ -61,9 +103,78 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 
 	@Override
 	public void contribute(ElasticsearchSearchPredicateCollector collector) {
+		JsonObject innerObject = getInnerObject();
+		if ( minimumShouldMatchConstraints != null ) {
+			MINIMUM_SHOULD_MATCH.set(
+					innerObject,
+					formatMinimumShouldMatchConstraints( minimumShouldMatchConstraints )
+			);
+		}
+
 		JsonObject outerObject = getOuterObject();
-		outerObject.add( "bool", getInnerObject() );
+		outerObject.add( "bool", innerObject );
 		collector.collectPredicate( outerObject );
+	}
+
+	private String formatMinimumShouldMatchConstraints(Map<Integer, MinimumShouldMatchConstraint> minimumShouldMatchConstraints) {
+		StringBuilder builder = new StringBuilder();
+		Iterator<Map.Entry<Integer, MinimumShouldMatchConstraint>> iterator =
+				minimumShouldMatchConstraints.entrySet().iterator();
+
+		// Process the first constraint differently
+		Map.Entry<Integer, MinimumShouldMatchConstraint> entry = iterator.next();
+		Integer ignoreConstraintCeiling = entry.getKey();
+		MinimumShouldMatchConstraint constraint = entry.getValue();
+		if ( ignoreConstraintCeiling.equals( 0 ) && minimumShouldMatchConstraints.size() == 1 ) {
+			// Special case: if there's only one constraint and its ignore ceiling is 0, do not mention the ceiling
+			constraint.appendTo( builder, null );
+			return builder.toString();
+		}
+		else {
+			entry.getValue().appendTo( builder, ignoreConstraintCeiling );
+		}
+
+		// Process the other constraints normally
+		while ( iterator.hasNext() ) {
+			entry = iterator.next();
+			ignoreConstraintCeiling = entry.getKey();
+			constraint = entry.getValue();
+			builder.append( ' ' );
+			constraint.appendTo( builder, ignoreConstraintCeiling );
+		}
+
+		return builder.toString();
+	}
+
+	private static final class MinimumShouldMatchConstraint {
+		private final Integer matchingClausesNumber;
+		private final Double matchingClausesRatio;
+
+		MinimumShouldMatchConstraint(Integer matchingClausesNumber, Double matchingClausesRatio) {
+			this.matchingClausesNumber = matchingClausesNumber;
+			this.matchingClausesRatio = matchingClausesRatio;
+		}
+
+		/**
+		 * Format the constraint according to
+		 * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html">
+		 * the format specified in the Elasticsearch documentation
+		 * </a>.
+		 *
+		 * @param builder The builder to append the formatted value to.
+		 * @param ignoreConstraintCeiling The ceiling above which this constraint is no longer ignored.
+		 */
+		void appendTo(StringBuilder builder, Integer ignoreConstraintCeiling) {
+			if ( ignoreConstraintCeiling != null ) {
+				builder.append( ignoreConstraintCeiling ).append( '<' );
+			}
+			if ( matchingClausesNumber != null ) {
+				builder.append( matchingClausesNumber );
+			}
+			else {
+				builder.append( matchingClausesRatio * 100.0 ).append( '%' );
+			}
+		}
 	}
 
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/predicate/impl/BooleanJunctionPredicateBuilderImpl.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/predicate/impl/BooleanJunctionPredicateBuilderImpl.java
@@ -66,10 +66,10 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 	}
 
 	@Override
-	public void minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio) {
+	public void minimumShouldMatchPercent(int ignoreConstraintCeiling, int matchingClausesPercent) {
 		addMinimumShouldMatchConstraint(
 				ignoreConstraintCeiling,
-				new MinimumShouldMatchConstraint( null, matchingClausesRatio )
+				new MinimumShouldMatchConstraint( null, matchingClausesPercent )
 		);
 	}
 
@@ -148,11 +148,11 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 
 	private static final class MinimumShouldMatchConstraint {
 		private final Integer matchingClausesNumber;
-		private final Double matchingClausesRatio;
+		private final Integer matchingClausesPercent;
 
-		MinimumShouldMatchConstraint(Integer matchingClausesNumber, Double matchingClausesRatio) {
+		MinimumShouldMatchConstraint(Integer matchingClausesNumber, Integer matchingClausesPercent) {
 			this.matchingClausesNumber = matchingClausesNumber;
-			this.matchingClausesRatio = matchingClausesRatio;
+			this.matchingClausesPercent = matchingClausesPercent;
 		}
 
 		/**
@@ -172,7 +172,7 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 				builder.append( matchingClausesNumber );
 			}
 			else {
-				builder.append( matchingClausesRatio * 100.0 ).append( '%' );
+				builder.append( matchingClausesPercent ).append( '%' );
 			}
 		}
 	}

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/logging/impl/Log.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/logging/impl/Log.java
@@ -183,4 +183,11 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 543, value = "Descending order is not supported by distance sort for field '%1$s'.")
 	SearchException descendingOrderNotSupportedByDistanceSort(String absoluteFieldPath);
+
+	@Message(id = 544, value = "Computed minimum for minimumShouldMatch constraint is out of bounds:"
+			+ " expected a number between 1 and '%1$s', got '%2$s'.")
+	SearchException minimumShouldMatchMinimumOutOfBounds(int minimum, int totalShouldClauseNumber);
+
+	@Message(id = 545, value = "Multiple conflicting minimumShouldMatch constraints for ceiling '%1$s'")
+	SearchException minimumShouldMatchConflictingConstraints(int ignoreConstraintCeiling);
 }

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/predicate/impl/BooleanJunctionPredicateBuilderImpl.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/predicate/impl/BooleanJunctionPredicateBuilderImpl.java
@@ -6,11 +6,19 @@
  */
 package org.hibernate.search.v6poc.backend.lucene.search.predicate.impl;
 
+import java.lang.invoke.MethodHandles;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.MatchAllDocsQuery;
 import org.apache.lucene.search.Query;
+
+import org.hibernate.search.v6poc.backend.lucene.logging.impl.Log;
 import org.hibernate.search.v6poc.search.predicate.spi.BooleanJunctionPredicateBuilder;
+import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 
 
 /**
@@ -19,10 +27,15 @@ import org.hibernate.search.v6poc.search.predicate.spi.BooleanJunctionPredicateB
 class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 		implements BooleanJunctionPredicateBuilder<LuceneSearchPredicateCollector> {
 
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
 	private final BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
 
 	private boolean hasMustNot = false;
 	private boolean hasOnlyMustNot = true;
+	private int shouldClauseCount = 0;
+
+	private NavigableMap<Integer, MinimumShouldMatchConstraint> minimumShouldMatchConstraints;
 
 	@Override
 	public LuceneSearchPredicateCollector getMustCollector() {
@@ -44,6 +57,34 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 		return this::filter;
 	}
 
+	@Override
+	public void minimumShouldMatchNumber(int ignoreConstraintCeiling, int matchingClausesNumber) {
+		addMinimumShouldMatchConstraint(
+				ignoreConstraintCeiling,
+				new MinimumShouldMatchConstraint( matchingClausesNumber, null )
+		);
+	}
+
+	@Override
+	public void minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio) {
+		addMinimumShouldMatchConstraint(
+				ignoreConstraintCeiling,
+				new MinimumShouldMatchConstraint( null, matchingClausesRatio )
+		);
+	}
+
+	private void addMinimumShouldMatchConstraint(int ignoreConstraintCeiling,
+			MinimumShouldMatchConstraint constraint) {
+		if ( minimumShouldMatchConstraints == null ) {
+			// We'll need to go through the data in ascending order, so use a TreeMap
+			minimumShouldMatchConstraints = new TreeMap<>();
+		}
+		Object previous = minimumShouldMatchConstraints.put( ignoreConstraintCeiling, constraint );
+		if ( previous != null ) {
+			throw log.minimumShouldMatchConflictingConstraints( ignoreConstraintCeiling );
+		}
+	}
+
 	private void must(Query luceneQuery) {
 		booleanQueryBuilder.add( luceneQuery, Occur.MUST );
 		hasOnlyMustNot = false;
@@ -56,6 +97,7 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 
 	private void should(Query luceneQuery) {
 		booleanQueryBuilder.add( luceneQuery, Occur.SHOULD );
+		++shouldClauseCount;
 		hasOnlyMustNot = false;
 	}
 
@@ -69,6 +111,54 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 		if ( hasMustNot && hasOnlyMustNot ) {
 			booleanQueryBuilder.add( new MatchAllDocsQuery(), Occur.FILTER );
 		}
+		if ( minimumShouldMatchConstraints != null ) {
+			int minimumShouldMatch;
+			Map.Entry<Integer, MinimumShouldMatchConstraint> entry =
+					minimumShouldMatchConstraints.lowerEntry( shouldClauseCount );
+			if ( entry != null ) {
+				minimumShouldMatch = entry.getValue().toMinimum( shouldClauseCount );
+			}
+			else {
+				minimumShouldMatch = shouldClauseCount;
+			}
+			booleanQueryBuilder.setMinimumNumberShouldMatch( minimumShouldMatch );
+		}
 		return booleanQueryBuilder.build();
+	}
+
+	private static final class MinimumShouldMatchConstraint {
+		private final Integer matchingClausesNumber;
+		private final Double matchingClausesRatio;
+
+		MinimumShouldMatchConstraint(Integer matchingClausesNumber, Double matchingClausesRatio) {
+			this.matchingClausesNumber = matchingClausesNumber;
+			this.matchingClausesRatio = matchingClausesRatio;
+		}
+
+		int toMinimum(int totalShouldClauseNumber) {
+			int minimum;
+			if ( matchingClausesNumber != null ) {
+				if ( matchingClausesNumber >= 0 ) {
+					minimum = matchingClausesNumber;
+				}
+				else {
+					minimum = totalShouldClauseNumber + matchingClausesNumber;
+				}
+			}
+			else {
+				if ( matchingClausesRatio >= 0.0 ) {
+					minimum = (int) ( matchingClausesRatio * totalShouldClauseNumber );
+				}
+				else {
+					minimum = totalShouldClauseNumber + (int) ( matchingClausesRatio * totalShouldClauseNumber );
+				}
+			}
+
+			if ( minimum < 1 || minimum > totalShouldClauseNumber ) {
+				throw log.minimumShouldMatchMinimumOutOfBounds( minimum, totalShouldClauseNumber );
+			}
+
+			return minimum;
+		}
 	}
 }

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/predicate/impl/BooleanJunctionPredicateBuilderImpl.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/predicate/impl/BooleanJunctionPredicateBuilderImpl.java
@@ -66,10 +66,10 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 	}
 
 	@Override
-	public void minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio) {
+	public void minimumShouldMatchPercent(int ignoreConstraintCeiling, int matchingClausesPercent) {
 		addMinimumShouldMatchConstraint(
 				ignoreConstraintCeiling,
-				new MinimumShouldMatchConstraint( null, matchingClausesRatio )
+				new MinimumShouldMatchConstraint( null, matchingClausesPercent )
 		);
 	}
 
@@ -128,11 +128,11 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 
 	private static final class MinimumShouldMatchConstraint {
 		private final Integer matchingClausesNumber;
-		private final Double matchingClausesRatio;
+		private final Integer matchingClausesPercent;
 
-		MinimumShouldMatchConstraint(Integer matchingClausesNumber, Double matchingClausesRatio) {
+		MinimumShouldMatchConstraint(Integer matchingClausesNumber, Integer matchingClausesPercent) {
 			this.matchingClausesNumber = matchingClausesNumber;
-			this.matchingClausesRatio = matchingClausesRatio;
+			this.matchingClausesPercent = matchingClausesPercent;
 		}
 
 		int toMinimum(int totalShouldClauseNumber) {
@@ -146,11 +146,11 @@ class BooleanJunctionPredicateBuilderImpl extends AbstractSearchPredicateBuilder
 				}
 			}
 			else {
-				if ( matchingClausesRatio >= 0.0 ) {
-					minimum = (int) ( matchingClausesRatio * totalShouldClauseNumber );
+				if ( matchingClausesPercent >= 0 ) {
+					minimum = matchingClausesPercent * totalShouldClauseNumber / 100;
 				}
 				else {
-					minimum = totalShouldClauseNumber + (int) ( matchingClausesRatio * totalShouldClauseNumber );
+					minimum = totalShouldClauseNumber + matchingClausesPercent * totalShouldClauseNumber / 100;
 				}
 			}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/BooleanJunctionPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/BooleanJunctionPredicateContext.java
@@ -43,102 +43,24 @@ import org.hibernate.search.v6poc.search.dsl.ExplicitEndContext;
  * <ul>
  * <li>
  *     When there isn't any "must" clause nor any "filter" clause in the boolean predicate,
- *     and there is no "minimumShouldMatch" constraint (see below),
+ *     and there is no <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraint</a>,
  *     then at least one "should" clause is required to match.
  *     Simply put, in this case, the "should" clauses
  *     <strong>behave as if there was an "OR" operator between each of them</strong>.
  * </li>
  * <li>
  *     When there is at least one "must" clause or one "filter" clause in the boolean predicate,
- *     and there is no "minimumShouldMatch" constraint (see below),
+ *     and there is no <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraint</a>,
  *     then the "should" clauses are not required to match,
  *     and are simply used for scoring.
  * </li>
  * <li>
- *     When there is at least one "minimumShouldMatch" constraint (see below),
+ *     When there is at least one <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraint</a>,
  *     then the "should" clauses are required according to the "minimumShouldMatch" constraints.
  * </li>
  * </ul>
  * <p>
  * Matching "should" clauses are taken into account in score computation.
- *
- * <h3 id="minimumshouldmatch">"minimumShouldMatch" constraints</h3>
- * <p>
- * "minimumShouldMatch" constraints define a minimum number of "should" clauses that have to match
- * in order for the boolean predicate to match.
- * <p>
- * The feature is similar, and will work identically, to
- * <a href="https://lucene.apache.org/solr/7_3_0/solr-core/org/apache/solr/util/doc-files/min-should-match.html">"Min Number Should Match"</a>
- * in Solr or
- * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html">{@code minimum_should_match}</a>
- * in Elasticsearch.
- *
- * <h4 id="minimumshouldmatch-minimum">Definition of the minimum</h4>
- * <p>
- * The minimum may be defined either directly as a positive number, or indirectly as a negative number
- * or positive or negative percentage representing a ratio of the total number of "should" clauses in this boolean predicate.
- * <p>
- * Here is how each type of input is interpreted:
- * <dl>
- *     <dt>Positive number</dt>
- *     <dd>
- *         The value is interpreted directly as the minimum number of "should" clauses that have to match.
- *     </dd>
- *     <dt>Negative number</dt>
- *     <dd>
- *         The absolute value is interpreted as the maximum number of "should" clauses that may not match:
- *         the absolute value is subtracted from the total number of "should" clauses.
- *     </dd>
- *     <dt>Positive percentage</dt>
- *     <dd>
- *         The value is interpreted as the minimum percentage of the total number of "should" clauses that have to match:
- *         the percentage is applied to the total number of "should" clauses, then rounded down.
- *     </dd>
- *     <dt>Negative percentage</dt>
- *     <dd>
- *         The absolute value is interpreted as the maximum percentage of the total number of "should" clauses that may not match:
- *         the absolute value of the percentage is applied to the total number of "should" clauses, then rounded down,
- *         then subtracted from the total number of "should" clauses.
- *     </dd>
- * </dl>
- * <p>
- * In any case, if the computed minimum is 0 or less, or higher than the total number of "should" clauses,
- * behavior is backend-specific (it may throw an exception, or produce unpredictable results,
- * or fall back to some default behavior).
- *
- * <h4 id="minimumshouldmatch-conditionalconstraints">Conditional constraints</h4>
- * <p>
- * Multiple conditional constraints may be defined,
- * only one of them being applied depending on the total number of "should" clauses.
- * <p>
- * Each constraint is attributed a minimum number of "should" clauses
- * that have to match, <strong>and an additional number</strong>.
- * The additional number is unique to each constraint.
- * <p>
- * The additional number will be compared to the total number of "should" clauses,
- * and the one closest while still strictly lower will be picked: its associated constraint will be applied.
- * If no number matches, the minimum number of matching "should" clauses
- * will be set to the total number of "should" clauses.
- * <p>
- * Examples:
- * <pre><code>
- *     // Example 1: at least 3 "should" clauses have to match
- *     booleanContext1.minimumShouldMatchNumber( 3 );
- *     // Example 2: at most 2 "should" clauses may not match
- *     booleanContext2.minimumShouldMatchNumber( -2 );
- *     // Example 3: at least 75% of "should" clauses have to match (rounded down)
- *     booleanContext3.minimumShouldMatchPercent( 75 );
- *     // Example 4: at most 25% of "should" clauses may not match (rounded down)
- *     booleanContext4.minimumShouldMatchPercent( -25 );
- *     // Example 5: if there are 3 "should" clauses or less, all "should" clauses have to match.
- *     // If there are 4 "should" clauses or more, at least 90% of "should" clauses have to match (rounded down).
- *     booleanContext5.minimumShouldMatchPercent( 3, 90 );
- *     // Example 6: if there are 4 "should" clauses or less, all "should" clauses have to match.
- *     // If there are 5 to 9 "should" clauses, at most 25% of "should" clauses may not match (rounded down).
- *     // If there are 10 "should" clauses or more, at most 3 "should" clauses may not match.
- *     booleanContext6.minimumShouldMatchPercent( 4, 25 )
- *             .minimumShouldMatchNumber( 9, -3 );
- * </code></pre>
  *
  * @param <N> The type of the next context (returned by {@link ExplicitEndContext#end()}).
  */
@@ -266,57 +188,56 @@ public interface BooleanJunctionPredicateContext<N> extends SearchPredicateConte
 	 */
 
 	/**
-	 * Add a default <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
+	 * Add a default <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
 	 *
 	 * @param matchingClausesNumber A definition of the number of "should" clauses that have to match.
 	 * If positive, it is the number of clauses that have to match.
-	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
+	 * See <a href="MinimumShouldMatchContext.html#minimumshouldmatch-minimum">Definition of the minimum</a>
+	 * for details and possible values, in particular negative values.
 	 * @return {@code this}, for method chaining.
 	 */
 	default BooleanJunctionPredicateContext<N> minimumShouldMatchNumber(int matchingClausesNumber) {
-		return minimumShouldMatchNumber( 0, matchingClausesNumber );
+		return minimumShouldMatch()
+				.ifMoreThan( 0 ).thenRequireNumber( matchingClausesNumber )
+				.end();
 	}
 
 	/**
-	 * Add a default <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
+	 * Add a default <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
 	 *
 	 * @param matchingClausesPercent A definition of the number of "should" clauses that have to match, as a percentage.
 	 * If positive, it is the percentage of the total number of "should" clauses that have to match.
-	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
+	 * See <a href="MinimumShouldMatchContext.html#minimumshouldmatch-minimum">Definition of the minimum</a>
+	 * for details and possible values, in particular negative values.
 	 * @return {@code this}, for method chaining.
 	 */
 	default BooleanJunctionPredicateContext<N> minimumShouldMatchPercent(int matchingClausesPercent) {
-		return minimumShouldMatchPercent( 0, matchingClausesPercent );
+		return minimumShouldMatch()
+				.ifMoreThan( 0 ).thenRequirePercent( matchingClausesPercent )
+				.end();
 	}
 
 	/**
-	 * Add a <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a> that will be applied
-	 * if there are strictly more than {@code ignoreConstraintCeiling} "should" clauses.
+	 * Start defining the minimum number of "should" constraints that have to match
+	 * in order for the boolean predicate to match.
 	 * <p>
-	 * See <a href="#minimumshouldmatch-conditionalconstraints">Conditional constraints</a> for the detailed rules
-	 * defining whether a constraint is applied or not.
+	 * See {@link MinimumShouldMatchContext}.
 	 *
-	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
-	 * will cease to be ignored.
-	 * @param matchingClausesNumber A definition of the number of "should" clauses that have to match.
-	 * If positive, it is the number of clauses that have to match.
-	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
-	 * @return {@code this}, for method chaining.
+	 * @return A {@link MinimumShouldMatchContext} allowing to define constraints.
 	 */
-	BooleanJunctionPredicateContext<N> minimumShouldMatchNumber(int ignoreConstraintCeiling, int matchingClausesNumber);
+	MinimumShouldMatchContext<? extends BooleanJunctionPredicateContext<N>> minimumShouldMatch();
 
 	/**
-	 * Add a <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a> that will be applied
-	 * if there are strictly more than {@code ignoreConstraintCeiling} "should" clauses.
+	 * Start defining the minimum number of "should" constraints that have to match
+	 * in order for the boolean predicate to match.
 	 * <p>
-	 * See <a href="#minimumshouldmatch-conditionalconstraints">Conditional constraints</a> for the detailed rules
-	 * defining whether a constraint is applied or not.
-	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
-	 * will cease to be ignored.
-	 * @param matchingClausesPercent A definition of the number of "should" clauses that have to match, as a percentage.
-	 * If positive, it is the percentage of the total number of "should" clauses that have to match.
+	 * See {@link MinimumShouldMatchContext}.
+	 *
+	 * @param constraintContributor A consumer that will add constraints to the context passed in parameter.
+	 * Should generally be a lambda expression.
 	 * @return {@code this}, for method chaining.
 	 */
-	BooleanJunctionPredicateContext<N> minimumShouldMatchPercent(int ignoreConstraintCeiling, int matchingClausesPercent);
+	BooleanJunctionPredicateContext<N> minimumShouldMatch(
+			Consumer<? super MinimumShouldMatchContext<?>> constraintContributor);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/BooleanJunctionPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/BooleanJunctionPredicateContext.java
@@ -43,18 +43,102 @@ import org.hibernate.search.v6poc.search.dsl.ExplicitEndContext;
  * <ul>
  * <li>
  *     When there isn't any "must" clause nor any "filter" clause in the boolean predicate,
+ *     and there is no "minimumShouldMatch" constraint (see below),
  *     then at least one "should" clause is required to match.
  *     Simply put, in this case, the "should" clauses
  *     <strong>behave as if there was an "OR" operator between each of them</strong>.
  * </li>
  * <li>
  *     When there is at least one "must" clause or one "filter" clause in the boolean predicate,
+ *     and there is no "minimumShouldMatch" constraint (see below),
  *     then the "should" clauses are not required to match,
  *     and are simply used for scoring.
+ * </li>
+ * <li>
+ *     When there is at least one "minimumShouldMatch" constraint (see below),
+ *     then the "should" clauses are required according to the "minimumShouldMatch" constraints.
  * </li>
  * </ul>
  * <p>
  * Matching "should" clauses are taken into account in score computation.
+ *
+ * <h3 id="minimumshouldmatch">"minimumShouldMatch" constraints</h3>
+ * <p>
+ * "minimumShouldMatch" constraints define a minimum number of "should" clauses that have to match
+ * in order for the boolean predicate to match.
+ * <p>
+ * The feature is similar, and will work identically, to
+ * <a href="https://lucene.apache.org/solr/7_3_0/solr-core/org/apache/solr/util/doc-files/min-should-match.html">"Min Number Should Match"</a>
+ * in Solr or
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html">{@code minimum_should_match}</a>
+ * in Elasticsearch.
+ *
+ * <h4 id="minimumshouldmatch-minimum">Definition of the minimum</h4>
+ * <p>
+ * The minimum may be defined either directly as a positive integer, or indirectly as a negative integer
+ * or positive or negative double representing a ratio of the total number of "should" clauses in this boolean predicate.
+ * <p>
+ * Here is how each type of input is interpreted:
+ * <dl>
+ *     <dt>Positive integer</dt>
+ *     <dd>
+ *         The value is interpreted directly as the minimum number of "should" clauses that have to match.
+ *     </dd>
+ *     <dt>Negative integer</dt>
+ *     <dd>
+ *         The absolute value is interpreted as the maximum number of "should" clauses that may not match:
+ *         the absolute value is subtracted from the total number of "should" clauses.
+ *     </dd>
+ *     <dt>Positive ratio</dt>
+ *     <dd>
+ *         The value is interpreted as the minimum ratio of the total number of "should" clauses that have to match:
+ *         the value is multiplied by the total number of "should" clauses, then rounded down.
+ *     </dd>
+ *     <dt>Negative ratio</dt>
+ *     <dd>
+ *         The absolute value is interpreted as the maximum ratio of the total number of "should" clauses that may not match:
+ *         the absolute value is multiplied by the total number of "should" clauses, then rounded down,
+ *         then subtracted from the total number of "should" clauses.
+ *     </dd>
+ * </dl>
+ * <p>
+ * In any case, if the computed minimum is 0 or less, or higher than the total number of "should" clauses,
+ * behavior is backend-specific (it may throw an exception, or produce unpredictable results,
+ * or fall back to some default behavior).
+ *
+ * <h4 id="minimumshouldmatch-conditionalconstraints">Conditional constraints</h4>
+ * <p>
+ * Multiple conditional constraints may be defined,
+ * only one of them being applied depending on the total number of "should" clauses.
+ * <p>
+ * Each constraint is attributed a minimum number of "should" clauses
+ * that have to match, <strong>and an additional number</strong>.
+ * The additional number is unique to each constraint.
+ * <p>
+ * The additional number will be compared to the total number of "should" clauses,
+ * and the one closest while still strictly lower will be picked: its associated constraint will be applied.
+ * If no number matches, the minimum number of matching "should" clauses
+ * will be set to the total number of "should" clauses.
+ * <p>
+ * Examples:
+ * <pre><code>
+ *     // Example 1: at least 3 "should" clauses have to match
+ *     booleanContext1.minimumShouldMatchNumber( 3 );
+ *     // Example 2: at most 2 "should" clauses may not match
+ *     booleanContext2.minimumShouldMatchNumber( -2 );
+ *     // Example 3: at least 75% of "should" clauses have to match (rounded down)
+ *     booleanContext3.minimumShouldMatchRatio( 0.75 );
+ *     // Example 4: at most 25% of "should" clauses may not match (rounded down)
+ *     booleanContext4.minimumShouldMatchRatio( -0.25 );
+ *     // Example 5: if there are 3 "should" clauses or less, all "should" clauses have to match.
+ *     // If there are 4 "should" clauses or more, at least 90% of "should" clauses have to match (rounded down).
+ *     booleanContext5.minimumShouldMatchRatio( 3, 0.9 );
+ *     // Example 6: if there are 4 "should" clauses or less, all "should" clauses have to match.
+ *     // If there are 5 to 9 "should" clauses, at most 25% of "should" clauses may not match (rounded down).
+ *     // If there are 10 "should" clauses or more, at most 3 "should" clauses may not match.
+ *     booleanContext6.minimumShouldMatchRatio( 4, -0.25 )
+ *             .minimumShouldMatchNumber( 9, -3 );
+ * </code></pre>
  *
  * @param <N> The type of the next context (returned by {@link ExplicitEndContext#end()}).
  */
@@ -176,5 +260,65 @@ public interface BooleanJunctionPredicateContext<N> extends SearchPredicateConte
 	 * @return {@code this}, for method chaining.
 	 */
 	BooleanJunctionPredicateContext<N> filter(Consumer<? super SearchPredicateContainerContext<?>> clauseContributor);
+
+	/*
+	 * Options
+	 */
+
+	/**
+	 * Add a default <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
+	 *
+	 * @param matchingClausesNumber A definition of the number of "should" clauses that have to match.
+	 * If positive, it is the number of clauses that have to match.
+	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
+	 * @return {@code this}, for method chaining.
+	 */
+	default BooleanJunctionPredicateContext<N> minimumShouldMatchNumber(int matchingClausesNumber) {
+		return minimumShouldMatchNumber( 0, matchingClausesNumber );
+	}
+
+	/**
+	 * Add a default <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
+	 *
+	 * @param matchingClausesRatio A definition of the number of "should" clauses that have to match, as a ratio.
+	 * If positive, it is the ratio of the total number of "should" clauses that have to match.
+	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
+	 * @return {@code this}, for method chaining.
+	 */
+	default BooleanJunctionPredicateContext<N> minimumShouldMatchRatio(double matchingClausesRatio) {
+		return minimumShouldMatchRatio( 0, matchingClausesRatio );
+	}
+
+	/**
+	 * Add a <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a> that will be applied
+	 * if there are strictly more than {@code ignoreConstraintCeiling} "should" clauses.
+	 * <p>
+	 * See <a href="#minimumshouldmatch-conditionalconstraints">Conditional constraints</a> for the detailed rules
+	 * defining whether a constraint is applied or not.
+	 *
+	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
+	 * will cease to be ignored.
+	 * @param matchingClausesNumber A definition of the number of "should" clauses that have to match.
+	 * If positive, it is the number of clauses that have to match.
+	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
+	 * @return {@code this}, for method chaining.
+	 */
+	BooleanJunctionPredicateContext<N> minimumShouldMatchNumber(int ignoreConstraintCeiling, int matchingClausesNumber);
+
+	/**
+	 * Add a <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a> that will be applied
+	 * if there are strictly more than {@code ignoreConstraintCeiling} "should" clauses.
+	 * <p>
+	 * See <a href="#minimumshouldmatch-conditionalconstraints">Conditional constraints</a> for the detailed rules
+	 * defining whether a constraint is applied or not.
+	 *
+	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
+	 * will cease to be ignored.
+	 * @param matchingClausesRatio A definition of the number of "should" clauses that have to match, as a ratio.
+	 * If positive, it is the ratio of the total number of "should" clauses that have to match.
+	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
+	 * @return {@code this}, for method chaining.
+	 */
+	BooleanJunctionPredicateContext<N> minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/BooleanJunctionPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/BooleanJunctionPredicateContext.java
@@ -13,29 +13,115 @@ import org.hibernate.search.v6poc.search.dsl.ExplicitEndContext;
 
 /**
  * The context used when defining a boolean junction, allowing in particular to add clauses.
+ * <p>
+ * Different types of clauses have different effects, see below.
+ *
+ * <h3 id="must">"must" clauses</h3>
+ * <p>
+ * "must" clauses are required to match: if they don't match, then the boolean predicate will not match.
+ * <p>
+ * Matching "must" clauses are taken into account in score computation.
+ *
+ * <h3 id="mustnot">"must not" clauses</h3>
+ * <p>
+ * "must not" clauses are required to not match: if they don't match, then the boolean predicate will not match.
+ * <p>
+ * "must not" clauses are ignored from score computation.
+ * <p>
+ * "must not" clauses are
+ *
+ * <h3 id="filter">"filter" clauses</h3>
+ * <p>
+ * "filter" clauses are required to match: if they don't match, then the boolean predicate will not match.
+ * <p>
+ * "filter" clauses are ignored from score computation,
+ * and so are any clauses of boolean predicates contained in the filter clause (even "match" or "should" clauses).
+ *
+ * <h3 id="should">"should" clauses</h3>
+ * <p>
+ * "should" clauses may optionally match, and are required to match depending on the context.
+ * <ul>
+ * <li>
+ *     When there isn't any "must" clause nor any "filter" clause in the boolean predicate,
+ *     then at least one "should" clause is required to match.
+ *     Simply put, in this case, the "should" clauses
+ *     <strong>behave as if there was an "OR" operator between each of them</strong>.
+ * </li>
+ * <li>
+ *     When there is at least one "must" clause or one "filter" clause in the boolean predicate,
+ *     then the "should" clauses are not required to match,
+ *     and are simply used for scoring.
+ * </li>
+ * </ul>
+ * <p>
+ * Matching "should" clauses are taken into account in score computation.
  *
  * @param <N> The type of the next context (returned by {@link ExplicitEndContext#end()}).
  */
 public interface BooleanJunctionPredicateContext<N> extends SearchPredicateContext<BooleanJunctionPredicateContext<N>>, ExplicitEndContext<N> {
 
+	/**
+	 * Add a <a href="#must">"must" clause</a> based on a previously-built {@link SearchPredicate}.
+	 *
+	 * @param searchPredicate The predicate that must match.
+	 * @return {@code this}, for method chaining.
+	 */
 	BooleanJunctionPredicateContext<N> must(SearchPredicate searchPredicate);
 
+	/**
+	 * Add a <a href="#mustnot">"must not" clause</a> based on a previously-built {@link SearchPredicate}.
+	 *
+	 * @param searchPredicate The predicate that must not match.
+	 * @return {@code this}, for method chaining.
+	 */
 	BooleanJunctionPredicateContext<N> mustNot(SearchPredicate searchPredicate);
 
+	/**
+	 * Add a <a href="#should">"should" clause</a> based on a previously-built {@link SearchPredicate}.
+	 *
+	 * @param searchPredicate The predicate that should match.
+	 * @return {@code this}, for method chaining.
+	 */
 	BooleanJunctionPredicateContext<N> should(SearchPredicate searchPredicate);
 
+	/**
+	 * Add a <a href="#filter">"filter" clause</a> based on a previously-built {@link SearchPredicate}.
+	 *
+	 * @param searchPredicate The predicate that must match.
+	 * @return {@code this}, for method chaining.
+	 */
 	BooleanJunctionPredicateContext<N> filter(SearchPredicate searchPredicate);
 
 	/*
 	 * Fully fluid syntax.
 	 */
 
+	/**
+	 * Create a context allowing to define a <a href="#must">"must" clause</a>.
+	 *
+	 * @return A {@link SearchPredicateContainerContext} allowing to define the predicate of the "must" clause.
+	 */
 	SearchPredicateContainerContext<? extends BooleanJunctionPredicateContext<N>> must();
 
+	/**
+	 * Create a context allowing to define a <a href="#mustnot">"must not" clause</a>.
+	 *
+	 * @return A {@link SearchPredicateContainerContext} allowing to define the predicate of the "must not" clause.
+	 */
 	SearchPredicateContainerContext<? extends BooleanJunctionPredicateContext<N>> mustNot();
 
+	/**
+	 * Create a context allowing to define a <a href="#should">"should" clause</a>.
+	 *
+	 * @return A {@link SearchPredicateContainerContext} allowing to define the predicate of the "should" clause.
+	 */
 	SearchPredicateContainerContext<? extends BooleanJunctionPredicateContext<N>> should();
 
+	/**
+	 * Create a context allowing to define a <a href="#filter">"filter" clause</a>.
+	 *
+	 * @return A {@link SearchPredicateContainerContext} allowing to define the predicate of the "filter" clause.
+	 */
 	SearchPredicateContainerContext<? extends BooleanJunctionPredicateContext<N>> filter();
 
 	/*
@@ -43,12 +129,52 @@ public interface BooleanJunctionPredicateContext<N> extends SearchPredicateConte
 	 * allowing to introduce if/else statements in the query building code.
 	 */
 
+	/**
+	 * Create a context allowing to define a <a href="#must">"must" clause</a>,
+	 * and apply a consumer to it.
+	 * <p>
+	 * Best used with lambda expressions.
+	 *
+	 * @param clauseContributor A consumer that will add clauses to the context passed in parameter.
+	 * Should generally be a lambda expression.
+	 * @return {@code this}, for method chaining.
+	 */
 	BooleanJunctionPredicateContext<N> must(Consumer<? super SearchPredicateContainerContext<?>> clauseContributor);
 
+	/**
+	 * Create a context allowing to define a <a href="#mustnot">"must not" clause</a>,
+	 * and apply a consumer to it.
+	 * <p>
+	 * Best used with lambda expressions.
+	 *
+	 * @param clauseContributor A consumer that will add clauses to the context passed in parameter.
+	 * Should generally be a lambda expression.
+	 * @return {@code this}, for method chaining.
+	 */
 	BooleanJunctionPredicateContext<N> mustNot(Consumer<? super SearchPredicateContainerContext<?>> clauseContributor);
 
+	/**
+	 * Create a context allowing to define a <a href="#should">"should" clause</a>,
+	 * and apply a consumer to it.
+	 * <p>
+	 * Best used with lambda expressions.
+	 *
+	 * @param clauseContributor A consumer that will add clauses to the context passed in parameter.
+	 * Should generally be a lambda expression.
+	 * @return {@code this}, for method chaining.
+	 */
 	BooleanJunctionPredicateContext<N> should(Consumer<? super SearchPredicateContainerContext<?>> clauseContributor);
 
+	/**
+	 * Create a context allowing to define a <a href="#filter">"filter" clause</a>,
+	 * and apply a consumer to it.
+	 * <p>
+	 * Best used with lambda expressions.
+	 *
+	 * @param clauseContributor A consumer that will add clauses to the context passed in parameter.
+	 * Should generally be a lambda expression.
+	 * @return {@code this}, for method chaining.
+	 */
 	BooleanJunctionPredicateContext<N> filter(Consumer<? super SearchPredicateContainerContext<?>> clauseContributor);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/BooleanJunctionPredicateContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/BooleanJunctionPredicateContext.java
@@ -75,29 +75,29 @@ import org.hibernate.search.v6poc.search.dsl.ExplicitEndContext;
  *
  * <h4 id="minimumshouldmatch-minimum">Definition of the minimum</h4>
  * <p>
- * The minimum may be defined either directly as a positive integer, or indirectly as a negative integer
- * or positive or negative double representing a ratio of the total number of "should" clauses in this boolean predicate.
+ * The minimum may be defined either directly as a positive number, or indirectly as a negative number
+ * or positive or negative percentage representing a ratio of the total number of "should" clauses in this boolean predicate.
  * <p>
  * Here is how each type of input is interpreted:
  * <dl>
- *     <dt>Positive integer</dt>
+ *     <dt>Positive number</dt>
  *     <dd>
  *         The value is interpreted directly as the minimum number of "should" clauses that have to match.
  *     </dd>
- *     <dt>Negative integer</dt>
+ *     <dt>Negative number</dt>
  *     <dd>
  *         The absolute value is interpreted as the maximum number of "should" clauses that may not match:
  *         the absolute value is subtracted from the total number of "should" clauses.
  *     </dd>
- *     <dt>Positive ratio</dt>
+ *     <dt>Positive percentage</dt>
  *     <dd>
- *         The value is interpreted as the minimum ratio of the total number of "should" clauses that have to match:
- *         the value is multiplied by the total number of "should" clauses, then rounded down.
+ *         The value is interpreted as the minimum percentage of the total number of "should" clauses that have to match:
+ *         the percentage is applied to the total number of "should" clauses, then rounded down.
  *     </dd>
- *     <dt>Negative ratio</dt>
+ *     <dt>Negative percentage</dt>
  *     <dd>
- *         The absolute value is interpreted as the maximum ratio of the total number of "should" clauses that may not match:
- *         the absolute value is multiplied by the total number of "should" clauses, then rounded down,
+ *         The absolute value is interpreted as the maximum percentage of the total number of "should" clauses that may not match:
+ *         the absolute value of the percentage is applied to the total number of "should" clauses, then rounded down,
  *         then subtracted from the total number of "should" clauses.
  *     </dd>
  * </dl>
@@ -127,16 +127,16 @@ import org.hibernate.search.v6poc.search.dsl.ExplicitEndContext;
  *     // Example 2: at most 2 "should" clauses may not match
  *     booleanContext2.minimumShouldMatchNumber( -2 );
  *     // Example 3: at least 75% of "should" clauses have to match (rounded down)
- *     booleanContext3.minimumShouldMatchRatio( 0.75 );
+ *     booleanContext3.minimumShouldMatchPercent( 75 );
  *     // Example 4: at most 25% of "should" clauses may not match (rounded down)
- *     booleanContext4.minimumShouldMatchRatio( -0.25 );
+ *     booleanContext4.minimumShouldMatchPercent( -25 );
  *     // Example 5: if there are 3 "should" clauses or less, all "should" clauses have to match.
  *     // If there are 4 "should" clauses or more, at least 90% of "should" clauses have to match (rounded down).
- *     booleanContext5.minimumShouldMatchRatio( 3, 0.9 );
+ *     booleanContext5.minimumShouldMatchPercent( 3, 90 );
  *     // Example 6: if there are 4 "should" clauses or less, all "should" clauses have to match.
  *     // If there are 5 to 9 "should" clauses, at most 25% of "should" clauses may not match (rounded down).
  *     // If there are 10 "should" clauses or more, at most 3 "should" clauses may not match.
- *     booleanContext6.minimumShouldMatchRatio( 4, -0.25 )
+ *     booleanContext6.minimumShouldMatchPercent( 4, 25 )
  *             .minimumShouldMatchNumber( 9, -3 );
  * </code></pre>
  *
@@ -280,13 +280,13 @@ public interface BooleanJunctionPredicateContext<N> extends SearchPredicateConte
 	/**
 	 * Add a default <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
 	 *
-	 * @param matchingClausesRatio A definition of the number of "should" clauses that have to match, as a ratio.
-	 * If positive, it is the ratio of the total number of "should" clauses that have to match.
+	 * @param matchingClausesPercent A definition of the number of "should" clauses that have to match, as a percentage.
+	 * If positive, it is the percentage of the total number of "should" clauses that have to match.
 	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
 	 * @return {@code this}, for method chaining.
 	 */
-	default BooleanJunctionPredicateContext<N> minimumShouldMatchRatio(double matchingClausesRatio) {
-		return minimumShouldMatchRatio( 0, matchingClausesRatio );
+	default BooleanJunctionPredicateContext<N> minimumShouldMatchPercent(int matchingClausesPercent) {
+		return minimumShouldMatchPercent( 0, matchingClausesPercent );
 	}
 
 	/**
@@ -311,14 +311,12 @@ public interface BooleanJunctionPredicateContext<N> extends SearchPredicateConte
 	 * <p>
 	 * See <a href="#minimumshouldmatch-conditionalconstraints">Conditional constraints</a> for the detailed rules
 	 * defining whether a constraint is applied or not.
-	 *
 	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
 	 * will cease to be ignored.
-	 * @param matchingClausesRatio A definition of the number of "should" clauses that have to match, as a ratio.
-	 * If positive, it is the ratio of the total number of "should" clauses that have to match.
-	 * See <a href="#minimumshouldmatch-minimum">Definition of the minimum</a> for details and possible values.
+	 * @param matchingClausesPercent A definition of the number of "should" clauses that have to match, as a percentage.
+	 * If positive, it is the percentage of the total number of "should" clauses that have to match.
 	 * @return {@code this}, for method chaining.
 	 */
-	BooleanJunctionPredicateContext<N> minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio);
+	BooleanJunctionPredicateContext<N> minimumShouldMatchPercent(int ignoreConstraintCeiling, int matchingClausesPercent);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/MinimumShouldMatchConditionContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/MinimumShouldMatchConditionContext.java
@@ -1,0 +1,41 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.search.dsl.predicate;
+
+/**
+ * The context used when defining a "minimum should match" constraint,
+ * after a {@link MinimumShouldMatchContext condition was defined}.
+ * <p>
+ * See <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraints</a>.
+ *
+ * @param <N> The type of the next context (returned by {@link MinimumShouldMatchNonEmptyContext#end()}).
+ */
+public interface MinimumShouldMatchConditionContext<N> {
+
+	/**
+	 * Add a <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
+	 *
+	 * @param matchingClausesNumber A definition of the number of "should" clauses that have to match.
+	 * If positive, it is the number of clauses that have to match.
+	 * See <a href="MinimumShouldMatchContext.html#minimumshouldmatch-minimum">Definition of the minimum</a>
+	 * for details and possible values, in particular negative values.
+	 * @return A context allowing to add additional constraints.
+	 */
+	MinimumShouldMatchNonEmptyContext<N> thenRequireNumber(int matchingClausesNumber);
+
+	/**
+	 * Add a <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraint</a>.
+	 *
+	 * @param matchingClausesPercent A definition of the number of "should" clauses that have to match, as a percentage.
+	 * If positive, it is the percentage of the total number of "should" clauses that have to match.
+	 * See <a href="MinimumShouldMatchContext.html#minimumshouldmatch-minimum">Definition of the minimum</a>
+	 * for details and possible values, in particular negative values.
+	 * @return A context allowing to add additional constraints.
+	 */
+	MinimumShouldMatchNonEmptyContext<N> thenRequirePercent(int matchingClausesPercent);
+
+}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/MinimumShouldMatchContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/MinimumShouldMatchContext.java
@@ -1,0 +1,110 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.search.dsl.predicate;
+
+/**
+ * The context used when defining "minimum should match" constraints.
+ * <p>
+ * <h3 id="minimumshouldmatch">"minimumShouldMatch" constraints</h3>
+ * <p>
+ * "minimumShouldMatch" constraints define a minimum number of "should" clauses that have to match
+ * in order for the boolean predicate to match.
+ * <p>
+ * The feature is similar, and will work identically, to
+ * <a href="https://lucene.apache.org/solr/7_3_0/solr-core/org/apache/solr/util/doc-files/min-should-match.html">"Min Number Should Match"</a>
+ * in Solr or
+ * <a href="https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-minimum-should-match.html">{@code minimum_should_match}</a>
+ * in Elasticsearch.
+ *
+ * <h4 id="minimumshouldmatch-minimum">Definition of the minimum</h4>
+ * <p>
+ * The minimum may be defined either directly as a positive number, or indirectly as a negative number
+ * or positive or negative percentage representing a ratio of the total number of "should" clauses in this boolean predicate.
+ * <p>
+ * Here is how each type of input is interpreted:
+ * <dl>
+ *     <dt>Positive number</dt>
+ *     <dd>
+ *         The value is interpreted directly as the minimum number of "should" clauses that have to match.
+ *     </dd>
+ *     <dt>Negative number</dt>
+ *     <dd>
+ *         The absolute value is interpreted as the maximum number of "should" clauses that may not match:
+ *         the absolute value is subtracted from the total number of "should" clauses.
+ *     </dd>
+ *     <dt>Positive percentage</dt>
+ *     <dd>
+ *         The value is interpreted as the minimum percentage of the total number of "should" clauses that have to match:
+ *         the percentage is applied to the total number of "should" clauses, then rounded down.
+ *     </dd>
+ *     <dt>Negative percentage</dt>
+ *     <dd>
+ *         The absolute value is interpreted as the maximum percentage of the total number of "should" clauses that may not match:
+ *         the absolute value of the percentage is applied to the total number of "should" clauses, then rounded down,
+ *         then subtracted from the total number of "should" clauses.
+ *     </dd>
+ * </dl>
+ * <p>
+ * In any case, if the computed minimum is 0 or less, or higher than the total number of "should" clauses,
+ * behavior is backend-specific (it may throw an exception, or produce unpredictable results,
+ * or fall back to some default behavior).
+ *
+ * <h4 id="minimumshouldmatch-conditionalconstraints">Conditional constraints</h4>
+ * <p>
+ * Multiple conditional constraints may be defined,
+ * only one of them being applied depending on the total number of "should" clauses.
+ * <p>
+ * Each constraint is attributed a minimum number of "should" clauses
+ * that have to match, <strong>and an additional number</strong>.
+ * The additional number is unique to each constraint.
+ * <p>
+ * The additional number will be compared to the total number of "should" clauses,
+ * and the one closest while still strictly lower will be picked: its associated constraint will be applied.
+ * If no number matches, the minimum number of matching "should" clauses
+ * will be set to the total number of "should" clauses.
+ * <p>
+ * Examples:
+ * <pre><code>
+ *     // Example 1: at least 3 "should" clauses have to match
+ *     booleanContext1.minimumShouldMatchNumber( 3 );
+ *     // Example 2: at most 2 "should" clauses may not match
+ *     booleanContext2.minimumShouldMatchNumber( -2 );
+ *     // Example 3: at least 75% of "should" clauses have to match (rounded down)
+ *     booleanContext3.minimumShouldMatchPercent( 75 );
+ *     // Example 4: at most 25% of "should" clauses may not match (rounded down)
+ *     booleanContext4.minimumShouldMatchPercent( -25 );
+ *     // Example 5: if there are 3 "should" clauses or less, all "should" clauses have to match.
+ *     // If there are 4 "should" clauses or more, at least 90% of "should" clauses have to match (rounded down).
+ *     booleanContext5.minimumShouldMatchPercent( 3, 90 );
+ *     // Example 6: if there are 4 "should" clauses or less, all "should" clauses have to match.
+ *     // If there are 5 to 9 "should" clauses, at most 25% of "should" clauses may not match (rounded down).
+ *     // If there are 10 "should" clauses or more, at most 3 "should" clauses may not match.
+ *     booleanContext6.minimumShouldMatch()
+ *             .ifMoreThan( 4 ).thenRequirePercent( 25 )
+ *             .ifMoreThan( 9 ).thenRequireNumber( -3 )
+ *             .end();
+ * </code></pre>
+ *
+ * @param <N> The type of the next context (returned by {@link MinimumShouldMatchNonEmptyContext#end()}).
+ */
+public interface MinimumShouldMatchContext<N> {
+
+	/**
+	 * Start adding a <a href="#minimumshouldmatch">"minimumShouldMatch" constraint</a> that will be applied
+	 * if (and only if) there are strictly more than {@code ignoreConstraintCeiling} "should" clauses.
+	 * <p>
+	 * See <a href="#minimumshouldmatch-conditionalconstraints">Conditional constraints</a> for the detailed rules
+	 * defining whether a constraint is applied or not.
+	 *
+	 * @param ignoreConstraintCeiling The number of "should" clauses above which the constraint
+	 * will cease to be ignored.
+	 * @return A context allowing to define the constraint to apply when there are strictly more
+	 * than {@code ignoreConstraintCeiling} "should" clauses.
+	 */
+	MinimumShouldMatchConditionContext<N> ifMoreThan(int ignoreConstraintCeiling);
+
+}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/MinimumShouldMatchNonEmptyContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/MinimumShouldMatchNonEmptyContext.java
@@ -1,0 +1,22 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.search.dsl.predicate;
+
+import org.hibernate.search.v6poc.search.dsl.ExplicitEndContext;
+
+/**
+ * The context used when at least one "minimum should match" constraint was defined,
+ * allowing to {@link #ifMoreThan(int) define more constraints}
+ * or to {@link #end() end} the definition and get back to the parent context.
+ * <p>
+ * See <a href="MinimumShouldMatchContext.html#minimumshouldmatch">"minimumShouldMatch" constraints</a>.
+ *
+ * @param <N> The type of the next context (returned by {@link MinimumShouldMatchNonEmptyContext#end()}).
+ */
+public interface MinimumShouldMatchNonEmptyContext<N> extends MinimumShouldMatchContext<N>, ExplicitEndContext<N> {
+
+}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
@@ -125,10 +125,10 @@ class BooleanJunctionPredicateContextImpl<N, C>
 	}
 
 	@Override
-	public BooleanJunctionPredicateContext<N> minimumShouldMatchRatio(int ignoreConstraintCeiling,
-			double matchingClausesRatio) {
+	public BooleanJunctionPredicateContext<N> minimumShouldMatchPercent(int ignoreConstraintCeiling,
+			int matchingClausesPercent) {
 		Contracts.assertPositiveOrZero( ignoreConstraintCeiling, "ignoreConstraintCeiling" );
-		builder.minimumShouldMatchRatio( ignoreConstraintCeiling, matchingClausesRatio );
+		builder.minimumShouldMatchPercent( ignoreConstraintCeiling, matchingClausesPercent );
 		return this;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
@@ -13,12 +13,12 @@ import java.util.function.Supplier;
 
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext;
+import org.hibernate.search.v6poc.search.dsl.predicate.MinimumShouldMatchContext;
 import org.hibernate.search.v6poc.search.dsl.predicate.SearchPredicateContainerContext;
 import org.hibernate.search.v6poc.search.dsl.predicate.spi.SearchPredicateDslContext;
 import org.hibernate.search.v6poc.search.predicate.spi.BooleanJunctionPredicateBuilder;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateContributor;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateFactory;
-import org.hibernate.search.v6poc.util.impl.common.Contracts;
 
 
 class BooleanJunctionPredicateContextImpl<N, C>
@@ -29,6 +29,8 @@ class BooleanJunctionPredicateContextImpl<N, C>
 	private final Supplier<N> nextContextProvider;
 
 	private final BooleanJunctionPredicateBuilder<C> builder;
+
+	private final MinimumShouldMatchContextImpl<BooleanJunctionPredicateContext<N>> minimumShouldMatchContext;
 
 	private final OccurContext must;
 	private final OccurContext mustNot;
@@ -44,6 +46,7 @@ class BooleanJunctionPredicateContextImpl<N, C>
 		this.mustNot = new OccurContext();
 		this.should = new OccurContext();
 		this.filter = new OccurContext();
+		this.minimumShouldMatchContext = new MinimumShouldMatchContextImpl<>( builder, this );
 	}
 
 	@Override
@@ -117,18 +120,14 @@ class BooleanJunctionPredicateContextImpl<N, C>
 	}
 
 	@Override
-	public BooleanJunctionPredicateContext<N> minimumShouldMatchNumber(int ignoreConstraintCeiling,
-			int matchingClausesNumber) {
-		Contracts.assertPositiveOrZero( ignoreConstraintCeiling, "ignoreConstraintCeiling" );
-		builder.minimumShouldMatchNumber( ignoreConstraintCeiling, matchingClausesNumber );
-		return this;
+	public MinimumShouldMatchContext<? extends BooleanJunctionPredicateContext<N>> minimumShouldMatch() {
+		return minimumShouldMatchContext;
 	}
 
 	@Override
-	public BooleanJunctionPredicateContext<N> minimumShouldMatchPercent(int ignoreConstraintCeiling,
-			int matchingClausesPercent) {
-		Contracts.assertPositiveOrZero( ignoreConstraintCeiling, "ignoreConstraintCeiling" );
-		builder.minimumShouldMatchPercent( ignoreConstraintCeiling, matchingClausesPercent );
+	public BooleanJunctionPredicateContext<N> minimumShouldMatch(
+			Consumer<? super MinimumShouldMatchContext<?>> constraintContributor) {
+		constraintContributor.accept( minimumShouldMatchContext );
 		return this;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
@@ -18,6 +18,7 @@ import org.hibernate.search.v6poc.search.dsl.predicate.spi.SearchPredicateDslCon
 import org.hibernate.search.v6poc.search.predicate.spi.BooleanJunctionPredicateBuilder;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateContributor;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateFactory;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
 
 
 class BooleanJunctionPredicateContextImpl<N, C>
@@ -112,6 +113,22 @@ class BooleanJunctionPredicateContextImpl<N, C>
 	@Override
 	public BooleanJunctionPredicateContext<N> filter(Consumer<? super SearchPredicateContainerContext<?>> clauseContributor) {
 		clauseContributor.accept( filter() );
+		return this;
+	}
+
+	@Override
+	public BooleanJunctionPredicateContext<N> minimumShouldMatchNumber(int ignoreConstraintCeiling,
+			int matchingClausesNumber) {
+		Contracts.assertPositiveOrZero( ignoreConstraintCeiling, "ignoreConstraintCeiling" );
+		builder.minimumShouldMatchNumber( ignoreConstraintCeiling, matchingClausesNumber );
+		return this;
+	}
+
+	@Override
+	public BooleanJunctionPredicateContext<N> minimumShouldMatchRatio(int ignoreConstraintCeiling,
+			double matchingClausesRatio) {
+		Contracts.assertPositiveOrZero( ignoreConstraintCeiling, "ignoreConstraintCeiling" );
+		builder.minimumShouldMatchRatio( ignoreConstraintCeiling, matchingClausesRatio );
 		return this;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/MinimumShouldMatchContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/MinimumShouldMatchContextImpl.java
@@ -1,0 +1,51 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.search.dsl.predicate.impl;
+
+import org.hibernate.search.v6poc.search.dsl.predicate.MinimumShouldMatchConditionContext;
+import org.hibernate.search.v6poc.search.dsl.predicate.MinimumShouldMatchContext;
+import org.hibernate.search.v6poc.search.dsl.predicate.MinimumShouldMatchNonEmptyContext;
+import org.hibernate.search.v6poc.search.predicate.spi.BooleanJunctionPredicateBuilder;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
+
+final class MinimumShouldMatchContextImpl<N> implements MinimumShouldMatchContext<N>,
+		MinimumShouldMatchConditionContext<N>, MinimumShouldMatchNonEmptyContext<N> {
+
+	private final BooleanJunctionPredicateBuilder<?> builder;
+	private final N nextContext;
+	private int ignoreConstraintCeiling = 0;
+
+	MinimumShouldMatchContextImpl(BooleanJunctionPredicateBuilder<?> builder, N nextContext) {
+		this.builder = builder;
+		this.nextContext = nextContext;
+	}
+
+	@Override
+	public MinimumShouldMatchConditionContext<N> ifMoreThan(int ignoreConstraintCeiling) {
+		Contracts.assertPositiveOrZero( ignoreConstraintCeiling, "ignoreConstraintCeiling" );
+		this.ignoreConstraintCeiling = ignoreConstraintCeiling;
+		return this;
+	}
+
+	@Override
+	public MinimumShouldMatchNonEmptyContext<N> thenRequireNumber(int matchingClausesNumber) {
+		builder.minimumShouldMatchNumber( ignoreConstraintCeiling, matchingClausesNumber );
+		return this;
+	}
+
+	@Override
+	public MinimumShouldMatchNonEmptyContext<N> thenRequirePercent(int matchingClausesPercent) {
+		builder.minimumShouldMatchPercent( ignoreConstraintCeiling, matchingClausesPercent );
+		return this;
+	}
+
+	@Override
+	public N end() {
+		return nextContext;
+	}
+
+}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/predicate/spi/BooleanJunctionPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/predicate/spi/BooleanJunctionPredicateBuilder.java
@@ -26,12 +26,12 @@ public interface BooleanJunctionPredicateBuilder<C> extends SearchPredicateBuild
 	void minimumShouldMatchNumber(int ignoreConstraintCeiling, int matchingClausesNumber);
 
 	/**
-	 * See {@link org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext#minimumShouldMatchNumber(int, int)}.
+	 * See {@link org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext#minimumShouldMatchPercent(int, int)}.
 	 *
 	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
 	 * will cease to be ignored.
-	 * @param matchingClausesRatio A definition of the number of "should" clauses that have to match, as a ratio.
+	 * @param matchingClausesPercent A definition of the number of "should" clauses that have to match, as a percentage.
 	 */
-	void minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio);
+	void minimumShouldMatchPercent(int ignoreConstraintCeiling, int matchingClausesPercent);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/predicate/spi/BooleanJunctionPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/predicate/spi/BooleanJunctionPredicateBuilder.java
@@ -16,4 +16,22 @@ public interface BooleanJunctionPredicateBuilder<C> extends SearchPredicateBuild
 
 	C getFilterCollector();
 
+	/**
+	 * See {@link org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext#minimumShouldMatchNumber(int, int)}.
+	 *
+	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
+	 * will cease to be ignored.
+	 * @param matchingClausesNumber A definition of the number of "should" clauses that have to match.
+	 */
+	void minimumShouldMatchNumber(int ignoreConstraintCeiling, int matchingClausesNumber);
+
+	/**
+	 * See {@link org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext#minimumShouldMatchNumber(int, int)}.
+	 *
+	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
+	 * will cease to be ignored.
+	 * @param matchingClausesRatio A definition of the number of "should" clauses that have to match, as a ratio.
+	 */
+	void minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio);
+
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/predicate/spi/BooleanJunctionPredicateBuilder.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/predicate/spi/BooleanJunctionPredicateBuilder.java
@@ -17,7 +17,7 @@ public interface BooleanJunctionPredicateBuilder<C> extends SearchPredicateBuild
 	C getFilterCollector();
 
 	/**
-	 * See {@link org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext#minimumShouldMatchNumber(int, int)}.
+	 * See {@link org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext#minimumShouldMatch()}.
 	 *
 	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
 	 * will cease to be ignored.
@@ -26,7 +26,7 @@ public interface BooleanJunctionPredicateBuilder<C> extends SearchPredicateBuild
 	void minimumShouldMatchNumber(int ignoreConstraintCeiling, int matchingClausesNumber);
 
 	/**
-	 * See {@link org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext#minimumShouldMatchPercent(int, int)}.
+	 * See {@link org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext#minimumShouldMatch()}.
 	 *
 	 * @param ignoreConstraintCeiling The maximum number of "should" clauses above which this constraint
 	 * will cease to be ignored.

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -9,6 +9,8 @@ package org.hibernate.search.v6poc.integrationtest.backend.tck.search.predicate;
 import static org.hibernate.search.v6poc.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert.assertThat;
 import static org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
 
+import java.util.function.Consumer;
+
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
 import org.hibernate.search.v6poc.backend.document.IndexFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaElement;
@@ -20,8 +22,12 @@ import org.hibernate.search.v6poc.integrationtest.backend.tck.util.rule.SearchSe
 import org.hibernate.search.v6poc.search.DocumentReference;
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.SearchQuery;
+import org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext;
+import org.hibernate.search.v6poc.util.SearchException;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.StubSessionContext;
+import org.hibernate.search.v6poc.util.impl.test.SubTest;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,18 +43,24 @@ public class BoolSearchPredicateIT {
 	private static final String FIELD1_VALUE1 = "Irving";
 	private static final Integer FIELD2_VALUE1 = 3;
 	private static final Integer FIELD3_VALUE1 = 4;
+	private static final Integer FIELD4_VALUE1AND2 = 1_000;
+	private static final Integer FIELD5_VALUE1AND2 = 2_000;
 
 	// Document 2
 
 	private static final String FIELD1_VALUE2 = "Auster";
 	private static final Integer FIELD2_VALUE2 = 13;
 	private static final Integer FIELD3_VALUE2 = 14;
+	// Field 4: Same as document 1
+	// Field 5: Same as document 1
 
 	// Document 3
 
 	private static final String FIELD1_VALUE3 = "Coe";
 	private static final Integer FIELD2_VALUE3 = 25;
 	private static final Integer FIELD3_VALUE3 = 42;
+	private static final Integer FIELD4_VALUE3 = 42_000; // Different from document 1
+	private static final Integer FIELD5_VALUE3 = 142_000; // Different from document 1
 
 	@Rule
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
@@ -442,22 +454,440 @@ public class BoolSearchPredicateIT {
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
 	}
 
+	@Test
+	public void minimumShouldMatchNumber_positive() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		// Expect default behavior (1 "should" clause has to match)
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchNumber( 1 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+
+		// Expect to require 1 "should" clause to match even though there's a "must"
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.must().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.minimumShouldMatchNumber( 1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+
+		// Expect to require 2 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchNumber( 2 )
+						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// Expect to require all "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchNumber( 2 )
+						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatchNumber_negative() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		// Expect default behavior (1 "should" clause has to match)
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchNumber( -1 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+
+		// Expect to require 1 "should" clause to match even though there's a "must"
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.must().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.minimumShouldMatchNumber( -1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+
+		// Expect to require 2 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchNumber( -1 )
+						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatchRatio_positive() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		// Expect default behavior (1 "should" clause has to match)
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchRatio( 0.5 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+
+		// Expect to require 1 "should" clause to match even though there's a "must"
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.must().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.minimumShouldMatchRatio( 0.5 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+
+		// Expect to require 2 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchRatio( 0.7 ) // The minimum should be rounded down to 2
+						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// Expect to require all "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchRatio( 1.0 )
+						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatchRatio_negative() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		// Expect default behavior (1 "should" clause has to match)
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchRatio( -0.5 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+
+		// Expect to require 1 "should" clause to match even though there's a "must"
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.must().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.minimumShouldMatchRatio( -0.5 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+
+		// Expect to require 2 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.minimumShouldMatchRatio( -0.4 ) // The minimum should be rounded up to 2
+						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatch_multipleConstraints() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		Consumer<BooleanJunctionPredicateContext<?>> minimumShouldMatchConstraints = b -> {
+			b.minimumShouldMatchNumber( 2, -1 );
+			b.minimumShouldMatchRatio( 4, 0.7 );
+		};
+
+		// 0 "should" clause: expect the constraints to be ignored
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.must().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+
+		// 1 "should" clause: expect to require all "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// 2 "should" clauses: expect to require all "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// 3 "should" clauses: expect to require 2 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE3 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// 4 "should" clauses: expect to require 3 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE2 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// 5 "should" clauses: expect to require 3 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE2 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE3 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// 6 "should" clauses: expect to require 4 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
+					b.should().match().onField( "field5" ).matching( FIELD5_VALUE1AND2 );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE2 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE3 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+	}
+
+	@Test
+	public void minimumShouldMatch_multipleConstraints_0ceiling() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		Consumer<BooleanJunctionPredicateContext<?>> minimumShouldMatchConstraints = b -> {
+			// Test that we can set the "default" minimum by using a ceiling of 0
+			b.minimumShouldMatchNumber( 0, 1 );
+			b.minimumShouldMatchNumber( 2, -1 );
+			b.minimumShouldMatchRatio( 4, 0.7 );
+		};
+
+		// 1 "should" clause: expect to require 1 "should" clause to match
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// 2 "should" clauses: expect to require 1 "should" clause to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE2 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+
+		// 3 "should" clauses: expect to require 2 "should" clauses to match
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool( b -> {
+					minimumShouldMatchConstraints.accept( b );
+					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
+					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+					b.should().match().onField( "field2" ).matching( FIELD2_VALUE3 );
+				} )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// The rest should behave exactly as in the other multiple-constraints test
+	}
+
+	@Test
+	public void minimumShouldMatch_error_negativeCeiling() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		SubTest.expectException(
+				"minimumShouldMatch constraint with negative ignoreConstraintCeiling",
+				() -> searchTarget.predicate().bool().minimumShouldMatchNumber( -1, 1 )
+		)
+				.assertThrown()
+				.isInstanceOf( IllegalArgumentException.class )
+				.hasMessageContaining( "'ignoreConstraintCeiling'" )
+				.hasMessageContaining( "must be positive or zero" );
+
+		SubTest.expectException(
+				"minimumShouldMatch constraint with negative ignoreConstraintCeiling",
+				() -> searchTarget.predicate().bool().minimumShouldMatchRatio( -1, 0.5 )
+		)
+				.assertThrown()
+				.isInstanceOf( IllegalArgumentException.class )
+				.hasMessageContaining( "'ignoreConstraintCeiling'" )
+				.hasMessageContaining( "must be positive or zero" );
+	}
+
+	@Test
+	public void minimumShouldMatch_error_multipleConflictingCeilings() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		SubTest.expectException(
+				"bool() predicate with minimumShouldMatch constraints with multiple conflicting ceilings",
+				() -> searchTarget.predicate().bool()
+						.minimumShouldMatchNumber( 2, -1 )
+						.minimumShouldMatchRatio( 4, 0.7 )
+						.minimumShouldMatchRatio( 4, 0.7 )
+		)
+				.assertThrown()
+				.isInstanceOf( SearchException.class )
+				.hasMessageContaining( "Multiple conflicting minimumShouldMatch constraints for ceiling" )
+				.hasMessageContaining( "'4'" );
+	}
+
 	private void initData() {
 		ChangesetIndexWorker<? extends DocumentElement> worker = indexManager.createWorker( sessionContext );
 		worker.add( referenceProvider( DOCUMENT_1 ), document -> {
 			indexAccessors.field1.write( document, FIELD1_VALUE1 );
 			indexAccessors.field2.write( document, FIELD2_VALUE1 );
 			indexAccessors.field3.write( document, FIELD3_VALUE1 );
+			indexAccessors.field4.write( document, FIELD4_VALUE1AND2 );
+			indexAccessors.field5.write( document, FIELD5_VALUE1AND2 );
 		} );
 		worker.add( referenceProvider( DOCUMENT_2 ), document -> {
 			indexAccessors.field1.write( document, FIELD1_VALUE2 );
 			indexAccessors.field2.write( document, FIELD2_VALUE2 );
 			indexAccessors.field3.write( document, FIELD3_VALUE2 );
+			indexAccessors.field4.write( document, FIELD4_VALUE1AND2 );
+			indexAccessors.field5.write( document, FIELD5_VALUE1AND2 );
 		} );
 		worker.add( referenceProvider( DOCUMENT_3 ), document -> {
 			indexAccessors.field1.write( document, FIELD1_VALUE3 );
 			indexAccessors.field2.write( document, FIELD2_VALUE3 );
 			indexAccessors.field3.write( document, FIELD3_VALUE3 );
+			indexAccessors.field4.write( document, FIELD4_VALUE3 );
+			indexAccessors.field5.write( document, FIELD5_VALUE3 );
 		} );
 
 		worker.execute().join();
@@ -475,11 +905,15 @@ public class BoolSearchPredicateIT {
 		final IndexFieldAccessor<String> field1;
 		final IndexFieldAccessor<Integer> field2;
 		final IndexFieldAccessor<Integer> field3;
+		final IndexFieldAccessor<Integer> field4;
+		final IndexFieldAccessor<Integer> field5;
 
 		IndexAccessors(IndexSchemaElement root) {
 			field1 = root.field( "field1" ).asString().createAccessor();
 			field2 = root.field( "field2" ).asInteger().createAccessor();
 			field3 = root.field( "field3" ).asInteger().createAccessor();
+			field4 = root.field( "field4" ).asInteger().createAccessor();
+			field5 = root.field( "field5" ).asInteger().createAccessor();
 		}
 	}
 }

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -22,7 +22,7 @@ import org.hibernate.search.v6poc.integrationtest.backend.tck.util.rule.SearchSe
 import org.hibernate.search.v6poc.search.DocumentReference;
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.SearchQuery;
-import org.hibernate.search.v6poc.search.dsl.predicate.BooleanJunctionPredicateContext;
+import org.hibernate.search.v6poc.search.dsl.predicate.MinimumShouldMatchContext;
 import org.hibernate.search.v6poc.util.SearchException;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.StubSessionContext;
@@ -668,16 +668,15 @@ public class BoolSearchPredicateIT {
 	public void minimumShouldMatch_multipleConstraints() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		Consumer<BooleanJunctionPredicateContext<?>> minimumShouldMatchConstraints = b -> {
-			b.minimumShouldMatchNumber( 2, -1 );
-			b.minimumShouldMatchPercent( 4, 70 );
-		};
+		Consumer<MinimumShouldMatchContext<?>> minimumShouldMatchConstraints = b -> b
+				.ifMoreThan( 2 ).thenRequireNumber( -1 )
+				.ifMoreThan( 4 ).thenRequirePercent( 70 );
 
 		// 0 "should" clause: expect the constraints to be ignored
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.must().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
 				} )
 				.build();
@@ -689,7 +688,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 				} )
 				.build();
@@ -701,7 +700,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 				} )
@@ -714,7 +713,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 					b.should().match().onField( "field2" ).matching( FIELD2_VALUE3 );
@@ -728,7 +727,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 					b.should().match().onField( "field2" ).matching( FIELD2_VALUE1 );
@@ -743,7 +742,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 					b.should().match().onField( "field2" ).matching( FIELD2_VALUE1 );
@@ -759,7 +758,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
 					b.should().match().onField( "field5" ).matching( FIELD5_VALUE1AND2 );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
@@ -777,18 +776,17 @@ public class BoolSearchPredicateIT {
 	public void minimumShouldMatch_multipleConstraints_0ceiling() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		Consumer<BooleanJunctionPredicateContext<?>> minimumShouldMatchConstraints = b -> {
-			// Test that we can set the "default" minimum by using a ceiling of 0
-			b.minimumShouldMatchNumber( 0, 1 );
-			b.minimumShouldMatchNumber( 2, -1 );
-			b.minimumShouldMatchPercent( 4, 70 );
-		};
+		Consumer<MinimumShouldMatchContext<?>> minimumShouldMatchConstraints = b -> b
+				// Test that we can set the "default" minimum by using a ceiling of 0
+				.ifMoreThan( 0 ).thenRequireNumber( 1 )
+				.ifMoreThan( 2 ).thenRequireNumber( -1 )
+				.ifMoreThan( 4 ).thenRequirePercent( 70 );
 
 		// 1 "should" clause: expect to require 1 "should" clause to match
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 				} )
 				.build();
@@ -800,7 +798,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 					b.should().match().onField( "field2" ).matching( FIELD2_VALUE2 );
 				} )
@@ -813,7 +811,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool( b -> {
-					minimumShouldMatchConstraints.accept( b );
+					b.minimumShouldMatch( minimumShouldMatchConstraints );
 					b.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 );
 					b.should().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 					b.should().match().onField( "field2" ).matching( FIELD2_VALUE3 );
@@ -832,7 +830,8 @@ public class BoolSearchPredicateIT {
 
 		SubTest.expectException(
 				"minimumShouldMatch constraint with negative ignoreConstraintCeiling",
-				() -> searchTarget.predicate().bool().minimumShouldMatchNumber( -1, 1 )
+				() -> searchTarget.predicate().bool().minimumShouldMatch()
+						.ifMoreThan( -1 ).thenRequireNumber( 1 )
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
@@ -841,7 +840,8 @@ public class BoolSearchPredicateIT {
 
 		SubTest.expectException(
 				"minimumShouldMatch constraint with negative ignoreConstraintCeiling",
-				() -> searchTarget.predicate().bool().minimumShouldMatchPercent( -1, 50 )
+				() -> searchTarget.predicate().bool().minimumShouldMatch()
+						.ifMoreThan( -1 ).thenRequirePercent( 50 )
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
@@ -855,10 +855,10 @@ public class BoolSearchPredicateIT {
 
 		SubTest.expectException(
 				"bool() predicate with minimumShouldMatch constraints with multiple conflicting ceilings",
-				() -> searchTarget.predicate().bool()
-						.minimumShouldMatchNumber( 2, -1 )
-						.minimumShouldMatchPercent( 4, 70 )
-						.minimumShouldMatchPercent( 4, 70 )
+				() -> searchTarget.predicate().bool().minimumShouldMatch()
+						.ifMoreThan( 2 ).thenRequireNumber( -1 )
+						.ifMoreThan( 4 ).thenRequirePercent( 70 )
+						.ifMoreThan( 4 ).thenRequirePercent( 70 )
 		)
 				.assertThrown()
 				.isInstanceOf( SearchException.class )

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -34,18 +34,21 @@ public class BoolSearchPredicateIT {
 
 	// Document 1
 
-	private static final String STRING_1 = "Irving";
-	private static final Integer INTEGER_1 = 3;
+	private static final String FIELD1_VALUE1 = "Irving";
+	private static final Integer FIELD2_VALUE1 = 3;
+	private static final Integer FIELD3_VALUE1 = 4;
 
 	// Document 2
 
-	private static final String STRING_2 = "Auster";
-	private static final Integer INTEGER_2 = 13;
+	private static final String FIELD1_VALUE2 = "Auster";
+	private static final Integer FIELD2_VALUE2 = 13;
+	private static final Integer FIELD3_VALUE2 = 14;
 
 	// Document 3
 
-	private static final String STRING_3 = "Coe";
-	private static final Integer INTEGER_3 = 25;
+	private static final String FIELD1_VALUE3 = "Coe";
+	private static final Integer FIELD2_VALUE3 = 25;
+	private static final Integer FIELD3_VALUE3 = 42;
 
 	@Rule
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
@@ -78,7 +81,7 @@ public class BoolSearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.must().match().onField( "string" ).matching( STRING_1 )
+						.must().match().onField( "field1" ).matching( FIELD1_VALUE1 )
 				.end()
 				.build();
 
@@ -88,8 +91,8 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.must().match().onField( "string" ).matching( STRING_1 )
-						.must().match().onField( "integer" ).matching( INTEGER_2 )
+						.must().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.must().match().onField( "field2" ).matching( FIELD2_VALUE2 )
 				.end()
 				.build();
 
@@ -98,8 +101,8 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.must().match().onField( "string" ).matching( STRING_1 )
-						.must().match().onField( "integer" ).matching( INTEGER_1 )
+						.must().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.must().match().onField( "field2" ).matching( FIELD2_VALUE1 )
 				.end()
 				.build();
 
@@ -114,7 +117,7 @@ public class BoolSearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.must( c -> c.match().onField( "string" ).matching( STRING_1 ) )
+						.must( c -> c.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				.end()
 				.build();
 
@@ -126,7 +129,7 @@ public class BoolSearchPredicateIT {
 	public void must_predicate() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		SearchPredicate predicate = searchTarget.predicate().match().onField( "string" ).matching( STRING_1 );
+		SearchPredicate predicate = searchTarget.predicate().match().onField( "field1" ).matching( FIELD1_VALUE1 );
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -146,7 +149,7 @@ public class BoolSearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.should().match().onField( "string" ).matching( STRING_1 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
 				.end()
 				.build();
 
@@ -156,8 +159,8 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.should().match().onField( "string" ).matching( STRING_1 )
-						.should().match().onField( "string" ).matching( STRING_2 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE2 )
 				.end()
 				.build();
 
@@ -172,8 +175,8 @@ public class BoolSearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.should( c -> c.match().onField( "string" ).matching( STRING_1 ) )
-						.should( c -> c.match().onField( "string" ).matching( STRING_2 ) )
+						.should( c -> c.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
+						.should( c -> c.match().onField( "field1" ).matching( FIELD1_VALUE2 ) )
 				.end()
 				.build();
 
@@ -185,8 +188,8 @@ public class BoolSearchPredicateIT {
 	public void should_predicate() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		SearchPredicate predicate1 = searchTarget.predicate().match().onField( "string" ).matching( STRING_1 );
-		SearchPredicate predicate2 = searchTarget.predicate().match().onField( "string" ).matching( STRING_3 );
+		SearchPredicate predicate1 = searchTarget.predicate().match().onField( "field1" ).matching( FIELD1_VALUE1 );
+		SearchPredicate predicate2 = searchTarget.predicate().match().onField( "field1" ).matching( FIELD1_VALUE3 );
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -207,7 +210,7 @@ public class BoolSearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.mustNot().match().onField( "string" ).matching( STRING_1 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE1 )
 				.end()
 				.build();
 
@@ -217,8 +220,8 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.mustNot().match().onField( "string" ).matching( STRING_1 )
-						.mustNot().match().onField( "string" ).matching( STRING_3 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE3 )
 				.end()
 				.build();
 
@@ -233,7 +236,7 @@ public class BoolSearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.mustNot( c -> c.match().onField( "string" ).matching( STRING_1 ) )
+						.mustNot( c -> c.match().onField( "field1" ).matching( FIELD1_VALUE1 ) )
 				.end()
 				.build();
 
@@ -245,7 +248,7 @@ public class BoolSearchPredicateIT {
 	public void mustNot_predicate() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		SearchPredicate predicate = searchTarget.predicate().match().onField( "string" ).matching( STRING_2 );
+		SearchPredicate predicate = searchTarget.predicate().match().onField( "field1" ).matching( FIELD1_VALUE2 );
 
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -265,9 +268,9 @@ public class BoolSearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.should().match().onField( "string" ).matching( STRING_1 )
-						.should().match().onField( "string" ).matching( STRING_3 )
-						.mustNot().match().onField( "string" ).matching( STRING_1 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field1" ).matching( FIELD1_VALUE3 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE1 )
 				.end()
 				.build();
 
@@ -282,8 +285,8 @@ public class BoolSearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.must().match().onField( "string" ).matching( STRING_1 )
-						.mustNot().match().onField( "string" ).matching( STRING_1 )
+						.must().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE1 )
 				.end()
 				.build();
 
@@ -292,8 +295,8 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.must().match().onField( "string" ).matching( STRING_1 )
-						.mustNot().match().onField( "string" ).matching( STRING_2 )
+						.must().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE2 )
 				.end()
 				.build();
 
@@ -310,8 +313,8 @@ public class BoolSearchPredicateIT {
 				.predicate().bool()
 						.must(
 								c -> c.bool()
-										.should().match().onField( "string" ).matching( STRING_1 )
-										.should().match().onField( "string" ).matching( STRING_3 )
+										.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+										.should().match().onField( "field1" ).matching( FIELD1_VALUE3 )
 						)
 				.end()
 				.build();
@@ -324,10 +327,10 @@ public class BoolSearchPredicateIT {
 				.predicate().bool()
 						.must(
 								c -> c.bool()
-										.should().match().onField( "string" ).matching( STRING_1 )
-										.should().match().onField( "string" ).matching( STRING_3 )
+										.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+										.should().match().onField( "field1" ).matching( FIELD1_VALUE3 )
 						)
-						.mustNot().match().onField( "string" ).matching( STRING_3 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE3 )
 				.end()
 				.build();
 
@@ -335,19 +338,126 @@ public class BoolSearchPredicateIT {
 				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
 	}
 
+	@Test
+	public void must_should() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		// A boolean predicate with must + should clauses:
+		// documents should match regardless of whether should clauses match.
+
+		// Non-matching "should" clauses
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.must().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// One matching and one non-matching "should" clause
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.must().match().onField( "field1" ).matching( FIELD1_VALUE2 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+	}
+
+	@Test
+	public void filter_should() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		// A boolean predicate with filter + should clauses:
+		// documents should match regardless of whether should clauses match.
+
+		// Non-matching "should" clauses
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.filter().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+
+		// One matching and one non-matching "should" clause
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.filter().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+	}
+
+	@Test
+	public void mustNot_should() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		// A boolean predicate with mustNot + should clauses:
+		// documents should match only if at least one should clause matches
+
+		// Non-matching "should" clauses
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE2 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE3 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasNoHits();
+
+		// One matching and one non-matching "should" clause
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate().bool()
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE1 )
+						.mustNot().match().onField( "field1" ).matching( FIELD1_VALUE3 )
+						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
+						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
+				.end()
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+	}
+
 	private void initData() {
 		ChangesetIndexWorker<? extends DocumentElement> worker = indexManager.createWorker( sessionContext );
 		worker.add( referenceProvider( DOCUMENT_1 ), document -> {
-			indexAccessors.string.write( document, STRING_1 );
-			indexAccessors.integer.write( document, INTEGER_1 );
+			indexAccessors.field1.write( document, FIELD1_VALUE1 );
+			indexAccessors.field2.write( document, FIELD2_VALUE1 );
+			indexAccessors.field3.write( document, FIELD3_VALUE1 );
 		} );
 		worker.add( referenceProvider( DOCUMENT_2 ), document -> {
-			indexAccessors.string.write( document, STRING_2 );
-			indexAccessors.integer.write( document, INTEGER_2 );
+			indexAccessors.field1.write( document, FIELD1_VALUE2 );
+			indexAccessors.field2.write( document, FIELD2_VALUE2 );
+			indexAccessors.field3.write( document, FIELD3_VALUE2 );
 		} );
 		worker.add( referenceProvider( DOCUMENT_3 ), document -> {
-			indexAccessors.string.write( document, STRING_3 );
-			indexAccessors.integer.write( document, INTEGER_3 );
+			indexAccessors.field1.write( document, FIELD1_VALUE3 );
+			indexAccessors.field2.write( document, FIELD2_VALUE3 );
+			indexAccessors.field3.write( document, FIELD3_VALUE3 );
 		} );
 
 		worker.execute().join();
@@ -362,12 +472,14 @@ public class BoolSearchPredicateIT {
 	}
 
 	private static class IndexAccessors {
-		final IndexFieldAccessor<String> string;
-		final IndexFieldAccessor<Integer> integer;
+		final IndexFieldAccessor<String> field1;
+		final IndexFieldAccessor<Integer> field2;
+		final IndexFieldAccessor<Integer> field3;
 
 		IndexAccessors(IndexSchemaElement root) {
-			string = root.field( "string" ).asString().createAccessor();
-			integer = root.field( "integer" ).asInteger().createAccessor();
+			field1 = root.field( "field1" ).asString().createAccessor();
+			field2 = root.field( "field2" ).asInteger().createAccessor();
+			field3 = root.field( "field3" ).asInteger().createAccessor();
 		}
 	}
 }

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -560,14 +560,14 @@ public class BoolSearchPredicateIT {
 	}
 
 	@Test
-	public void minimumShouldMatchRatio_positive() {
+	public void minimumShouldMatchPercent_positive() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
 		// Expect default behavior (1 "should" clause has to match)
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.minimumShouldMatchRatio( 0.5 )
+						.minimumShouldMatchPercent( 50 )
 						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
 						.should().match().onField( "field2" ).matching( FIELD2_VALUE3 )
 				.end()
@@ -581,7 +581,7 @@ public class BoolSearchPredicateIT {
 				.asReferences()
 				.predicate().bool()
 						.must().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
-						.minimumShouldMatchRatio( 0.5 )
+						.minimumShouldMatchPercent( 50 )
 						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
 						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
 				.end()
@@ -594,7 +594,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.minimumShouldMatchRatio( 0.7 ) // The minimum should be rounded down to 2
+						.minimumShouldMatchPercent( 70 ) // The minimum should be rounded down to 2
 						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
 						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
 						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
@@ -608,7 +608,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.minimumShouldMatchRatio( 1.0 )
+						.minimumShouldMatchPercent( 100 )
 						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
 						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
 				.end()
@@ -619,14 +619,14 @@ public class BoolSearchPredicateIT {
 	}
 
 	@Test
-	public void minimumShouldMatchRatio_negative() {
+	public void minimumShouldMatchPercent_negative() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
 		// Expect default behavior (1 "should" clause has to match)
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.minimumShouldMatchRatio( -0.5 )
+						.minimumShouldMatchPercent( -50 )
 						.should().match().onField( "field1" ).matching( FIELD1_VALUE1 )
 						.should().match().onField( "field2" ).matching( FIELD2_VALUE3 )
 				.end()
@@ -640,7 +640,7 @@ public class BoolSearchPredicateIT {
 				.asReferences()
 				.predicate().bool()
 						.must().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
-						.minimumShouldMatchRatio( -0.5 )
+						.minimumShouldMatchPercent( -50 )
 						.should().match().onField( "field2" ).matching( FIELD2_VALUE2 )
 						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
 				.end()
@@ -653,7 +653,7 @@ public class BoolSearchPredicateIT {
 		query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate().bool()
-						.minimumShouldMatchRatio( -0.4 ) // The minimum should be rounded up to 2
+						.minimumShouldMatchPercent( -40 ) // The minimum should be rounded up to 2
 						.should().match().onField( "field4" ).matching( FIELD4_VALUE1AND2 )
 						.should().match().onField( "field2" ).matching( FIELD2_VALUE1 )
 						.should().match().onField( "field3" ).matching( FIELD3_VALUE3 )
@@ -670,7 +670,7 @@ public class BoolSearchPredicateIT {
 
 		Consumer<BooleanJunctionPredicateContext<?>> minimumShouldMatchConstraints = b -> {
 			b.minimumShouldMatchNumber( 2, -1 );
-			b.minimumShouldMatchRatio( 4, 0.7 );
+			b.minimumShouldMatchPercent( 4, 70 );
 		};
 
 		// 0 "should" clause: expect the constraints to be ignored
@@ -781,7 +781,7 @@ public class BoolSearchPredicateIT {
 			// Test that we can set the "default" minimum by using a ceiling of 0
 			b.minimumShouldMatchNumber( 0, 1 );
 			b.minimumShouldMatchNumber( 2, -1 );
-			b.minimumShouldMatchRatio( 4, 0.7 );
+			b.minimumShouldMatchPercent( 4, 70 );
 		};
 
 		// 1 "should" clause: expect to require 1 "should" clause to match
@@ -841,7 +841,7 @@ public class BoolSearchPredicateIT {
 
 		SubTest.expectException(
 				"minimumShouldMatch constraint with negative ignoreConstraintCeiling",
-				() -> searchTarget.predicate().bool().minimumShouldMatchRatio( -1, 0.5 )
+				() -> searchTarget.predicate().bool().minimumShouldMatchPercent( -1, 50 )
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
@@ -857,8 +857,8 @@ public class BoolSearchPredicateIT {
 				"bool() predicate with minimumShouldMatch constraints with multiple conflicting ceilings",
 				() -> searchTarget.predicate().bool()
 						.minimumShouldMatchNumber( 2, -1 )
-						.minimumShouldMatchRatio( 4, 0.7 )
-						.minimumShouldMatchRatio( 4, 0.7 )
+						.minimumShouldMatchPercent( 4, 70 )
+						.minimumShouldMatchPercent( 4, 70 )
 		)
 				.assertThrown()
 				.isInstanceOf( SearchException.class )

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/CollectionHelper.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/CollectionHelper.java
@@ -6,6 +6,7 @@
  */
 package org.hibernate.search.v6poc.util.impl.common;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -44,6 +45,14 @@ public final class CollectionHelper {
 		Set<T> set = new HashSet<>( ts.length );
 		Collections.addAll( set, ts );
 		return set;
+	}
+
+	@SafeVarargs
+	public static <T> List<T> asList(T firstItem, T... otherItems) {
+		List<T> list = new ArrayList<>( otherItems.length + 1 );
+		list.add( firstItem );
+		Collections.addAll( list, otherItems );
+		return list;
 	}
 
 	public static <T> List<T> toImmutableList(List<? extends T> list) {

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/Contracts.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/Contracts.java
@@ -29,4 +29,10 @@ public final class Contracts {
 			throw log.mustNotBeNullNorEmpty( objectDescription );
 		}
 	}
+
+	public static void assertPositiveOrZero(int number, String objectDescription) {
+		if ( number < 0 ) {
+			throw log.mustBePositiveOrZero( objectDescription );
+		}
+	}
 }

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/logging/Log.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/logging/Log.java
@@ -34,4 +34,7 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 500, value = "'%1$s' must not be null or empty.")
 	IllegalArgumentException mustNotBeNullNorEmpty(String objectDescription);
+
+	@Message(id = 501, value = "'%1$s' must be positive or zero.")
+	IllegalArgumentException mustBePositiveOrZero(String objectDescription);
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/assertion/DocumentReferencesSearchResultAssert.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/assertion/DocumentReferencesSearchResultAssert.java
@@ -35,15 +35,15 @@ public class DocumentReferencesSearchResultAssert<T extends DocumentReference>
 		super( actual );
 	}
 
-	public DocumentReferencesSearchResultAssert<T> hasReferencesHitsExactOrder(String indexName, String... ids) {
+	public DocumentReferencesSearchResultAssert<T> hasReferencesHitsExactOrder(String indexName, String firstId, String... otherIds) {
 		return hasReferencesHitsExactOrder( ctx -> {
-			ctx = ctx.doc( indexName, ids );
+			ctx.doc( indexName, firstId, otherIds );
 		} );
 	}
 
-	public DocumentReferencesSearchResultAssert<T> hasReferencesHitsAnyOrder(String indexName, String... ids) {
+	public DocumentReferencesSearchResultAssert<T> hasReferencesHitsAnyOrder(String indexName, String firstId, String... otherIds) {
 		return hasReferencesHitsAnyOrder( ctx -> {
-			ctx = ctx.doc( indexName, ids );
+			ctx.doc( indexName, firstId, otherIds );
 		} );
 	}
 
@@ -78,8 +78,9 @@ public class DocumentReferencesSearchResultAssert<T extends DocumentReference>
 		private ReferencesHitsBuilder() {
 		}
 
-		public ReferencesHitsBuilder doc(String indexName, String... ids) {
-			for ( String id : ids ) {
+		public ReferencesHitsBuilder doc(String indexName, String firstId, String... otherIds) {
+			expectedHits.add( NormalizationUtils.reference( indexName, firstId ) );
+			for ( String id : otherIds ) {
 				expectedHits.add( NormalizationUtils.reference( indexName, id ) );
 			}
 			return this;

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/assertion/ProjectionsSearchResultAssert.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/assertion/ProjectionsSearchResultAssert.java
@@ -7,11 +7,11 @@
 package org.hibernate.search.v6poc.util.impl.integrationtest.common.assertion;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
+import org.hibernate.search.v6poc.util.impl.common.CollectionHelper;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.NormalizationUtils;
 import org.hibernate.search.v6poc.search.SearchQuery;
 import org.hibernate.search.v6poc.search.SearchResult;
@@ -63,8 +63,9 @@ public class ProjectionsSearchResultAssert<T extends List<?>>
 		private ProjectionsHitsBuilder() {
 		}
 
-		public ProjectionsHitsBuilder projection(Object ... projectionItems) {
-			expectedHits.add( NormalizationUtils.normalizeProjection( Arrays.asList( projectionItems ) ) );
+		public ProjectionsHitsBuilder projection(Object firstProjectionItem, Object ... otherProjectionItems) {
+			List<?> projectionItems = CollectionHelper.asList( firstProjectionItem, otherProjectionItems );
+			expectedHits.add( NormalizationUtils.normalizeProjection( projectionItems ) );
 			return this;
 		}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/assertion/SearchResultAssert.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/assertion/SearchResultAssert.java
@@ -10,6 +10,7 @@ import java.util.Collection;
 
 import org.hibernate.search.v6poc.search.SearchQuery;
 import org.hibernate.search.v6poc.search.SearchResult;
+import org.hibernate.search.v6poc.util.impl.common.CollectionHelper;
 
 import org.assertj.core.api.Assertions;
 
@@ -28,28 +29,26 @@ public class SearchResultAssert<T> extends AbstractSearchResultAssert<SearchResu
 	}
 
 	@SuppressWarnings("unchecked")
-	public SearchResultAssert<T> hasHitsExactOrder(Collection<T> hits) {
-		return hasHitsExactOrder( (T[]) hits.toArray() );
+	public SearchResultAssert<T> hasHitsExactOrder(T firstHist, T... otherHits) {
+		return hasHitsExactOrder( CollectionHelper.asList( firstHist, otherHits ) );
 	}
 
 	@SuppressWarnings("unchecked")
-	public SearchResultAssert<T> hasHitsAnyOrder(Collection<T> hits) {
-		return hasHitsAnyOrder( (T[]) hits.toArray() );
+	public SearchResultAssert<T> hasHitsAnyOrder(T firstHist, T... otherHits) {
+		return hasHitsAnyOrder( CollectionHelper.asList( firstHist, otherHits ) );
 	}
 
-	@SafeVarargs
-	public final SearchResultAssert<T> hasHitsExactOrder(T... hits) {
+	public final SearchResultAssert<T> hasHitsExactOrder(Collection<T> hits) {
 		Assertions.assertThat( actual.getHits() )
 				.as( "Hits of " + actual )
-				.containsExactly( hits );
+				.containsExactly( (T[]) hits.toArray() );
 		return thisAsSelfType();
 	}
 
-	@SafeVarargs
-	public final SearchResultAssert<T> hasHitsAnyOrder(T... hits) {
+	public final SearchResultAssert<T> hasHitsAnyOrder(Collection<T> hits) {
 		Assertions.assertThat( actual.getHits() )
 				.as( "Hits of " + actual )
-				.containsOnly( hits );
+				.containsOnly( (T[]) hits.toArray() );
 		return thisAsSelfType();
 	}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -50,6 +50,16 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubQueryE
 	}
 
 	@Override
+	public void minimumShouldMatchNumber(int ignoreConstraintCeiling, int matchingClausesNumber) {
+		// No-op
+	}
+
+	@Override
+	public void minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio) {
+		// No-op
+	}
+
+	@Override
 	public void value(Object value) {
 		// No-op
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubPredicateBuilder.java
@@ -55,7 +55,7 @@ public class StubPredicateBuilder implements MatchAllPredicateBuilder<StubQueryE
 	}
 
 	@Override
-	public void minimumShouldMatchRatio(int ignoreConstraintCeiling, double matchingClausesRatio) {
+	public void minimumShouldMatchPercent(int ignoreConstraintCeiling, int matchingClausesPercent) {
 		// No-op
 	}
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3197
https://hibernate.atlassian.net//browse/HSEARCH-3208

This implements "minimumShouldMatch" for boolean queries: it adds support for both simple, non-conditional syntax (HSEARCH-3197) and advanced, conditional syntax (HSEARCH-3208).

This implements "minimumShouldMatch" for boolean queries only: I created [HSEARCH-3200](https://hibernate.atlassian.net/browse/HSEARCH-3200) to also implement it for match queries and simple query string queries.

**HSEARCH-3197 (at least) should be backported to Search 5, please do not mark the ticket as resolved yet.** I expect we won't be able to backport as-is, in particular because in Search 5, information is passed to the Elasticsearch backend as Lucene queries, meaning we will have to do the computation of the minimum even in the Elasticsearch case, and the Elasticsearch backend will only use the syntax where the minimum is defined as a positive integer.