### PR TITLE
HSEARCH-3073 Search 6 groundwork - Restore support for using JPA's @Id as a default for document IDs

### DIFF
--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingAccessTypeIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingAccessTypeIT.java
@@ -24,7 +24,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -191,7 +190,6 @@ public class OrmAnnotationMappingAccessTypeIT {
 
 		public static final String INDEX = "IndexedEntity";
 
-		@DocumentId
 		private Integer id;
 
 		@Access( AccessType.FIELD )
@@ -273,7 +271,6 @@ public class OrmAnnotationMappingAccessTypeIT {
 		public static final String INDEX = "IndexedEntityWithoutIdSetter";
 
 		@Id
-		@DocumentId
 		@GeneratedValue
 		private Integer id;
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingDiscoveryIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingDiscoveryIT.java
@@ -19,7 +19,6 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.orm.mapping.HibernateOrmMappingDefinition;
 import org.hibernate.search.v6poc.entity.orm.mapping.HibernateOrmSearchMappingContributor;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -27,8 +26,8 @@ import org.hibernate.search.v6poc.integrationtest.orm.bridge.CustomMarkerConsumi
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomMarkerAnnotation;
 import org.hibernate.search.v6poc.integrationtest.orm.bridge.annotation.CustomMarkerConsumingPropertyBridgeAnnotation;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.service.ServiceRegistry;
 
 import org.junit.After;
@@ -174,7 +173,6 @@ public class OrmAnnotationMappingDiscoveryIT {
 		public static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@Embedded

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAnnotationMappingIT.java
@@ -484,7 +484,6 @@ public class OrmAnnotationMappingIT {
 		public static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@Field(name = "myTextField")
@@ -583,7 +582,6 @@ public class OrmAnnotationMappingIT {
 		public static final String INDEX = "YetAnotherIndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@Field

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingBasicIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingBasicIT.java
@@ -20,7 +20,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
@@ -364,7 +363,6 @@ public class OrmAutomaticIndexingBasicIT {
 		static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@Basic

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingBridgeIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingBridgeIT.java
@@ -38,7 +38,6 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeM
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.PropertyBridgeReference;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeReference;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoModelElementAccessor;
@@ -611,7 +610,6 @@ public class OrmAutomaticIndexingBridgeIT {
 	public static class ContainingEntity {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingEmbeddableIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingEmbeddableIT.java
@@ -31,7 +31,6 @@ import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.cfg.AvailableSettings;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.AssociationInverseSide;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -1458,7 +1457,6 @@ public class OrmAutomaticIndexingEmbeddableIT {
 		static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne(mappedBy = "parent")

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingEmbeddedBridgeIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingEmbeddedBridgeIT.java
@@ -36,7 +36,6 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.PropertyBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeReference;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.entity.pojo.model.PojoElement;
@@ -226,7 +225,6 @@ public class OrmAutomaticIndexingEmbeddedBridgeIT {
 		static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne(mappedBy = "parent")

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingGenericPolymorphicAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingGenericPolymorphicAssociationIT.java
@@ -23,7 +23,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -186,7 +185,6 @@ public class OrmAutomaticIndexingGenericPolymorphicAssociationIT {
 		static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne(mappedBy = "parent")
@@ -263,7 +261,6 @@ public class OrmAutomaticIndexingGenericPolymorphicAssociationIT {
 	public static class ContainedEntity<C extends ContainingEntity<C>> {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToMany(mappedBy = "containedSingle", targetEntity = ContainingEntity.class)

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingListAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingListAssociationIT.java
@@ -22,7 +22,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -771,7 +770,6 @@ public class OrmAutomaticIndexingListAssociationIT {
 	public static class ContainingEntity {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapKeysAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapKeysAssociationIT.java
@@ -31,7 +31,6 @@ import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.extractor.builtin.MapKeyExtractor;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.AssociationInverseSide;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ContainerValueExtractorBeanReference;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -768,7 +767,6 @@ public class OrmAutomaticIndexingMapKeysAssociationIT {
 	public static class ContainingEntity {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapValuesAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapValuesAssociationIT.java
@@ -26,7 +26,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -761,7 +760,6 @@ public class OrmAutomaticIndexingMapValuesAssociationIT {
 	public static class ContainingEntity {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMappedSuperclassIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMappedSuperclassIT.java
@@ -22,7 +22,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -145,7 +144,6 @@ public class OrmAutomaticIndexingMappedSuperclassIT {
 		static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		public Integer getId() {
@@ -161,7 +159,6 @@ public class OrmAutomaticIndexingMappedSuperclassIT {
 	public static class ContainedEntity {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToMany(mappedBy = "containedSingle")

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingOverReindexingIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingOverReindexingIT.java
@@ -29,7 +29,6 @@ import org.hibernate.search.v6poc.entity.pojo.bridge.TypeBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeMapping;
 import org.hibernate.search.v6poc.entity.pojo.bridge.declaration.TypeBridgeReference;
 import org.hibernate.search.v6poc.entity.pojo.dirtiness.impl.PojoImplicitReindexingResolverNode;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -210,7 +209,6 @@ public class OrmAutomaticIndexingOverReindexingIT {
 		static final String INDEX = "level1";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne
@@ -241,7 +239,6 @@ public class OrmAutomaticIndexingOverReindexingIT {
 		static final String INDEX = "level2";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne(mappedBy = "level2")

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingPolymorphicInverseSideAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingPolymorphicInverseSideAssociationIT.java
@@ -23,7 +23,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -256,7 +255,6 @@ public class OrmAutomaticIndexingPolymorphicInverseSideAssociationIT {
 		static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne
@@ -355,7 +353,6 @@ public class OrmAutomaticIndexingPolymorphicInverseSideAssociationIT {
 	public static class ContainedEntity {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToMany(mappedBy = "containedSingle")

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingPolymorphicOriginalSideAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingPolymorphicOriginalSideAssociationIT.java
@@ -24,7 +24,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -190,7 +189,6 @@ public class OrmAutomaticIndexingPolymorphicOriginalSideAssociationIT {
 		static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne(mappedBy = "parent")
@@ -284,7 +282,6 @@ public class OrmAutomaticIndexingPolymorphicOriginalSideAssociationIT {
 	public static class ContainedEntity {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToMany(mappedBy = "containedSingle")

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingSingleAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingSingleAssociationIT.java
@@ -21,7 +21,6 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
@@ -867,7 +866,6 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 	public static class ContainingEntity {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@OneToOne

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmGenericPropertyIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmGenericPropertyIT.java
@@ -21,14 +21,13 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.service.ServiceRegistry;
 
 import org.junit.After;
@@ -125,7 +124,6 @@ public class OrmGenericPropertyIT {
 		static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@ManyToOne
@@ -153,7 +151,6 @@ public class OrmGenericPropertyIT {
 	public abstract static class GenericEntity<T> {
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@Basic

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmPropertyInheritanceIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmPropertyInheritanceIT.java
@@ -19,14 +19,13 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
+import org.hibernate.search.v6poc.util.impl.test.rule.StaticCounters;
 import org.hibernate.service.ServiceRegistry;
 
 import org.junit.After;
@@ -130,7 +129,6 @@ public class OrmPropertyInheritanceIT {
 		private List<ParentIndexedEntity> embedding = new ArrayList<>();
 
 		@Id
-		@DocumentId
 		public Integer getId() {
 			return id;
 		}

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmUnusedPropertiesIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmUnusedPropertiesIT.java
@@ -17,12 +17,11 @@ import org.hibernate.boot.MetadataSources;
 import org.hibernate.boot.SessionFactoryBuilder;
 import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
 import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.test.rule.ExpectedLog4jLog;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
+import org.hibernate.search.v6poc.util.impl.test.rule.ExpectedLog4jLog;
 import org.hibernate.service.ServiceRegistry;
 
 import org.junit.After;
@@ -126,7 +125,6 @@ public class OrmUnusedPropertiesIT {
 		public static final String INDEX = "IndexedEntity";
 
 		@Id
-		@DocumentId
 		private Integer id;
 
 		@Field(name = "myTextField")

--- a/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/Library.java
+++ b/integrationtest/showcase/library/src/main/java/org/hibernate/search/v6poc/integrationtest/showcase/library/model/Library.java
@@ -20,10 +20,9 @@ import org.hibernate.search.v6poc.backend.document.model.dsl.Sortable;
 import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.spatial.annotation.GeoPointBridge;
 import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.spatial.annotation.Latitude;
 import org.hibernate.search.v6poc.entity.pojo.bridge.builtin.spatial.annotation.Longitude;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.DocumentId;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
-import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
+import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ValueBridgeBeanReference;
 import org.hibernate.search.v6poc.integrationtest.showcase.library.bridge.LibraryServiceBridge;
 
 /**
@@ -37,7 +36,6 @@ public class Library {
 	static final String INDEX = "Library";
 
 	@Id
-	@DocumentId
 	private Integer id;
 
 	@Basic

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/Log.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/Log.java
@@ -164,4 +164,8 @@ public interface Log extends BasicLogger {
 	@Message(id = 27, value = "Type '%1$s' is not marked as an entity type, yet it is indexed or targeted"
 			+ " by an association from an indexed type. Please check your configuration.")
 	SearchException missingEntityTypeMetadata(PojoRawTypeModel<?> typeModel);
+
+	@Message(id = 28, value = "There isn't any explicit document ID mapping for indexed type '%1$s',"
+			+ " and the entity ID cannot be used as a default because it is unknown.")
+	SearchException missingIdentifierMapping(PojoRawTypeModel<?> typeModel);
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIdentityMappingCollector.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIdentityMappingCollector.java
@@ -7,13 +7,12 @@
 package org.hibernate.search.v6poc.entity.pojo.mapping.building.impl;
 
 import org.hibernate.search.v6poc.entity.pojo.bridge.IdentifierBridge;
-import org.hibernate.search.v6poc.entity.pojo.model.spi.PropertyHandle;
 import org.hibernate.search.v6poc.entity.pojo.bridge.RoutingKeyBridge;
-import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
+import org.hibernate.search.v6poc.entity.pojo.model.path.impl.BoundPojoModelPathPropertyNode;
 
 public interface PojoIdentityMappingCollector {
 
-	<T> void identifierBridge(PojoTypeModel<T> propertyTypeModel, PropertyHandle handle, IdentifierBridge<T> bridge);
+	<T> void identifierBridge(BoundPojoModelPathPropertyNode<?, T> modelPath, IdentifierBridge<T> bridge);
 
 	void routingKeyBridge(RoutingKeyBridge bridge);
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
@@ -157,13 +157,11 @@ class PojoIndexedTypeManagerBuilder<E, D extends DocumentElement> {
 
 		@Override
 		public <T> void identifierBridge(PojoTypeModel<T> propertyTypeModel, PropertyHandle handle, IdentifierBridge<T> bridge) {
-			// FIXME ensure the bridge is closed upon build failure and when closing the SearchManagerRepository
 			this.identifierMapping = new PropertyIdentifierMapping<>( propertyTypeModel.getRawType().getCaster(), handle, bridge );
 		}
 
 		@Override
 		public void routingKeyBridge(RoutingKeyBridge bridge) {
-			// FIXME ensure the bridge is closed upon build failure and when closing the SearchManagerRepository
 			this.routingKeyBridge = bridge;
 		}
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
@@ -99,7 +99,7 @@ class PojoIndexedTypeManagerBuilder<E, D extends DocumentElement> {
 			PojoImplicitReindexingResolverBuildingHelper reindexingResolverBuildingHelper,
 			PojoTypeAdditionalMetadata typeAdditionalMetadata) {
 		if ( preBuiltIndexingProcessor == null ) {
-			throw new AssertionFailure( "Internal error - preBuild should be called before addTo" );
+			throw new AssertionFailure( "Internal error - preBuild should be called before buildAndAddTo" );
 		}
 
 		IdentifierMapping<?, E> identifierMapping = identityMappingCollector.identifierMapping;

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoIndexedTypeManagerBuilder.java
@@ -28,14 +28,13 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.impl.RoutingKeyBridgeRouti
 import org.hibernate.search.v6poc.entity.pojo.mapping.impl.RoutingKeyProvider;
 import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.impl.PojoTypeAdditionalMetadata;
 import org.hibernate.search.v6poc.entity.pojo.model.path.impl.BoundPojoModelPath;
+import org.hibernate.search.v6poc.entity.pojo.model.path.impl.BoundPojoModelPathPropertyNode;
 import org.hibernate.search.v6poc.entity.pojo.model.path.spi.PojoPathFilterFactory;
+import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoPropertyModel;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoRawTypeModel;
-import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
-import org.hibernate.search.v6poc.entity.pojo.model.spi.PropertyHandle;
 import org.hibernate.search.v6poc.entity.pojo.processing.building.impl.PojoIndexingProcessorTypeNodeBuilder;
 import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessor;
 import org.hibernate.search.v6poc.util.AssertionFailure;
-import org.hibernate.search.v6poc.util.SearchException;
 import org.hibernate.search.v6poc.util.impl.common.Closer;
 import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 
@@ -43,6 +42,8 @@ class PojoIndexedTypeManagerBuilder<E, D extends DocumentElement> {
 	private static Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final PojoRawTypeModel<E> typeModel;
+	private final PojoTypeAdditionalMetadata typeAdditionalMetadata;
+	private final PojoMappingHelper mappingHelper;
 	private final IndexManagerBuildingState<D> indexManagerBuildingState;
 
 	private final PojoIdentityMappingCollectorImpl identityMappingCollector;
@@ -53,10 +54,13 @@ class PojoIndexedTypeManagerBuilder<E, D extends DocumentElement> {
 	private boolean closed = false;
 
 	PojoIndexedTypeManagerBuilder(PojoRawTypeModel<E> typeModel,
+			PojoTypeAdditionalMetadata typeAdditionalMetadata,
 			PojoMappingHelper mappingHelper,
 			IndexManagerBuildingState<D> indexManagerBuildingState,
 			IdentifierMapping<?, E> defaultIdentifierMapping) {
 		this.typeModel = typeModel;
+		this.typeAdditionalMetadata = typeAdditionalMetadata;
+		this.mappingHelper = mappingHelper;
 		this.indexManagerBuildingState = indexManagerBuildingState;
 		this.identityMappingCollector = new PojoIdentityMappingCollectorImpl( defaultIdentifierMapping );
 		IndexModelBindingContext bindingContext = indexManagerBuildingState.getRootBindingContext();
@@ -104,7 +108,19 @@ class PojoIndexedTypeManagerBuilder<E, D extends DocumentElement> {
 
 		IdentifierMapping<?, E> identifierMapping = identityMappingCollector.identifierMapping;
 		if ( identifierMapping == null ) {
-			throw new SearchException( "Missing identifier mapping for indexed type '" + typeModel + "'" );
+			// Fall back to the entity ID, if possible
+			Optional<BoundPojoModelPathPropertyNode<E, ?>> entityIdPathOptional = getEntityIdentifierPath();
+			if ( entityIdPathOptional.isPresent() ) {
+				BoundPojoModelPathPropertyNode<E, ?> entityIdPath = entityIdPathOptional.get();
+				identityMappingCollector.defaultIdentifierBridge(
+						mappingHelper,
+						entityIdPath
+				);
+				identifierMapping = identityMappingCollector.identifierMapping;
+			}
+			else {
+				throw log.missingIdentifierMapping( typeModel );
+			}
 		}
 
 		RoutingKeyBridge routingKeyBridge = identityMappingCollector.routingKeyBridge;
@@ -140,6 +156,19 @@ class PojoIndexedTypeManagerBuilder<E, D extends DocumentElement> {
 		closed = true;
 	}
 
+	private Optional<BoundPojoModelPathPropertyNode<E, ?>> getEntityIdentifierPath() {
+		Optional<String> entityIdPropertyName = typeAdditionalMetadata.getEntityTypeMetadata()
+				.orElseThrow( () -> log.missingEntityTypeMetadata( typeModel ) )
+				.getEntityIdPropertyName();
+		if ( entityIdPropertyName.isPresent() ) {
+			PojoPropertyModel<?> propertyModel = typeModel.getProperty( entityIdPropertyName.get() );
+			return Optional.of( BoundPojoModelPath.root( typeModel ).property( propertyModel.getHandle() ) );
+		}
+		else {
+			return Optional.empty();
+		}
+	}
+
 	private class PojoIdentityMappingCollectorImpl implements PojoIdentityMappingCollector {
 		private IdentifierMapping<?, E> identifierMapping;
 		private RoutingKeyBridge routingKeyBridge;
@@ -156,8 +185,21 @@ class PojoIndexedTypeManagerBuilder<E, D extends DocumentElement> {
 		}
 
 		@Override
-		public <T> void identifierBridge(PojoTypeModel<T> propertyTypeModel, PropertyHandle handle, IdentifierBridge<T> bridge) {
-			this.identifierMapping = new PropertyIdentifierMapping<>( propertyTypeModel.getRawType().getCaster(), handle, bridge );
+		public <T> void identifierBridge(BoundPojoModelPathPropertyNode<?, T> modelPath, IdentifierBridge<T> bridge) {
+			PojoPropertyModel<T> propertyModel = modelPath.getPropertyModel();
+			this.identifierMapping = new PropertyIdentifierMapping<>(
+					propertyModel.getTypeModel().getRawType().getCaster(),
+					propertyModel.getHandle(),
+					bridge
+			);
+		}
+
+		<T> void defaultIdentifierBridge(PojoMappingHelper mappingHelper,
+				BoundPojoModelPathPropertyNode<?, T> entityIdPath) {
+			identifierBridge(
+					entityIdPath,
+					mappingHelper.getIndexModelBinder().createIdentifierBridge( entityIdPath, null )
+			);
 		}
 
 		@Override

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoMapper.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/mapping/building/impl/PojoMapper.java
@@ -110,8 +110,12 @@ public class PojoMapper<M> implements Mapper<M> {
 
 		PojoRawTypeModel<?> entityTypeModel = (PojoRawTypeModel<?>) typeModel;
 		PojoIndexedTypeManagerBuilder<?, ?> builder = new PojoIndexedTypeManagerBuilder<>(
-				entityTypeModel, mappingHelper, indexManagerBuildingState,
-				implicitProvidedId ? ProvidedStringIdentifierMapping.get() : null );
+				entityTypeModel,
+				typeAdditionalMetadataProvider.get( entityTypeModel ),
+				mappingHelper,
+				indexManagerBuildingState,
+				implicitProvidedId ? ProvidedStringIdentifierMapping.get() : null
+		);
 		// Put the builder in the map before anything else, so it will be closed on error
 		indexedTypeManagerBuilders.put( entityTypeModel, builder );
 

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/impl/PojoEntityTypeAdditionalMetadataBuilder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/impl/PojoEntityTypeAdditionalMetadataBuilder.java
@@ -1,0 +1,31 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.building.impl;
+
+import java.util.Optional;
+
+import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.building.spi.PojoAdditionalMetadataCollectorEntityTypeNode;
+import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.impl.PojoEntityTypeAdditionalMetadata;
+import org.hibernate.search.v6poc.entity.pojo.model.path.spi.PojoPathFilterFactory;
+
+class PojoEntityTypeAdditionalMetadataBuilder implements PojoAdditionalMetadataCollectorEntityTypeNode {
+	private final PojoPathFilterFactory pathFilterFactory;
+	private String entityIdPropertyName;
+
+	PojoEntityTypeAdditionalMetadataBuilder(PojoPathFilterFactory pathFilterFactory) {
+		this.pathFilterFactory = pathFilterFactory;
+	}
+
+	@Override
+	public void entityIdPropertyName(String propertyName) {
+		this.entityIdPropertyName = propertyName;
+	}
+
+	public PojoEntityTypeAdditionalMetadata build() {
+		return new PojoEntityTypeAdditionalMetadata( pathFilterFactory, Optional.ofNullable( entityIdPropertyName ) );
+	}
+}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/impl/PojoPropertyAdditionalMetadataBuilder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/impl/PojoPropertyAdditionalMetadataBuilder.java
@@ -53,7 +53,6 @@ class PojoPropertyAdditionalMetadataBuilder implements PojoAdditionalMetadataCol
 		Map<ContainerValueExtractorPath, PojoValueAdditionalMetadata> values = new HashMap<>();
 		for ( Map.Entry<ContainerValueExtractorPath, PojoValueAdditionalMetadataBuilder> entry : valueBuilders.entrySet() ) {
 			values.put( entry.getKey(), entry.getValue().build() );
-
 		}
 		return new PojoPropertyAdditionalMetadata( values, markers );
 	}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/impl/PojoTypeAdditionalMetadataBuilder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/impl/PojoTypeAdditionalMetadataBuilder.java
@@ -14,19 +14,19 @@ import java.util.Set;
 
 import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.building.spi.PojoAdditionalMetadataCollectorPropertyNode;
 import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.building.spi.PojoAdditionalMetadataCollectorTypeNode;
-import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.impl.PojoEntityTypeAdditionalMetadata;
 import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.impl.PojoPropertyAdditionalMetadata;
 import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.impl.PojoTypeAdditionalMetadata;
 import org.hibernate.search.v6poc.entity.pojo.model.path.spi.PojoPathFilterFactory;
 
 class PojoTypeAdditionalMetadataBuilder implements PojoAdditionalMetadataCollectorTypeNode {
-	private Optional<PojoEntityTypeAdditionalMetadata> entityTypeMetadata = Optional.empty();
+	private PojoEntityTypeAdditionalMetadataBuilder entityTypeMetadataBuilder;
 	// Use a LinkedHashMap for deterministic iteration
 	private final Map<String, PojoPropertyAdditionalMetadataBuilder> propertyBuilders = new LinkedHashMap<>();
 
 	@Override
-	public void markAsEntity(PojoPathFilterFactory<Set<String>> pathFilterFactory) {
-		this.entityTypeMetadata = Optional.of( new PojoEntityTypeAdditionalMetadata( pathFilterFactory ) );
+	public PojoEntityTypeAdditionalMetadataBuilder markAsEntity(PojoPathFilterFactory<Set<String>> pathFilterFactory) {
+		entityTypeMetadataBuilder = new PojoEntityTypeAdditionalMetadataBuilder( pathFilterFactory );
+		return entityTypeMetadataBuilder;
 	}
 
 	@Override
@@ -39,6 +39,9 @@ class PojoTypeAdditionalMetadataBuilder implements PojoAdditionalMetadataCollect
 		for ( Map.Entry<String, PojoPropertyAdditionalMetadataBuilder> entry : propertyBuilders.entrySet() ) {
 			properties.put( entry.getKey(), entry.getValue().build() );
 		}
-		return new PojoTypeAdditionalMetadata( entityTypeMetadata, properties );
+		return new PojoTypeAdditionalMetadata(
+				entityTypeMetadataBuilder == null ? Optional.empty() : Optional.of( entityTypeMetadataBuilder.build() ),
+				properties
+		);
 	}
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/spi/PojoAdditionalMetadataCollectorEntityTypeNode.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/spi/PojoAdditionalMetadataCollectorEntityTypeNode.java
@@ -1,0 +1,17 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.building.spi;
+
+public interface PojoAdditionalMetadataCollectorEntityTypeNode extends PojoAdditionalMetadataCollector {
+
+	/**
+	 * @param propertyName The name of a property hosting the entity ID.
+	 * This ID will be used by default to generate document IDs when no document ID was configured in the mapping.
+	 */
+	void entityIdPropertyName(String propertyName);
+
+}

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/spi/PojoAdditionalMetadataCollectorTypeNode.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/building/spi/PojoAdditionalMetadataCollectorTypeNode.java
@@ -30,8 +30,10 @@ public interface PojoAdditionalMetadataCollectorTypeNode extends PojoAdditionalM
 	 * @param pathFilterFactory The path filter factory for this entity type,
 	 * i.e. the object allowing to create path filters that will be used in particular
 	 * when performing dirty checking during automatic reindexing.
+	 * @return A {@link PojoAdditionalMetadataCollectorEntityTypeNode}, allowing to provide optional metadata
+	 * about the entity.
 	 */
-	void markAsEntity(PojoPathFilterFactory<Set<String>> pathFilterFactory);
+	PojoAdditionalMetadataCollectorEntityTypeNode markAsEntity(PojoPathFilterFactory<Set<String>> pathFilterFactory);
 
 	PojoAdditionalMetadataCollectorPropertyNode property(String propertyName);
 

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/impl/PojoEntityTypeAdditionalMetadata.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/impl/PojoEntityTypeAdditionalMetadata.java
@@ -6,15 +6,19 @@
  */
 package org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.impl;
 
+import java.util.Optional;
 import java.util.Set;
 
 import org.hibernate.search.v6poc.entity.pojo.model.path.spi.PojoPathFilterFactory;
 
 public class PojoEntityTypeAdditionalMetadata {
 	private final PojoPathFilterFactory pathFilterFactory;
+	private final Optional<String> entityIdPropertyName;
 
-	public PojoEntityTypeAdditionalMetadata(PojoPathFilterFactory pathFilterFactory) {
+	public PojoEntityTypeAdditionalMetadata(PojoPathFilterFactory pathFilterFactory,
+			Optional<String> entityIdPropertyName) {
 		this.pathFilterFactory = pathFilterFactory;
+		this.entityIdPropertyName = entityIdPropertyName;
 	}
 
 	/**
@@ -22,5 +26,9 @@ public class PojoEntityTypeAdditionalMetadata {
 	 */
 	public PojoPathFilterFactory<Set<String>> getPathFilterFactory() {
 		return pathFilterFactory;
+	}
+
+	public Optional<String> getEntityIdPropertyName() {
+		return entityIdPropertyName;
 	}
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/impl/PojoPropertyAdditionalMetadata.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/model/additionalmetadata/impl/PojoPropertyAdditionalMetadata.java
@@ -42,6 +42,4 @@ public class PojoPropertyAdditionalMetadata {
 		return ( (List<M>) this.markers.getOrDefault( markerType, Collections.emptyList() ) )
 				.stream();
 	}
-
-
 }

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/processing/building/impl/PojoIndexingProcessorPropertyNodeBuilder.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/processing/building/impl/PojoIndexingProcessorPropertyNodeBuilder.java
@@ -31,7 +31,6 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.building.spi.PojoMappingCo
 import org.hibernate.search.v6poc.entity.pojo.model.path.impl.BoundPojoModelPath;
 import org.hibernate.search.v6poc.entity.pojo.model.path.impl.BoundPojoModelPathPropertyNode;
 import org.hibernate.search.v6poc.entity.pojo.model.path.impl.BoundPojoModelPathValueNode;
-import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoGenericTypeModel;
 import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessor;
 import org.hibernate.search.v6poc.entity.pojo.processing.impl.PojoIndexingProcessorPropertyNode;
 import org.hibernate.search.v6poc.util.impl.common.Closer;
@@ -82,10 +81,10 @@ class PojoIndexingProcessorPropertyNodeBuilder<T, P> extends AbstractPojoProcess
 	@SuppressWarnings( {"rawtypes", "unchecked"} )
 	public void identifierBridge(BridgeBuilder<? extends IdentifierBridge<?>> builder) {
 		if ( identityMappingCollector.isPresent() ) {
-			PojoGenericTypeModel<P> propertyTypeModel = modelPath.getPropertyModel().getTypeModel();
 			IdentifierBridge<P> bridge = mappingHelper.getIndexModelBinder().createIdentifierBridge(
-					modelPath, builder );
-			identityMappingCollector.get().identifierBridge( propertyTypeModel, modelPath.getPropertyHandle(), bridge );
+					modelPath, builder
+			);
+			identityMappingCollector.get().identifierBridge( modelPath, bridge );
 		}
 	}
 

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/mapping/impl/HibernateOrmEntityTypeMetadataContributor.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/mapping/impl/HibernateOrmEntityTypeMetadataContributor.java
@@ -15,18 +15,23 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.building.spi.PojoTypeMetad
 import org.hibernate.search.v6poc.entity.pojo.model.additionalmetadata.building.spi.PojoAdditionalMetadataCollectorTypeNode;
 
 final class HibernateOrmEntityTypeMetadataContributor implements PojoTypeMetadataContributor {
+
 	private final PersistentClass persistentClass;
+	private final String idPropertyName;
 	private final List<PojoTypeMetadataContributor> delegates;
 
 	HibernateOrmEntityTypeMetadataContributor(PersistentClass persistentClass,
+			String idPropertyName,
 			List<PojoTypeMetadataContributor> delegates) {
 		this.persistentClass = persistentClass;
+		this.idPropertyName = idPropertyName;
 		this.delegates = delegates;
 	}
 
 	@Override
 	public void contributeModel(PojoAdditionalMetadataCollectorTypeNode collector) {
-		collector.markAsEntity( new HibernateOrmPathFilterFactory( persistentClass ) );
+		collector.markAsEntity( new HibernateOrmPathFilterFactory( persistentClass ) )
+				.entityIdPropertyName( idPropertyName );
 		for ( PojoTypeMetadataContributor delegate : delegates ) {
 			delegate.contributeModel( collector );
 		}

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/mapping/impl/HibernateOrmMetatadaContributor.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/mapping/impl/HibernateOrmMetatadaContributor.java
@@ -56,11 +56,14 @@ public final class HibernateOrmMetatadaContributor implements PojoMappingConfigu
 			Class<?> clazz = persistentClass.getMappedClass();
 			PojoRawTypeModel<?> typeModel = introspector.getTypeModel( clazz );
 			collectPropertyDelegates( delegatesCollector, clazz, persistentClass.getPropertyIterator() );
+
+			String identifierPropertyName = persistentClass.getIdentifierProperty().getName();
+			List<PojoTypeMetadataContributor> delegates = delegatesCollector.buildAndRemove( clazz );
+
 			configurationCollector.collectContributor(
 					typeModel,
 					new HibernateOrmEntityTypeMetadataContributor(
-							persistentClass,
-							delegatesCollector.buildAndRemove( clazz )
+							persistentClass, identifierPropertyName, delegates
 					)
 			);
 		}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3073
