### PR TITLE
HSEARCH-3205 Search 6 groundwork - Allow to map annotations to bridges directly, without requiring a builder

### DIFF
--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/CustomMarkerConsumingPropertyBridge.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/CustomMarkerConsumingPropertyBridge.java
@@ -13,33 +13,14 @@ import java.util.stream.Collectors;
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
 import org.hibernate.search.v6poc.backend.document.IndexObjectFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.v6poc.engine.spi.BuildContext;
 import org.hibernate.search.v6poc.entity.model.SearchModel;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
-import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelProperty;
-import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.annotation.CustomMarkerConsumingPropertyBridgeAnnotation;
 
 public final class CustomMarkerConsumingPropertyBridge implements PropertyBridge {
 
-	public static final class Builder
-			implements AnnotationBridgeBuilder<PropertyBridge, CustomMarkerConsumingPropertyBridgeAnnotation> {
-		@Override
-		public void initialize(CustomMarkerConsumingPropertyBridgeAnnotation annotation) {
-			// Nothing to do
-		}
-
-		@Override
-		public PropertyBridge build(BuildContext buildContext) {
-			return new CustomMarkerConsumingPropertyBridge();
-		}
-	}
-
 	private List<IndexObjectFieldAccessor> objectFieldAccessors = new ArrayList<>();
-
-	private CustomMarkerConsumingPropertyBridge() {
-	}
 
 	@Override
 	public void bind(IndexSchemaElement indexSchemaElement, PojoModelProperty bridgedPojoModelProperty,

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/annotation/CustomMarkerConsumingPropertyBridgeAnnotation.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/annotation/CustomMarkerConsumingPropertyBridgeAnnotation.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomMarkerConsumingPropertyBridge;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
-@PropertyBridgeMapping(builder = @PropertyBridgeMappingBuilderReference(type = CustomMarkerConsumingPropertyBridge.Builder.class))
+@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(type = CustomMarkerConsumingPropertyBridge.Builder.class))
 public @interface CustomMarkerConsumingPropertyBridgeAnnotation {
 
 }

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/annotation/CustomMarkerConsumingPropertyBridgeAnnotation.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/annotation/CustomMarkerConsumingPropertyBridgeAnnotation.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeReference;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomMarkerConsumingPropertyBridge;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
-@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(type = CustomMarkerConsumingPropertyBridge.Builder.class))
+@PropertyBridgeMapping(bridge = @PropertyBridgeReference(type = CustomMarkerConsumingPropertyBridge.class))
 public @interface CustomMarkerConsumingPropertyBridgeAnnotation {
 
 }

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/annotation/CustomPropertyBridgeAnnotation.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/annotation/CustomPropertyBridgeAnnotation.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomPropertyBridge;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })
-@PropertyBridgeMapping(builder = @PropertyBridgeMappingBuilderReference(type = CustomPropertyBridge.Builder.class))
+@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(type = CustomPropertyBridge.Builder.class))
 public @interface CustomPropertyBridgeAnnotation {
 
 	String objectName();

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/annotation/CustomTypeBridgeAnnotation.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/bridge/annotation/CustomTypeBridgeAnnotation.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.integrationtest.mapper.pojo.bridge.CustomTypeBridge;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@TypeBridgeMapping(builder = @TypeBridgeMappingBuilderReference(type = CustomTypeBridge.Builder.class))
+@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(type = CustomTypeBridge.Builder.class))
 public @interface CustomTypeBridgeAnnotation {
 
 	String objectName();

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingBridgeIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingBridgeIT.java
@@ -30,16 +30,14 @@ import org.hibernate.search.v6poc.backend.document.IndexFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.IndexObjectFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaObjectField;
-import org.hibernate.search.v6poc.engine.spi.BuildContext;
 import org.hibernate.search.v6poc.entity.model.SearchModel;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
-import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
@@ -709,7 +707,7 @@ public class OrmAutomaticIndexingBridgeIT {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.TYPE })
-	@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(type = ContainingEntityTypeBridge.Builder.class))
+	@TypeBridgeMapping(bridge = @TypeBridgeReference(type = ContainingEntityTypeBridge.class))
 	public @interface ContainingEntityTypeBridgeAnnotation {
 	}
 
@@ -721,19 +719,6 @@ public class OrmAutomaticIndexingBridgeIT {
 		private IndexFieldAccessor<String> directFieldTargetAccessor;
 		private IndexObjectFieldAccessor childObjectFieldAccessor;
 		private IndexFieldAccessor<String> includedInTypeBridgeTargetAccessor;
-
-		public static class Builder
-				implements AnnotationBridgeBuilder<ContainingEntityTypeBridge, ContainingEntityTypeBridgeAnnotation> {
-			@Override
-			public void initialize(ContainingEntityTypeBridgeAnnotation annotation) {
-				// Nothing to do
-			}
-
-			@Override
-			public ContainingEntityTypeBridge build(BuildContext buildContext) {
-				return new ContainingEntityTypeBridge();
-			}
-		}
 
 		@Override
 		public void bind(IndexSchemaElement indexSchemaElement, PojoModelType bridgedPojoModelType,
@@ -767,7 +752,7 @@ public class OrmAutomaticIndexingBridgeIT {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.METHOD, ElementType.FIELD })
-	@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(type = ContainingEntityPropertyBridge.Builder.class))
+	@PropertyBridgeMapping(bridge = @PropertyBridgeReference(type = ContainingEntityPropertyBridge.class))
 	public @interface ContainingEntityPropertyBridgeAnnotation {
 	}
 
@@ -776,19 +761,6 @@ public class OrmAutomaticIndexingBridgeIT {
 		private PojoModelElementAccessor<String> includedInPropertyBridgeSourceAccessor;
 		private IndexObjectFieldAccessor propertyBridgeObjectFieldAccessor;
 		private IndexFieldAccessor<String> includedInPropertyBridgeTargetAccessor;
-
-		public static class Builder
-				implements AnnotationBridgeBuilder<ContainingEntityPropertyBridge, ContainingEntityPropertyBridgeAnnotation> {
-			@Override
-			public void initialize(ContainingEntityPropertyBridgeAnnotation annotation) {
-				// Nothing to do
-			}
-
-			@Override
-			public ContainingEntityPropertyBridge build(BuildContext buildContext) {
-				return new ContainingEntityPropertyBridge();
-			}
-		}
 
 		@Override
 		public void bind(IndexSchemaElement indexSchemaElement, PojoModelProperty bridgedPojoModelProperty,

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingBridgeIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingBridgeIT.java
@@ -36,9 +36,9 @@ import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
@@ -709,7 +709,7 @@ public class OrmAutomaticIndexingBridgeIT {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.TYPE })
-	@TypeBridgeMapping(builder = @TypeBridgeMappingBuilderReference(type = ContainingEntityTypeBridge.Builder.class))
+	@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(type = ContainingEntityTypeBridge.Builder.class))
 	public @interface ContainingEntityTypeBridgeAnnotation {
 	}
 
@@ -767,7 +767,7 @@ public class OrmAutomaticIndexingBridgeIT {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.METHOD, ElementType.FIELD })
-	@PropertyBridgeMapping(builder = @PropertyBridgeMappingBuilderReference(type = ContainingEntityPropertyBridge.Builder.class))
+	@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(type = ContainingEntityPropertyBridge.Builder.class))
 	public @interface ContainingEntityPropertyBridgeAnnotation {
 	}
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingEmbeddedBridgeIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingEmbeddedBridgeIT.java
@@ -36,7 +36,7 @@ import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
@@ -310,7 +310,7 @@ public class OrmAutomaticIndexingEmbeddedBridgeIT {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.TYPE })
-	@TypeBridgeMapping(builder = @TypeBridgeMappingBuilderReference(type = FirstTypeBridge.Builder.class))
+	@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(type = FirstTypeBridge.Builder.class))
 	public @interface FirstTypeBridgeAnnotation {
 	}
 
@@ -353,7 +353,7 @@ public class OrmAutomaticIndexingEmbeddedBridgeIT {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.TYPE })
-	@TypeBridgeMapping(builder = @TypeBridgeMappingBuilderReference(type = SecondTypeBridge.Builder.class))
+	@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(type = SecondTypeBridge.Builder.class))
 	public @interface SecondTypeBridgeAnnotation {
 	}
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingEmbeddedBridgeIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingEmbeddedBridgeIT.java
@@ -30,14 +30,12 @@ import org.hibernate.search.v6poc.backend.document.IndexFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.IndexObjectFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaElement;
 import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaObjectField;
-import org.hibernate.search.v6poc.engine.spi.BuildContext;
 import org.hibernate.search.v6poc.entity.model.SearchModel;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
-import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
@@ -310,7 +308,7 @@ public class OrmAutomaticIndexingEmbeddedBridgeIT {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.TYPE })
-	@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(type = FirstTypeBridge.Builder.class))
+	@TypeBridgeMapping(bridge = @TypeBridgeReference(type = FirstTypeBridge.class))
 	public @interface FirstTypeBridgeAnnotation {
 	}
 
@@ -319,19 +317,6 @@ public class OrmAutomaticIndexingEmbeddedBridgeIT {
 		private PojoModelElementAccessor<String> valueSourceAccessor;
 		private IndexObjectFieldAccessor objectFieldAccessor;
 		private IndexFieldAccessor<String> valueTargetAccessor;
-
-		public static class Builder
-				implements AnnotationBridgeBuilder<FirstTypeBridge, FirstTypeBridgeAnnotation> {
-			@Override
-			public void initialize(FirstTypeBridgeAnnotation annotation) {
-				// Nothing to do
-			}
-
-			@Override
-			public FirstTypeBridge build(BuildContext buildContext) {
-				return new FirstTypeBridge();
-			}
-		}
 
 		@Override
 		public void bind(IndexSchemaElement indexSchemaElement, PojoModelType bridgedPojoModelType,
@@ -353,7 +338,7 @@ public class OrmAutomaticIndexingEmbeddedBridgeIT {
 
 	@Retention(RetentionPolicy.RUNTIME)
 	@Target({ ElementType.TYPE })
-	@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(type = SecondTypeBridge.Builder.class))
+	@TypeBridgeMapping(bridge = @TypeBridgeReference(type = SecondTypeBridge.class))
 	public @interface SecondTypeBridgeAnnotation {
 	}
 
@@ -362,19 +347,6 @@ public class OrmAutomaticIndexingEmbeddedBridgeIT {
 		private PojoModelElementAccessor<String> valueSourceAccessor;
 		private IndexObjectFieldAccessor objectFieldAccessor;
 		private IndexFieldAccessor<String> valueTargetAccessor;
-
-		public static class Builder
-				implements AnnotationBridgeBuilder<SecondTypeBridge, SecondTypeBridgeAnnotation> {
-			@Override
-			public void initialize(SecondTypeBridgeAnnotation annotation) {
-				// Nothing to do
-			}
-
-			@Override
-			public SecondTypeBridge build(BuildContext buildContext) {
-				return new SecondTypeBridge();
-			}
-		}
 
 		@Override
 		public void bind(IndexSchemaElement indexSchemaElement, PojoModelType bridgedPojoModelType,

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/CustomMarkerConsumingPropertyBridge.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/CustomMarkerConsumingPropertyBridge.java
@@ -13,33 +13,14 @@ import java.util.stream.Collectors;
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
 import org.hibernate.search.v6poc.backend.document.IndexObjectFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaElement;
-import org.hibernate.search.v6poc.engine.spi.BuildContext;
 import org.hibernate.search.v6poc.entity.model.SearchModel;
 import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
-import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelProperty;
-import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomMarkerConsumingPropertyBridgeAnnotation;
 
 public final class CustomMarkerConsumingPropertyBridge implements PropertyBridge {
 
-	public static final class Builder
-			implements AnnotationBridgeBuilder<PropertyBridge, CustomMarkerConsumingPropertyBridgeAnnotation> {
-		@Override
-		public void initialize(CustomMarkerConsumingPropertyBridgeAnnotation annotation) {
-			// Nothing to do
-		}
-
-		@Override
-		public PropertyBridge build(BuildContext buildContext) {
-			return new CustomMarkerConsumingPropertyBridge();
-		}
-	}
-
 	private List<IndexObjectFieldAccessor> objectFieldAccessors = new ArrayList<>();
-
-	private CustomMarkerConsumingPropertyBridge() {
-	}
 
 	@Override
 	public void bind(IndexSchemaElement indexSchemaElement, PojoModelProperty bridgedPojoModelProperty,

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/annotation/CustomMarkerConsumingPropertyBridgeAnnotation.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/annotation/CustomMarkerConsumingPropertyBridgeAnnotation.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeReference;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomMarkerConsumingPropertyBridge;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
-@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(type = CustomMarkerConsumingPropertyBridge.Builder.class))
+@PropertyBridgeMapping(bridge = @PropertyBridgeReference(type = CustomMarkerConsumingPropertyBridge.class))
 public @interface CustomMarkerConsumingPropertyBridgeAnnotation {
 
 }

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/annotation/CustomMarkerConsumingPropertyBridgeAnnotation.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/annotation/CustomMarkerConsumingPropertyBridgeAnnotation.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomMarkerConsumingPropertyBridge;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ElementType.METHOD, ElementType.FIELD})
-@PropertyBridgeMapping(builder = @PropertyBridgeMappingBuilderReference(type = CustomMarkerConsumingPropertyBridge.Builder.class))
+@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(type = CustomMarkerConsumingPropertyBridge.Builder.class))
 public @interface CustomMarkerConsumingPropertyBridgeAnnotation {
 
 }

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/annotation/CustomPropertyBridgeAnnotation.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/annotation/CustomPropertyBridgeAnnotation.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomPropertyBridge;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.FIELD, ElementType.METHOD })
-@PropertyBridgeMapping(builder = @PropertyBridgeMappingBuilderReference(type = CustomPropertyBridge.Builder.class))
+@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(type = CustomPropertyBridge.Builder.class))
 public @interface CustomPropertyBridgeAnnotation {
 
 	String objectName();

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/annotation/CustomTypeBridgeAnnotation.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/bridge/annotation/CustomTypeBridgeAnnotation.java
@@ -12,12 +12,12 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomTypeBridge;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
-@TypeBridgeMapping(builder = @TypeBridgeMappingBuilderReference(type = CustomTypeBridge.Builder.class))
+@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(type = CustomTypeBridge.Builder.class))
 public @interface CustomTypeBridgeAnnotation {
 
 	String objectName();

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/annotation/MultiKeywordStringBridge.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/bridge/annotation/MultiKeywordStringBridge.java
@@ -14,10 +14,10 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 
 @PropertyBridgeMapping(
-		builder = @PropertyBridgeMappingBuilderReference(
+		builder = @PropertyBridgeAnnotationBuilderReference(
 				type = org.hibernate.search.v6poc.integrationtest.showcase.library.bridge.MultiKeywordStringBridge.Builder.class
 		)
 )

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/spatial/annotation/GeoPointBridge.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/builtin/spatial/annotation/GeoPointBridge.java
@@ -15,9 +15,9 @@ import java.lang.annotation.Target;
 
 import org.hibernate.search.v6poc.backend.document.model.dsl.Store;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.spatial.GeoPoint;
 
 /**
@@ -63,10 +63,10 @@ import org.hibernate.search.v6poc.spatial.GeoPoint;
  * @hsearch.experimental Spatial support is still considered experimental
  * @author Nicolas Helleringer
  */
-@PropertyBridgeMapping(builder = @PropertyBridgeMappingBuilderReference(
+@PropertyBridgeMapping(builder = @PropertyBridgeAnnotationBuilderReference(
 		type = org.hibernate.search.v6poc.entity.pojo.bridge.builtin.spatial.GeoPointBridge.Builder.class
 ))
-@TypeBridgeMapping(builder = @TypeBridgeMappingBuilderReference(
+@TypeBridgeMapping(builder = @TypeBridgeAnnotationBuilderReference(
 		type = org.hibernate.search.v6poc.entity.pojo.bridge.builtin.spatial.GeoPointBridge.Builder.class
 ))
 @Retention(RetentionPolicy.RUNTIME)

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeAnnotationBuilderReference.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeAnnotationBuilderReference.java
@@ -12,8 +12,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
+import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 
 /**
  * @author Yoann Rodiere
@@ -21,16 +21,16 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBui
 @Documented
 @Target({}) // Only used as a component in other annotations
 @Retention(RetentionPolicy.RUNTIME)
-public @interface TypeBridgeMappingBuilderReference {
+public @interface PropertyBridgeAnnotationBuilderReference {
 
 	String name() default "";
 
-	Class<? extends AnnotationBridgeBuilder<? extends TypeBridge,?>> type() default UndefinedImplementationType.class;
+	Class<? extends AnnotationBridgeBuilder<? extends PropertyBridge,?>> type() default UndefinedImplementationType.class;
 
 	/**
 	 * Class used as a marker for the default value of the {@link #type()} attribute.
 	 */
-	abstract class UndefinedImplementationType implements AnnotationBridgeBuilder<TypeBridge, Annotation> {
+	abstract class UndefinedImplementationType implements AnnotationBridgeBuilder<PropertyBridge, Annotation> {
 		private UndefinedImplementationType() {
 		}
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeMapping.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeMapping.java
@@ -28,6 +28,23 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
 public @interface PropertyBridgeMapping {
 
 	/**
+	 * Map a property bridge to an annotation type.
+	 * <p>
+	 * Each time the mapped annotation is encountered, an instance of the property bridge will be created
+	 * and applied to the location where the annotation was found.
+	 * <p>
+	 * Property bridges mapped this way cannot be parameterized:
+	 * any attribute of the mapped annotation will be ignored.
+	 * See {@link #builder()} to take advantage of the annotation attributes.
+	 * <p>
+	 * This attribute cannot be used in the same {@link PropertyBridgeMapping} annotation
+	 * as {@link #builder()}: either a bridge or a bridge builder can be provided, but never both.
+	 *
+	 * @return A reference to the property bridge to use.
+	 */
+	PropertyBridgeReference bridge() default @PropertyBridgeReference;
+
+	/**
 	 * Map a property bridge builder to an annotation type.
 	 * <p>
 	 * Each time the mapped annotation is encountered, an instance of the property bridge builder will be created.
@@ -38,9 +55,12 @@ public @interface PropertyBridgeMapping {
 	 * Property bridges mapped this way can be parameterized:
 	 * the bridge will be able to take any attribute of the mapped annotation into account
 	 * in its {@link AnnotationBridgeBuilder#initialize(Annotation)} method.
+	 * <p>
+	 * This attribute cannot be used in the same {@link PropertyBridgeMapping} annotation
+	 * as {@link #bridge()}: either a bridge or a bridge builder can be provided, but never both.
 	 *
 	 * @return A reference to the builder to use to build the property bridge.
 	 */
-	PropertyBridgeAnnotationBuilderReference builder();
+	PropertyBridgeAnnotationBuilderReference builder() default @PropertyBridgeAnnotationBuilderReference;
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeMapping.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeMapping.java
@@ -20,6 +20,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PropertyBridgeMapping {
 
-	PropertyBridgeMappingBuilderReference builder();
+	PropertyBridgeAnnotationBuilderReference builder();
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeMapping.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeMapping.java
@@ -6,20 +6,41 @@
  */
 package org.hibernate.search.v6poc.entity.pojo.bridge.declaration;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.hibernate.search.v6poc.engine.spi.BuildContext;
+import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
+import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
+
 /**
- * @author Yoann Rodiere
+ * Allows to map a property bridge to an annotation type,
+ * so that whenever the annotation is found on a field or method in the domain model,
+ * the property bridge mapped to the annotation will be applied.
  */
 @Documented
 @Target(value = ElementType.ANNOTATION_TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface PropertyBridgeMapping {
 
+	/**
+	 * Map a property bridge builder to an annotation type.
+	 * <p>
+	 * Each time the mapped annotation is encountered, an instance of the property bridge builder will be created.
+	 * The builder will be passed the annotation through its
+	 * {@link AnnotationBridgeBuilder#initialize(Annotation)} method,
+	 * and then the bridge will be retrieved by calling {@link BridgeBuilder#build(BuildContext)}.
+	 * <p>
+	 * Property bridges mapped this way can be parameterized:
+	 * the bridge will be able to take any attribute of the mapped annotation into account
+	 * in its {@link AnnotationBridgeBuilder#initialize(Annotation)} method.
+	 *
+	 * @return A reference to the builder to use to build the property bridge.
+	 */
 	PropertyBridgeAnnotationBuilderReference builder();
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeReference.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/PropertyBridgeReference.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.entity.pojo.bridge.declaration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
+
+@Documented
+@Target({}) // Only used as a component in other annotations
+@Retention(RetentionPolicy.RUNTIME)
+public @interface PropertyBridgeReference {
+
+	String name() default "";
+
+	Class<? extends PropertyBridge> type() default UndefinedImplementationType.class;
+
+	/**
+	 * Class used as a marker for the default value of the {@link #type()} attribute.
+	 */
+	abstract class UndefinedImplementationType implements PropertyBridge {
+		private UndefinedImplementationType() {
+		}
+	}
+}
+

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeAnnotationBuilderReference.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeAnnotationBuilderReference.java
@@ -12,8 +12,8 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
-import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 
 /**
  * @author Yoann Rodiere
@@ -21,16 +21,16 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 @Documented
 @Target({}) // Only used as a component in other annotations
 @Retention(RetentionPolicy.RUNTIME)
-public @interface PropertyBridgeMappingBuilderReference {
+public @interface TypeBridgeAnnotationBuilderReference {
 
 	String name() default "";
 
-	Class<? extends AnnotationBridgeBuilder<? extends PropertyBridge,?>> type() default UndefinedImplementationType.class;
+	Class<? extends AnnotationBridgeBuilder<? extends TypeBridge,?>> type() default UndefinedImplementationType.class;
 
 	/**
 	 * Class used as a marker for the default value of the {@link #type()} attribute.
 	 */
-	abstract class UndefinedImplementationType implements AnnotationBridgeBuilder<PropertyBridge, Annotation> {
+	abstract class UndefinedImplementationType implements AnnotationBridgeBuilder<TypeBridge, Annotation> {
 		private UndefinedImplementationType() {
 		}
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeMapping.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeMapping.java
@@ -6,20 +6,41 @@
  */
 package org.hibernate.search.v6poc.entity.pojo.bridge.declaration;
 
+import java.lang.annotation.Annotation;
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+import org.hibernate.search.v6poc.engine.spi.BuildContext;
+import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
+import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
+
 /**
- * @author Yoann Rodiere
+ * Allows to map a type bridge to an annotation type,
+ * so that whenever the annotation is found on a type in the domain model,
+ * the type bridge mapped to the annotation will be applied.
  */
 @Documented
 @Target(value = ElementType.ANNOTATION_TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TypeBridgeMapping {
 
+	/**
+	 * Map a type bridge builder to an annotation type.
+	 * <p>
+	 * Each time the mapped annotation is encountered, an instance of the type bridge builder will be created.
+	 * The builder will be passed the annotation through its
+	 * {@link AnnotationBridgeBuilder#initialize(Annotation)} method,
+	 * and then the bridge will be retrieved by calling {@link BridgeBuilder#build(BuildContext)}.
+	 * <p>
+	 * Type bridges mapped this way can be parameterized:
+	 * the bridge will be able to take any attribute of the mapped annotation into account
+	 * in its {@link AnnotationBridgeBuilder#initialize(Annotation)} method.
+	 *
+	 * @return A reference to the builder to use to build the type bridge.
+	 */
 	TypeBridgeAnnotationBuilderReference builder();
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeMapping.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeMapping.java
@@ -20,6 +20,6 @@ import java.lang.annotation.Target;
 @Retention(RetentionPolicy.RUNTIME)
 public @interface TypeBridgeMapping {
 
-	TypeBridgeMappingBuilderReference builder();
+	TypeBridgeAnnotationBuilderReference builder();
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeMapping.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeMapping.java
@@ -28,6 +28,23 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.BridgeBuilder;
 public @interface TypeBridgeMapping {
 
 	/**
+	 * Map a type bridge to an annotation type.
+	 * <p>
+	 * Each time the mapped annotation is encountered, an instance of the type bridge will be created
+	 * and applied to the location where the annotation was found.
+	 * <p>
+	 * Type bridges mapped this way cannot be parameterized:
+	 * any attribute of the mapped annotation will be ignored.
+	 * See {@link #builder()} to take advantage of the annotation attributes.
+	 * <p>
+	 * This attribute cannot be used in the same {@link TypeBridgeMapping} annotation
+	 * as {@link #builder()}: either a bridge or a bridge builder can be provided, but never both.
+	 *
+	 * @return A reference to the type bridge to use.
+	 */
+	TypeBridgeReference bridge() default @TypeBridgeReference;
+
+	/**
 	 * Map a type bridge builder to an annotation type.
 	 * <p>
 	 * Each time the mapped annotation is encountered, an instance of the type bridge builder will be created.
@@ -38,9 +55,12 @@ public @interface TypeBridgeMapping {
 	 * Type bridges mapped this way can be parameterized:
 	 * the bridge will be able to take any attribute of the mapped annotation into account
 	 * in its {@link AnnotationBridgeBuilder#initialize(Annotation)} method.
+	 * <p>
+	 * This attribute cannot be used in the same {@link TypeBridgeMapping} annotation
+	 * as {@link #bridge()}: either a bridge or a bridge builder can be provided, but never both.
 	 *
 	 * @return A reference to the builder to use to build the type bridge.
 	 */
-	TypeBridgeAnnotationBuilderReference builder();
+	TypeBridgeAnnotationBuilderReference builder() default @TypeBridgeAnnotationBuilderReference;
 
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeReference.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/bridge/declaration/TypeBridgeReference.java
@@ -1,0 +1,33 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.entity.pojo.bridge.declaration;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
+
+@Documented
+@Target({}) // Only used as a component in other annotations
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TypeBridgeReference {
+
+	String name() default "";
+
+	Class<? extends TypeBridge> type() default UndefinedImplementationType.class;
+
+	/**
+	 * Class used as a marker for the default value of the {@link #type()} attribute.
+	 */
+	abstract class UndefinedImplementationType implements TypeBridge {
+		private UndefinedImplementationType() {
+		}
+	}
+}
+

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/Log.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/Log.java
@@ -39,9 +39,10 @@ public interface Log extends BasicLogger {
 	@Message(id = 2, value = "Unable to find a default value bridge implementation for type '%1$s'")
 	SearchException unableToResolveDefaultValueBridgeFromSourceType(Class<?> sourceType);
 
-	@Message(id = 3, value = "Annotation type '%1$s' is annotated with @PropertyBridgeMapping,"
-			+ " but the bridge builder reference is empty.")
-	SearchException missingBuilderReferenceInBridgeMapping(Class<? extends Annotation> annotationType);
+	@Message(id = 3, value = "Annotation type '%2$s' is annotated with '%1$s',"
+			+ " but neither a bridge reference nor a bridge builder reference was provided.")
+	SearchException missingBridgeReferenceInBridgeMapping(Class<? extends Annotation> metaAnnotationType,
+			Class<? extends Annotation> annotationType);
 
 	@Message(id = 4, value = "Annotation type '%1$s' is annotated with @MarkerMapping,"
 			+ " but the marker builder reference is empty.")
@@ -153,4 +154,10 @@ public interface Log extends BasicLogger {
 	@Message(id = 25, value = "Cannot access the value of containing annotation '%1$s'."
 			+ " Ignoring annotation.")
 	void cannotAccessRepeateableContainingAnnotationValue(Class<?> containingAnnotationType, @Cause Throwable e);
+
+	@Message(id = 26, value = "Annotation type '%2$s' is annotated with '%1$s',"
+			+ " but both a bridge reference and a bridge builder reference were provided."
+			+ " Only one can be provided.")
+	SearchException conflictingBridgeReferenceInBridgeMapping(Class<? extends Annotation> metaAnnotationType,
+			Class<? extends Annotation> annotationType);
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorImpl.java
@@ -30,8 +30,10 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.MarkerMapping;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.MarkerMappingBuilderReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.impl.BeanResolverBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationMarkerBuilder;
@@ -150,14 +152,12 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 	}
 
 	private <A extends Annotation> void addTypeBridge(PojoMappingCollectorTypeNode collector, A annotation) {
-		AnnotationBridgeBuilder<? extends TypeBridge, A> builder = createTypeBridgeBuilder( annotation );
-		builder.initialize( annotation );
+		BridgeBuilder<? extends TypeBridge> builder = createTypeBridgeBuilder( annotation );
 		collector.bridge( builder );
 	}
 
 	private <A extends Annotation> void addPropertyBridge(PojoMappingCollectorPropertyNode collector, A annotation) {
-		AnnotationBridgeBuilder<? extends PropertyBridge, A> builder = createPropertyBridgeBuilder( annotation );
-		builder.initialize( annotation );
+		BridgeBuilder<? extends PropertyBridge> builder = createPropertyBridgeBuilder( annotation );
 		collector.bridge( builder );
 	}
 
@@ -274,36 +274,44 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 		}
 	}
 
-	private <A extends Annotation> AnnotationBridgeBuilder<? extends TypeBridge, A> createTypeBridgeBuilder(
-			A annotation) {
+	private <A extends Annotation> BridgeBuilder<? extends TypeBridge> createTypeBridgeBuilder(A annotation) {
 		TypeBridgeMapping bridgeMapping = annotation.annotationType().getAnnotation( TypeBridgeMapping.class );
+		TypeBridgeReference bridgeReferenceAnnotation = bridgeMapping.bridge();
 		TypeBridgeAnnotationBuilderReference bridgeBuilderReferenceAnnotation = bridgeMapping.builder();
-		BeanReference builderReference =
+
+		return createAnnotationMappedBridgeBuilder(
+				TypeBridgeMapping.class, TypeBridge.class, annotation,
+				toBeanReference(
+						bridgeReferenceAnnotation.name(),
+						bridgeReferenceAnnotation.type(),
+						TypeBridgeReference.UndefinedImplementationType.class
+				),
 				toBeanReference(
 						bridgeBuilderReferenceAnnotation.name(),
 						bridgeBuilderReferenceAnnotation.type(),
 						TypeBridgeAnnotationBuilderReference.UndefinedImplementationType.class
 				)
-						.orElseThrow( () -> log.missingBuilderReferenceInBridgeMapping( annotation.annotationType() ) );
-
-		// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in PojoIndexModelBinderImpl#addValueBridge
-		return beanProvider.getBean( builderReference, AnnotationBridgeBuilder.class );
+		);
 	}
 
-	private <A extends Annotation> AnnotationBridgeBuilder<? extends PropertyBridge, A> createPropertyBridgeBuilder(
-			A annotation) {
+	private <A extends Annotation> BridgeBuilder<? extends PropertyBridge> createPropertyBridgeBuilder(A annotation) {
 		PropertyBridgeMapping bridgeMapping = annotation.annotationType().getAnnotation( PropertyBridgeMapping.class );
+		PropertyBridgeReference bridgeReferenceAnnotation = bridgeMapping.bridge();
 		PropertyBridgeAnnotationBuilderReference bridgeBuilderReferenceAnnotation = bridgeMapping.builder();
-		BeanReference builderReference =
+
+		return createAnnotationMappedBridgeBuilder(
+				PropertyBridgeMapping.class, PropertyBridge.class, annotation,
+				toBeanReference(
+						bridgeReferenceAnnotation.name(),
+						bridgeReferenceAnnotation.type(),
+						PropertyBridgeReference.UndefinedImplementationType.class
+				),
 				toBeanReference(
 						bridgeBuilderReferenceAnnotation.name(),
 						bridgeBuilderReferenceAnnotation.type(),
 						PropertyBridgeAnnotationBuilderReference.UndefinedImplementationType.class
 				)
-						.orElseThrow( () -> log.missingBuilderReferenceInBridgeMapping( annotation.annotationType() ) );
-
-		// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in PojoIndexModelBinderImpl#addValueBridge
-		return beanProvider.getBean( builderReference, AnnotationBridgeBuilder.class );
+		);
 	}
 
 	private BridgeBuilder<? extends ValueBridge<?, ?>> createValueBridgeBuilder(
@@ -338,6 +346,26 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 		else {
 			// The bridge will be auto-detected from the property type
 			return null;
+		}
+	}
+
+	private <A extends Annotation, B> BridgeBuilder<B> createAnnotationMappedBridgeBuilder(
+			Class<? extends Annotation> bridgeMappingAnnotation, Class<B> bridgeClass, A annotation,
+			Optional<BeanReference> bridgeReferenceOptional, Optional<BeanReference> builderReferenceOptional) {
+		if ( bridgeReferenceOptional.isPresent() && builderReferenceOptional.isPresent() ) {
+			throw log.conflictingBridgeReferenceInBridgeMapping( bridgeMappingAnnotation, annotation.annotationType() );
+		}
+		else if ( bridgeReferenceOptional.isPresent() ) {
+			return new BeanResolverBridgeBuilder<>( bridgeClass, bridgeReferenceOptional.get() );
+		}
+		else if ( builderReferenceOptional.isPresent() ) {
+			AnnotationBridgeBuilder builder = beanProvider.getBean( builderReferenceOptional.get(), AnnotationBridgeBuilder.class );
+			// TODO check generic parameters of builder.getClass() somehow, maybe in a similar way to what we do in PojoIndexModelBinderImpl#addValueBridge
+			builder.initialize( annotation );
+			return builder;
+		}
+		else {
+			throw log.missingBridgeReferenceInBridgeMapping( bridgeMappingAnnotation, annotation.annotationType() );
 		}
 	}
 

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorImpl.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/definition/annotation/impl/AnnotationPojoTypeMetadataContributorImpl.java
@@ -29,9 +29,9 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.ValueBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.MarkerMapping;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.MarkerMappingBuilderReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
-import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMappingBuilderReference;
+import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeAnnotationBuilderReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.impl.BeanResolverBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationBridgeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.bridge.mapping.AnnotationMarkerBuilder;
@@ -277,12 +277,12 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 	private <A extends Annotation> AnnotationBridgeBuilder<? extends TypeBridge, A> createTypeBridgeBuilder(
 			A annotation) {
 		TypeBridgeMapping bridgeMapping = annotation.annotationType().getAnnotation( TypeBridgeMapping.class );
-		TypeBridgeMappingBuilderReference bridgeBuilderReferenceAnnotation = bridgeMapping.builder();
+		TypeBridgeAnnotationBuilderReference bridgeBuilderReferenceAnnotation = bridgeMapping.builder();
 		BeanReference builderReference =
 				toBeanReference(
 						bridgeBuilderReferenceAnnotation.name(),
 						bridgeBuilderReferenceAnnotation.type(),
-						TypeBridgeMappingBuilderReference.UndefinedImplementationType.class
+						TypeBridgeAnnotationBuilderReference.UndefinedImplementationType.class
 				)
 						.orElseThrow( () -> log.missingBuilderReferenceInBridgeMapping( annotation.annotationType() ) );
 
@@ -293,12 +293,12 @@ class AnnotationPojoTypeMetadataContributorImpl implements PojoTypeMetadataContr
 	private <A extends Annotation> AnnotationBridgeBuilder<? extends PropertyBridge, A> createPropertyBridgeBuilder(
 			A annotation) {
 		PropertyBridgeMapping bridgeMapping = annotation.annotationType().getAnnotation( PropertyBridgeMapping.class );
-		PropertyBridgeMappingBuilderReference bridgeBuilderReferenceAnnotation = bridgeMapping.builder();
+		PropertyBridgeAnnotationBuilderReference bridgeBuilderReferenceAnnotation = bridgeMapping.builder();
 		BeanReference builderReference =
 				toBeanReference(
 						bridgeBuilderReferenceAnnotation.name(),
 						bridgeBuilderReferenceAnnotation.type(),
-						PropertyBridgeMappingBuilderReference.UndefinedImplementationType.class
+						PropertyBridgeAnnotationBuilderReference.UndefinedImplementationType.class
 				)
 						.orElseThrow( () -> log.missingBuilderReferenceInBridgeMapping( annotation.annotationType() ) );
 


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3205
