### PR TITLE
Limit code duplication in ORM automatic indexing multi-valued association tests

### DIFF
--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/AbstractOrmAutomaticIndexingMultiAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/AbstractOrmAutomaticIndexingMultiAssociationIT.java
@@ -1,0 +1,787 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.integrationtest.orm;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
+import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
+import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
+import org.hibernate.search.v6poc.util.impl.test.annotation.TestForIssue;
+import org.hibernate.service.ServiceRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * An abstract base for tests dealing with automatic indexing based on Hibernate ORM entity events
+ * and involving a multi-valued association.
+ * <p>
+ * We use a contrived design based on a {@link ModelPrimitives} class that defines all the factory methods,
+ * setters and getters we need,
+ * because we want to have separate model classes for every test,
+ * in order to avoid introducing exotic situations that would arise
+ * when using generics or superclasses in an ORM model.
+ */
+public abstract class AbstractOrmAutomaticIndexingMultiAssociationIT<
+		TIndexed extends TContaining, TContaining, TContained,
+		TContainedAssociation, TContainingAssociation
+		> {
+
+	private static final String PREFIX = SearchOrmSettings.PREFIX;
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	private SessionFactory sessionFactory;
+
+	private final ModelPrimitives<TIndexed, TContaining, TContained,
+				TContainedAssociation, TContainingAssociation> primitives;
+
+	AbstractOrmAutomaticIndexingMultiAssociationIT(
+			ModelPrimitives<TIndexed, TContaining, TContained,
+								TContainedAssociation, TContainingAssociation> primitives) {
+		this.primitives = primitives;
+	}
+
+	@Before
+	public void setup() {
+		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
+				.applySetting( PREFIX + "backend.stubBackend.type", StubBackendFactory.class.getName() )
+				.applySetting( PREFIX + "index.default.backend", "stubBackend" );
+
+		ServiceRegistry serviceRegistry = registryBuilder.build();
+
+		MetadataSources ms = new MetadataSources( serviceRegistry )
+				.addAnnotatedClass( primitives.getIndexedClass() )
+				.addAnnotatedClass( primitives.getContainedClass() );
+
+		Metadata metadata = ms.buildMetadata();
+
+		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
+
+		backendMock.expectSchema( primitives.getIndexName(), b -> b
+				.objectField( "containedIndexedEmbedded", b2 -> b2
+						.field( "indexedField", String.class )
+				)
+				.objectField( "child", b3 -> b3
+						.objectField( "containedIndexedEmbedded", b2 -> b2
+								.field( "indexedField", String.class )
+						)
+				)
+		);
+
+		sessionFactory = sfb.build();
+		backendMock.verifyExpectationsMet();
+	}
+
+	@After
+	public void cleanup() {
+		if ( sessionFactory != null ) {
+			sessionFactory.close();
+		}
+	}
+
+	@Test
+	public void directAssociationUpdate_indexedEmbedded() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> { } )
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
+
+			TContained contained = primitives.newContained( 2 );
+			primitives.setIndexedField( contained, "firstValue" );
+
+			primitives.addContained( primitives.getContainedIndexedEmbedded( entity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), entity1 );
+
+			session.persist( contained );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "containedIndexedEmbedded", b2 -> b2
+									.field( "indexedField", "firstValue" )
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a second value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
+
+			TContained contained = primitives.newContained( 3 );
+			primitives.setIndexedField( contained, "secondValue" );
+
+			primitives.addContained( primitives.getContainedIndexedEmbedded( entity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), entity1 );
+
+			session.persist( contained );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "containedIndexedEmbedded", b2 -> b2
+									.field( "indexedField", "firstValue" )
+							)
+							.objectField( "containedIndexedEmbedded", b2 -> b2
+									.field( "indexedField", "secondValue" )
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test removing a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
+
+			TContained contained = session.get( primitives.getContainedClass(), 2 );
+
+			primitives.removeContaining( primitives.getContainingAsIndexedEmbedded( contained ), entity1 );
+			primitives.removeContained( primitives.getContainedIndexedEmbedded( entity1 ), contained );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "containedIndexedEmbedded", b2 -> b2
+									.field( "indexedField", "secondValue" )
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that replacing an IndexedEmbedded association in an indexed entity
+	 * does trigger reindexing of the entity.
+	 * <p>
+	 * We need dedicated tests for this because Hibernate ORM does not handle
+	 * replaced collections the same way as it does updated collections.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3199")
+	public void directAssociationReplace_indexedEmbedded() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContained contained = primitives.newContained( 2 );
+			primitives.setIndexedField( contained, "firstValue" );
+
+			primitives.addContained( primitives.getContainedIndexedEmbedded( entity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), entity1 );
+
+			session.persist( contained );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "containedIndexedEmbedded", b2 -> b2
+									.field( "indexedField", "firstValue" )
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
+
+			TContained contained = primitives.newContained( 3 );
+			primitives.setIndexedField( contained, "secondValue" );
+
+			TContainedAssociation newAssociation = primitives.newContainedAssociation(
+					primitives.getContainedIndexedEmbedded( entity1 )
+			);
+			primitives.addContained( newAssociation, contained );
+			primitives.setContainedIndexedEmbedded( entity1, newAssociation );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), entity1 );
+
+			session.persist( contained );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "containedIndexedEmbedded", b2 -> b2
+									.field( "indexedField", "firstValue" )
+							)
+							.objectField( "containedIndexedEmbedded", b2 -> b2
+									.field( "indexedField", "secondValue" )
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that updating a non-IndexedEmbedded association in an entity
+	 * whose other properties are indexed
+	 * does not trigger reindexing of the entity.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3199")
+	public void directAssociationUpdate_nonIndexedEmbedded() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> { } )
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
+
+			TContained contained = primitives.newContained( 2 );
+			primitives.setIndexedField( contained, "firstValue" );
+
+			primitives.addContained( primitives.getContainedNonIndexedEmbedded( entity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), entity1 );
+
+			session.persist( contained );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a second value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
+
+			TContained contained = primitives.newContained( 3 );
+			primitives.setIndexedField( contained, "secondValue" );
+
+			primitives.addContained( primitives.getContainedNonIndexedEmbedded( entity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), entity1 );
+
+			session.persist( contained );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test removing a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
+
+			TContained contained = session.get( primitives.getContainedClass(), 2 );
+
+			primitives.removeContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), entity1 );
+			primitives.removeContained( primitives.getContainedNonIndexedEmbedded( entity1 ), contained );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that replacing a non-IndexedEmbedded association in an entity
+	 * whose other properties are indexed
+	 * does not trigger reindexing of the entity.
+	 * <p>
+	 * We need dedicated tests for this because Hibernate ORM does not handle
+	 * replaced collections the same way as it does updated collections.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3204")
+	public void directAssociationReplace_nonIndexedEmbedded() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContained contained = primitives.newContained( 2 );
+			primitives.setIndexedField( contained, "firstValue" );
+
+			primitives.addContained( primitives.getContainedNonIndexedEmbedded( entity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), entity1 );
+
+			session.persist( contained );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> { } )
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = session.get( primitives.getIndexedClass(), 1 );
+
+			TContained contained = primitives.newContained( 3 );
+			primitives.setIndexedField( contained, "secondValue" );
+
+			TContainedAssociation newAssociation = primitives.newContainedAssociation(
+					primitives.getContainedNonIndexedEmbedded( entity1 )
+			);
+			primitives.addContained( newAssociation, contained );
+			primitives.setContainedNonIndexedEmbedded( entity1, newAssociation );
+			primitives.addContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), entity1 );
+
+			session.persist( contained );
+
+			// TODO HSEARCH-3204: remove the statement below to not expect any work
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> { } )
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void indirectAssociationUpdate_indexedEmbedded() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContaining deeplyNestedContainingEntity = primitives.newContaining( 3 );
+			primitives.setChild( containingEntity1, deeplyNestedContainingEntity );
+			primitives.setParent( deeplyNestedContainingEntity, containingEntity1 );
+
+			session.persist( deeplyNestedContainingEntity );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> { } )
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
+
+			TContained contained = primitives.newContained( 4 );
+			primitives.setIndexedField( contained, "firstValue" );
+
+			primitives.addContained( primitives.getContainedIndexedEmbedded( containingEntity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), containingEntity1 );
+
+			session.persist( contained );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "firstValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding another value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
+
+			TContained contained = primitives.newContained( 5 );
+			primitives.setIndexedField( contained, "secondValue" );
+
+			primitives.addContained( primitives.getContainedIndexedEmbedded( containingEntity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), containingEntity1 );
+
+			session.persist( contained );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "firstValue" )
+									)
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "secondValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining deeplyNestedContainingEntity1 = session.get( primitives.getContainingClass(), 3 );
+
+			TContained contained = primitives.newContained( 6 );
+			primitives.setIndexedField( contained, "outOfScopeValue" );
+
+			primitives.addContained( primitives.getContainedIndexedEmbedded( deeplyNestedContainingEntity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), deeplyNestedContainingEntity1 );
+
+			session.persist( contained );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test removing a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
+
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+
+			primitives.removeContaining( primitives.getContainingAsIndexedEmbedded( contained ), containingEntity1 );
+			primitives.removeContained( primitives.getContainedIndexedEmbedded( containingEntity1 ), contained );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "secondValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that replacing an IndexedEmbedded association in an entity
+	 * that is IndexedEmbedded in an indexed entity
+	 * does trigger reindexing of the indexed entity.
+	 * <p>
+	 * We need dedicated tests for this because Hibernate ORM does not handle
+	 * replaced collections the same way as it does updated collections.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3199")
+	public void indirectAssociationReplace_indexedEmbedded() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContained contained = primitives.newContained( 3 );
+			primitives.setIndexedField( contained, "firstValue" );
+			primitives.addContained( primitives.getContainedIndexedEmbedded( containingEntity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), containingEntity1 );
+
+			session.persist( contained );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "firstValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
+
+			TContained contained = primitives.newContained( 4 );
+			primitives.setIndexedField( contained, "secondValue" );
+
+			TContainedAssociation newAssociation = primitives.newContainedAssociation(
+					primitives.getContainedIndexedEmbedded( containingEntity1 )
+			);
+			primitives.addContained( newAssociation, contained );
+			primitives.setContainedIndexedEmbedded( containingEntity1, newAssociation );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained ), containingEntity1 );
+
+			session.persist( contained );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "firstValue" )
+									)
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "secondValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that updating a non-IndexedEmbedded association in an entity
+	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
+	 * does not trigger reindexing of the indexed entity.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3199")
+	public void indirectAssociationUpdate_nonIndexedEmbedded() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> { } )
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
+
+			TContained contained = primitives.newContained( 4 );
+			primitives.setIndexedField( contained, "firstValue" );
+
+			primitives.addContained( primitives.getContainedNonIndexedEmbedded( containingEntity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), containingEntity1 );
+
+			session.persist( contained );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding another value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
+
+			TContained contained = primitives.newContained( 5 );
+			primitives.setIndexedField( contained, "secondValue" );
+
+			primitives.addContained( primitives.getContainedNonIndexedEmbedded( containingEntity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), containingEntity1 );
+
+			session.persist( contained );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test removing a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
+
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+
+			primitives.removeContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), containingEntity1 );
+			primitives.removeContained( primitives.getContainedNonIndexedEmbedded( containingEntity1 ), contained );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that replacing a non-IndexedEmbedded association in an entity
+	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
+	 * does not trigger reindexing of the indexed entity.
+	 * <p>
+	 * We need dedicated tests for this because Hibernate ORM does not handle
+	 * replaced collections the same way as it does updated collections.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3204")
+	public void indirectAssociationReplace_nonIndexedEmbedded() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContained contained = primitives.newContained( 3 );
+			primitives.setIndexedField( contained, "firstValue" );
+			primitives.addContained( primitives.getContainedNonIndexedEmbedded( containingEntity1 ), contained );
+			primitives.addContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), containingEntity1 );
+
+			session.persist( contained );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> { } )
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContaining containingEntity1 = session.get( primitives.getContainingClass(), 2 );
+
+			TContained contained = primitives.newContained( 4 );
+			primitives.setIndexedField( contained, "secondValue" );
+
+			TContainedAssociation newAssociation = primitives.newContainedAssociation(
+					primitives.getContainedNonIndexedEmbedded( containingEntity1 )
+			);
+			primitives.addContained( newAssociation, contained );
+			primitives.setContainedNonIndexedEmbedded( containingEntity1, newAssociation );
+			primitives.addContaining( primitives.getContainingAsNonIndexedEmbedded( contained ), containingEntity1 );
+
+			session.persist( contained );
+
+			// TODO HSEARCH-3204: remove the statement below to not expect any work
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> { } )
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void indirectValueUpdate() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContaining deeplyNestedContainingEntity = primitives.newContaining( 3 );
+			primitives.setChild( containingEntity1, deeplyNestedContainingEntity );
+			primitives.setParent( deeplyNestedContainingEntity, containingEntity1 );
+
+			TContained contained1 = primitives.newContained( 4 );
+			primitives.setIndexedField( contained1, "initialValue" );
+			primitives.addContained( primitives.getContainedIndexedEmbedded( containingEntity1 ), contained1 );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained1 ), containingEntity1 );
+
+			TContained contained2 = primitives.newContained( 5 );
+			primitives.setIndexedField( contained2, "initialOutOfScopeValue" );
+			primitives.addContained( primitives.getContainedIndexedEmbedded( deeplyNestedContainingEntity ), contained2 );
+			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained2 ), deeplyNestedContainingEntity );
+
+			session.persist( contained1 );
+			session.persist( contained2 );
+			session.persist( deeplyNestedContainingEntity );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "initialValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test updating the value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.setIndexedField( contained, "updatedValue" );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "updatedValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 5 );
+			primitives.setIndexedField( contained, "updatedOutOfScopeValue" );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	interface ModelPrimitives<
+			TIndexed extends TContaining,
+			TContaining,
+			TContained,
+			TContainedAssociation,
+			TContainingAssociation
+			> {
+		String getIndexName();
+
+		Class<TIndexed> getIndexedClass();
+
+		Class<TContaining> getContainingClass();
+
+		Class<TContained> getContainedClass();
+
+		TIndexed newIndexed(int id);
+
+		TContaining newContaining(int id);
+
+		TContained newContained(int id);
+
+		void setIndexedField(TContained contained, String value);
+
+		void setChild(TContaining parent, TContaining child);
+
+		void setParent(TContaining child, TContaining parent);
+
+		TContainedAssociation newContainedAssociation(TContainedAssociation original);
+
+		void addContained(TContainedAssociation association, TContained contained);
+
+		void removeContained(TContainedAssociation association, TContained contained);
+
+		void addContaining(TContainingAssociation association, TContaining containing);
+
+		void removeContaining(TContainingAssociation association, TContaining containing);
+
+		TContainedAssociation getContainedIndexedEmbedded(TContaining containing);
+
+		void setContainedIndexedEmbedded(TContaining containing, TContainedAssociation association);
+
+		TContainingAssociation getContainingAsIndexedEmbedded(TContained contained);
+
+		TContainedAssociation getContainedNonIndexedEmbedded(TContaining containing);
+
+		void setContainedNonIndexedEmbedded(TContaining containing, TContainedAssociation association);
+
+		TContainingAssociation getContainingAsNonIndexedEmbedded(TContained contained);
+	}
+
+}

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingListAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingListAssociationIT.java
@@ -16,25 +16,9 @@ import javax.persistence.ManyToMany;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
-import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
-import org.hibernate.search.v6poc.util.impl.test.annotation.TestForIssue;
-import org.hibernate.service.ServiceRegistry;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
 /**
  * Test automatic indexing based on Hibernate ORM entity events.
@@ -42,728 +26,135 @@ import org.junit.Test;
  * This test only checks updates involving a multi-valued, List association.
  * Other tests in the same package check more basic, direct updates or updates involving different associations.
  */
-public class OrmAutomaticIndexingListAssociationIT {
+public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticIndexingMultiAssociationIT<
+		OrmAutomaticIndexingListAssociationIT.IndexedEntity,
+		OrmAutomaticIndexingListAssociationIT.ContainingEntity,
+		OrmAutomaticIndexingListAssociationIT.ContainedEntity,
+		List<OrmAutomaticIndexingListAssociationIT.ContainedEntity>,
+		List<OrmAutomaticIndexingListAssociationIT.ContainingEntity>
+		> {
 
-	private static final String PREFIX = SearchOrmSettings.PREFIX;
-
-	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
-
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
-		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
-				.applySetting( PREFIX + "backend.stubBackend.type", StubBackendFactory.class.getName() )
-				.applySetting( PREFIX + "index.default.backend", "stubBackend" );
-
-		ServiceRegistry serviceRegistry = registryBuilder.build();
-
-		MetadataSources ms = new MetadataSources( serviceRegistry )
-				.addAnnotatedClass( IndexedEntity.class )
-				.addAnnotatedClass( ContainedEntity.class );
-
-		Metadata metadata = ms.buildMetadata();
-
-		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
-
-		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
-				.objectField( "containedList", b2 -> b2
-						.field( "indexedField", String.class )
-				)
-				.objectField( "child", b3 -> b3
-						.objectField( "containedList", b2 -> b2
-								.field( "indexedField", String.class )
-						)
-				)
-		);
-
-		sessionFactory = sfb.build();
-		backendMock.verifyExpectationsMet();
+	public OrmAutomaticIndexingListAssociationIT() {
+		super( new ListModelPrimitives() );
 	}
 
-	@After
-	public void cleanup() {
-		if ( sessionFactory != null ) {
-			sessionFactory.close();
+	private static class ListModelPrimitives
+			implements ModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
+			List<ContainedEntity>, List<ContainingEntity>> {
+
+		@Override
+		public String getIndexName() {
+			return IndexedEntity.INDEX;
 		}
-	}
 
-	@Test
-	public void directAssociationUpdate_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			entity1.getContainedList().add( containedEntity );
-			containedEntity.getContainingAsList().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedList", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a second value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			entity1.getContainedList().add( containedEntity );
-			containedEntity.getContainingAsList().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedList", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-							.objectField( "containedList", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = entity1.getContainedList().get( 0 );
-
-			containedEntity.getContainingAsList().clear();
-			entity1.getContainedList().remove( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedList", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing an IndexedEmbedded association in an indexed entity
-	 * does trigger reindexing of the entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void directAssociationReplace_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			entity1.getContainedList().add( containedEntity );
-			containedEntity.getContainingAsList().add( entity1 );
-
-			session.persist( containedEntity );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "containedList", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			List<ContainedEntity> newAssociation = new ArrayList<>(
-					entity1.getContainedList()
-			);
-			newAssociation.add( containedEntity );
-			entity1.setContainedList( newAssociation );
-			containedEntity.getContainingAsList().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedList", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-							.objectField( "containedList", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that updating a non-IndexedEmbedded association in an entity
-	 * whose other properties are indexed
-	 * does not trigger reindexing of the entity.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void directAssociationUpdate_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			entity1.getContainedNonIndexedEmbeddedList().add( containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedList().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a second value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			entity1.getContainedNonIndexedEmbeddedList().add( containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedList().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = entity1.getContainedNonIndexedEmbeddedList().get( 0 );
-
-			containedEntity.getContainingAsNonIndexedEmbeddedList().clear();
-			entity1.getContainedNonIndexedEmbeddedList().remove( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing a non-IndexedEmbedded association in an entity
-	 * whose other properties are indexed
-	 * does not trigger reindexing of the entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3204")
-	public void directAssociationReplace_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			entity1.getContainedNonIndexedEmbeddedList().add( containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedList().add( entity1 );
-
-			session.persist( containedEntity );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			List<ContainedEntity> newAssociation = new ArrayList<>(
-					entity1.getContainedNonIndexedEmbeddedList()
-			);
-			newAssociation.add( containedEntity );
-			entity1.setContainedNonIndexedEmbeddedList( newAssociation );
-			containedEntity.getContainingAsNonIndexedEmbeddedList().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// TODO HSEARCH-3204: remove the statement below to not expect any work
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectAssociationUpdate_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
-
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			containingEntity1.getContainedList().add( containedEntity );
-			containedEntity.getContainingAsList().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding another value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 5 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			containingEntity1.getContainedList().add( containedEntity );
-			containedEntity.getContainingAsList().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity deeplyNestedContainingEntity1 = session.get( ContainingEntity.class, 3 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 6 );
-			containedEntity.setIndexedField( "outOfScopeValue" );
-
-			deeplyNestedContainingEntity1.getContainedList().add( containedEntity );
-			containedEntity.getContainingAsList().add( deeplyNestedContainingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = containingEntity1.getContainedList().get( 0 );
-
-			containedEntity.getContainingAsList().clear();
-			containingEntity1.getContainedList().remove( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing an IndexedEmbedded association in an entity
-	 * that is IndexedEmbedded in an indexed entity
-	 * does trigger reindexing of the indexed entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectAssociationReplace_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "firstValue" );
-			containingEntity1.getContainedList().add( containedEntity );
-			containedEntity.getContainingAsList().add( containingEntity1 );
-
-			session.persist( containedEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			List<ContainedEntity> newAssociation = new ArrayList<>(
-					containingEntity1.getContainedList()
-			);
-			newAssociation.add( containedEntity );
-			containingEntity1.setContainedList( newAssociation );
-			containedEntity.getContainingAsList().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that updating a non-IndexedEmbedded association in an entity
-	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
-	 * does not trigger reindexing of the indexed entity.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectAssociationUpdate_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			containingEntity1.getContainedNonIndexedEmbeddedList().add( containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedList().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding another value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 5 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			containingEntity1.getContainedNonIndexedEmbeddedList().add( containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedList().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = containingEntity1.getContainedNonIndexedEmbeddedList().get( 0 );
-
-			containedEntity.getContainingAsNonIndexedEmbeddedList().clear();
-			containingEntity1.getContainedNonIndexedEmbeddedList().remove( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing a non-IndexedEmbedded association in an entity
-	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
-	 * does not trigger reindexing of the indexed entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3204")
-	public void indirectAssociationReplace_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "firstValue" );
-			containingEntity1.getContainedNonIndexedEmbeddedList().add( containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedList().add( containingEntity1 );
-
-			session.persist( containedEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			List<ContainedEntity> newAssociation = new ArrayList<>(
-					containingEntity1.getContainedNonIndexedEmbeddedList()
-			);
-			newAssociation.add( containedEntity );
-			containingEntity1.setContainedNonIndexedEmbeddedList( newAssociation );
-			containedEntity.getContainingAsNonIndexedEmbeddedList().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// TODO HSEARCH-3204: remove the statement below to not expect any work
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectValueUpdate() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
-
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.setIndexedField( "initialValue" );
-			containingEntity1.getContainedList().add( containedEntity1 );
-			containedEntity1.getContainingAsList().add( containingEntity1 );
-
-			ContainedEntity containedEntity2 = new ContainedEntity();
-			containedEntity2.setId( 5 );
-			containedEntity2.setIndexedField( "initialOutOfScopeValue" );
-			deeplyNestedContainingEntity.getContainedList().add( containedEntity2 );
-			containedEntity2.getContainingAsList().add( deeplyNestedContainingEntity );
-
-			session.persist( containedEntity1 );
-			session.persist( containedEntity2 );
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "initialValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.setIndexedField( "updatedValue" );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedList", b3 -> b3
-											.field( "indexedField", "updatedValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
-			containedEntity.setIndexedField( "updatedOutOfScopeValue" );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
+		@Override
+		public Class<IndexedEntity> getIndexedClass() {
+			return IndexedEntity.class;
+		}
+
+		@Override
+		public Class<ContainingEntity> getContainingClass() {
+			return ContainingEntity.class;
+		}
+
+		@Override
+		public Class<ContainedEntity> getContainedClass() {
+			return ContainedEntity.class;
+		}
+
+		@Override
+		public IndexedEntity newIndexed(int id) {
+			IndexedEntity entity = new IndexedEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public ContainingEntity newContaining(int id) {
+			ContainingEntity entity = new ContainingEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public ContainedEntity newContained(int id) {
+			ContainedEntity entity = new ContainedEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public void setIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setIndexedField( value );
+		}
+
+		@Override
+		public void setChild(ContainingEntity parent, ContainingEntity child) {
+			parent.setChild( child );
+		}
+
+		@Override
+		public void setParent(ContainingEntity child, ContainingEntity parent) {
+			child.setParent( parent );
+
+		}
+
+		@Override
+		public List<ContainedEntity> newContainedAssociation(List<ContainedEntity> original) {
+			return new ArrayList<>( original );
+		}
+
+		@Override
+		public void addContained(List<ContainedEntity> containedEntities, ContainedEntity containedEntity) {
+			containedEntities.add( containedEntity );
+		}
+
+		@Override
+		public void removeContained(List<ContainedEntity> containedEntities, ContainedEntity containedEntity) {
+			containedEntities.remove( containedEntity );
+		}
+
+		@Override
+		public void addContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
+			containingEntities.add( containingEntity );
+		}
+
+		@Override
+		public void removeContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
+			containingEntities.remove( containingEntity );
+		}
+
+		@Override
+		public List<ContainedEntity> getContainedIndexedEmbedded(ContainingEntity containingEntity) {
+			return containingEntity.getContainedIndexedEmbedded();
+		}
+
+		@Override
+		public void setContainedIndexedEmbedded(ContainingEntity containingEntity,
+				List<ContainedEntity> containedEntities) {
+			containingEntity.setContainedIndexedEmbedded( containedEntities );
+		}
+
+		@Override
+		public List<ContainingEntity> getContainingAsIndexedEmbedded(ContainedEntity containedEntity) {
+			return containedEntity.getContainingAsIndexedEmbedded();
+		}
+
+		@Override
+		public List<ContainedEntity> getContainedNonIndexedEmbedded(ContainingEntity containingEntity) {
+			return containingEntity.getContainedNonIndexedEmbedded();
+		}
+
+		@Override
+		public void setContainedNonIndexedEmbedded(ContainingEntity containingEntity,
+				List<ContainedEntity> containedEntities) {
+			containingEntity.setContainedNonIndexedEmbedded( containedEntities );
+		}
+
+		@Override
+		public List<ContainingEntity> getContainingAsNonIndexedEmbedded(ContainedEntity containedEntity) {
+			return containedEntity.getContainingAsNonIndexedEmbedded();
+		}
 	}
 
 	@Entity(name = "containing")
@@ -777,18 +168,18 @@ public class OrmAutomaticIndexingListAssociationIT {
 
 		@OneToOne(mappedBy = "parent")
 		@IndexedEmbedded(includePaths = {
-				"containedList.indexedField"
+				"containedIndexedEmbedded.indexedField"
 		})
 		private ContainingEntity child;
 
 		@ManyToMany
-		@JoinTable(name = "indexed_list")
+		@JoinTable(name = "indexed_containedIndexedEmbedded")
 		@IndexedEmbedded(includePaths = "indexedField")
-		private List<ContainedEntity> containedList = new ArrayList<>();
+		private List<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
-		@JoinTable(name = "indexed_nonIndexedEmbeddedList")
-		private List<ContainedEntity> containedNonIndexedEmbeddedList = new ArrayList<>();
+		@JoinTable(name = "indexed_containedNonIndexedEmbedded")
+		private List<ContainedEntity> containedNonIndexedEmbedded = new ArrayList<>();
 
 		public Integer getId() {
 			return id;
@@ -814,20 +205,20 @@ public class OrmAutomaticIndexingListAssociationIT {
 			this.child = child;
 		}
 
-		public List<ContainedEntity> getContainedList() {
-			return containedList;
+		public List<ContainedEntity> getContainedIndexedEmbedded() {
+			return containedIndexedEmbedded;
 		}
 
-		public void setContainedList(List<ContainedEntity> containedList) {
-			this.containedList = containedList;
+		public void setContainedIndexedEmbedded(List<ContainedEntity> containedIndexedEmbedded) {
+			this.containedIndexedEmbedded = containedIndexedEmbedded;
 		}
 
-		public List<ContainedEntity> getContainedNonIndexedEmbeddedList() {
-			return containedNonIndexedEmbeddedList;
+		public List<ContainedEntity> getContainedNonIndexedEmbedded() {
+			return containedNonIndexedEmbedded;
 		}
 
-		public void setContainedNonIndexedEmbeddedList(List<ContainedEntity> containedNonIndexedEmbeddedList) {
-			this.containedNonIndexedEmbeddedList = containedNonIndexedEmbeddedList;
+		public void setContainedNonIndexedEmbedded(List<ContainedEntity> containedNonIndexedEmbedded) {
+			this.containedNonIndexedEmbedded = containedNonIndexedEmbedded;
 		}
 	}
 
@@ -845,13 +236,13 @@ public class OrmAutomaticIndexingListAssociationIT {
 		@Id
 		private Integer id;
 
-		@ManyToMany(mappedBy = "containedList")
+		@ManyToMany(mappedBy = "containedIndexedEmbedded")
 		@OrderBy("id asc") // Make sure the iteration order is predictable
-		private List<ContainingEntity> containingAsList = new ArrayList<>();
+		private List<ContainingEntity> containingAsIndexedEmbedded = new ArrayList<>();
 
-		@ManyToMany(mappedBy = "containedNonIndexedEmbeddedList")
+		@ManyToMany(mappedBy = "containedNonIndexedEmbedded")
 		@OrderBy("id asc") // Make sure the iteration order is predictable
-		private List<ContainingEntity> containingAsNonIndexedEmbeddedList = new ArrayList<>();
+		private List<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
 		@Basic
 		@Field
@@ -865,12 +256,12 @@ public class OrmAutomaticIndexingListAssociationIT {
 			this.id = id;
 		}
 
-		public List<ContainingEntity> getContainingAsList() {
-			return containingAsList;
+		public List<ContainingEntity> getContainingAsIndexedEmbedded() {
+			return containingAsIndexedEmbedded;
 		}
 
-		public List<ContainingEntity> getContainingAsNonIndexedEmbeddedList() {
-			return containingAsNonIndexedEmbeddedList;
+		public List<ContainingEntity> getContainingAsNonIndexedEmbedded() {
+			return containingAsNonIndexedEmbedded;
 		}
 
 		public String getIndexedField() {

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapKeysAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapKeysAssociationIT.java
@@ -22,12 +22,6 @@ import javax.persistence.MapKeyJoinColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.extractor.builtin.MapKeyExtractor;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.AssociationInverseSide;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.ContainerValueExtractorBeanReference;
@@ -35,16 +29,6 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Fiel
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.PropertyValue;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
-import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
-import org.hibernate.search.v6poc.util.impl.test.annotation.TestForIssue;
-import org.hibernate.service.ServiceRegistry;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
 /**
  * Test automatic indexing based on Hibernate ORM entity events.
@@ -52,715 +36,135 @@ import org.junit.Test;
  * This test only checks updates involving a multi-valued, Map keys association.
  * Other tests in the same package check more basic, direct updates or updates involving different associations.
  */
-public class OrmAutomaticIndexingMapKeysAssociationIT {
+public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomaticIndexingMultiAssociationIT<
+		OrmAutomaticIndexingMapKeysAssociationIT.IndexedEntity,
+		OrmAutomaticIndexingMapKeysAssociationIT.ContainingEntity,
+		OrmAutomaticIndexingMapKeysAssociationIT.ContainedEntity,
+		Map<OrmAutomaticIndexingMapKeysAssociationIT.ContainedEntity, String>,
+		List<OrmAutomaticIndexingMapKeysAssociationIT.ContainingEntity>
+		> {
 
-	private static final String PREFIX = SearchOrmSettings.PREFIX;
-
-	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
-
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
-		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
-				.applySetting( PREFIX + "backend.stubBackend.type", StubBackendFactory.class.getName() )
-				.applySetting( PREFIX + "index.default.backend", "stubBackend" );
-
-		ServiceRegistry serviceRegistry = registryBuilder.build();
-
-		MetadataSources ms = new MetadataSources( serviceRegistry )
-				.addAnnotatedClass( IndexedEntity.class )
-				.addAnnotatedClass( ContainedEntity.class );
-
-		Metadata metadata = ms.buildMetadata();
-
-		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
-
-		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
-				.objectField( "containedMapKeys", b2 -> b2
-						.field( "indexedField", String.class )
-				)
-				.objectField( "child", b3 -> b3
-						.objectField( "containedMapKeys", b2 -> b2
-								.field( "indexedField", String.class )
-						)
-				)
-		);
-
-		sessionFactory = sfb.build();
-		backendMock.verifyExpectationsMet();
+	public OrmAutomaticIndexingMapKeysAssociationIT() {
+		super( new MapKeysModelPrimitives() );
 	}
 
-	@After
-	public void cleanup() {
-		if ( sessionFactory != null ) {
-			sessionFactory.close();
+	private static class MapKeysModelPrimitives
+			implements ModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
+			Map<ContainedEntity, String>, List<ContainingEntity>> {
+
+		@Override
+		public String getIndexName() {
+			return IndexedEntity.INDEX;
 		}
-	}
 
-	@Test
-	public void directAssociationUpdate_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			entity1.getContainedMapKeys().put( containedEntity, "first" );
-			containedEntity.getContainingAsMapKeys().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedMapKeys", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a second value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			entity1.getContainedMapKeys().put( containedEntity, "second" );
-			containedEntity.getContainingAsMapKeys().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedMapKeys", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-							.objectField( "containedMapKeys", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = entity1.getContainedMapKeys().keySet().iterator().next();
-
-			containedEntity.getContainingAsMapKeys().clear();
-			entity1.getContainedMapKeys().keySet().remove( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedMapKeys", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing an IndexedEmbedded association in an indexed entity
-	 * does trigger reindexing of the entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void directAssociationReplace_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-			entity1.getContainedMapKeys().put( containedEntity, "first" );
-			containedEntity.getContainingAsMapKeys().add( entity1 );
-
-			session.persist( containedEntity );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "containedMapKeys", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			Map<ContainedEntity, String> newAssociation = new LinkedHashMap<>(
-					entity1.getContainedMapKeys()
-			);
-			newAssociation.put( containedEntity, "second" );
-			entity1.setContainedMapKeys( newAssociation );
-			containedEntity.getContainingAsMapKeys().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedMapKeys", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-							.objectField( "containedMapKeys", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void directAssociationUpdate_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			entity1.getContainedNonIndexedEmbeddedMapKeys().put( containedEntity, "first" );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a second value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			entity1.getContainedNonIndexedEmbeddedMapKeys().put( containedEntity, "second" );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = entity1.getContainedNonIndexedEmbeddedMapKeys().keySet().iterator().next();
-
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().clear();
-			entity1.getContainedNonIndexedEmbeddedMapKeys().keySet().remove( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing a non-IndexedEmbedded association in an entity
-	 * whose other properties are indexed
-	 * does not trigger reindexing of the entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3204")
-	public void directAssociationReplace_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-			entity1.getContainedNonIndexedEmbeddedMapKeys().put( containedEntity, "first" );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().add( entity1 );
-
-			session.persist( containedEntity );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			Map<ContainedEntity, String> newAssociation = new LinkedHashMap<>(
-					entity1.getContainedNonIndexedEmbeddedMapKeys()
-			);
-			newAssociation.put( containedEntity, "second" );
-			entity1.setContainedNonIndexedEmbeddedMapKeys( newAssociation );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// TODO HSEARCH-3204: remove the statement below to not expect any work
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectAssociationUpdate_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
-
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			containingEntity1.getContainedMapKeys().put( containedEntity, "first" );
-			containedEntity.getContainingAsMapKeys().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding another value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 5 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			containingEntity1.getContainedMapKeys().put( containedEntity, "second" );
-			containedEntity.getContainingAsMapKeys().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity deeplyNestedContainingEntity1 = session.get( ContainingEntity.class, 3 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 6 );
-			containedEntity.setIndexedField( "outOfScopeValue" );
-
-			deeplyNestedContainingEntity1.getContainedMapKeys().put( containedEntity, "outOfScopeValue" );
-			containedEntity.getContainingAsMapKeys().add( deeplyNestedContainingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = containingEntity1.getContainedMapKeys().keySet().iterator().next();
-
-			containedEntity.getContainingAsMapKeys().clear();
-			containingEntity1.getContainedMapKeys().remove( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing an IndexedEmbedded association in an entity
-	 * that is IndexedEmbedded in an indexed entity
-	 * does trigger reindexing of the indexed entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectAssociationReplace_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "firstValue" );
-			containingEntity1.getContainedMapKeys().put( containedEntity, "first" );
-			containedEntity.getContainingAsMapKeys().add( containingEntity1 );
-
-			session.persist( containedEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			Map<ContainedEntity, String> newAssociation = new LinkedHashMap<>(
-					containingEntity1.getContainedMapKeys()
-			);
-			newAssociation.put( containedEntity, "second" );
-			containingEntity1.setContainedMapKeys( newAssociation );
-			containedEntity.getContainingAsMapKeys().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectAssociationUpdate_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			containingEntity1.getContainedNonIndexedEmbeddedMapKeys().put( containedEntity, "first" );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding another value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 5 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			containingEntity1.getContainedNonIndexedEmbeddedMapKeys().put( containedEntity, "second" );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = containingEntity1.getContainedNonIndexedEmbeddedMapKeys()
-					.keySet().iterator().next();
-
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().clear();
-			containingEntity1.getContainedNonIndexedEmbeddedMapKeys().remove( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing a non-IndexedEmbedded association in an entity
-	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
-	 * does not trigger reindexing of the indexed entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3204")
-	public void indirectAssociationReplace_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "firstValue" );
-			containingEntity1.getContainedNonIndexedEmbeddedMapKeys().put( containedEntity, "first" );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().add( containingEntity1 );
-
-			session.persist( containedEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			Map<ContainedEntity, String> newAssociation = new LinkedHashMap<>(
-					containingEntity1.getContainedNonIndexedEmbeddedMapKeys()
-			);
-			newAssociation.put( containedEntity, "second" );
-			containingEntity1.setContainedNonIndexedEmbeddedMapKeys( newAssociation );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapKeys().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// TODO HSEARCH-3204: remove the statement below to not expect any work
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectValueUpdate() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
-
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.setIndexedField( "initialValue" );
-			containingEntity1.getContainedMapKeys().put( containedEntity1, "someValue" );
-			containedEntity1.getContainingAsMapKeys().add( containingEntity1 );
-
-			ContainedEntity containedEntity2 = new ContainedEntity();
-			containedEntity2.setId( 5 );
-			containedEntity2.setIndexedField( "initialOutOfScopeValue" );
-			deeplyNestedContainingEntity.getContainedMapKeys().put( containedEntity2, "someValue" );
-			containedEntity2.getContainingAsMapKeys().add( deeplyNestedContainingEntity );
-
-			session.persist( containedEntity1 );
-			session.persist( containedEntity2 );
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "initialValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.setIndexedField( "updatedValue" );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapKeys", b3 -> b3
-											.field( "indexedField", "updatedValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
-			containedEntity.setIndexedField( "updatedOutOfScopeValue" );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
+		@Override
+		public Class<IndexedEntity> getIndexedClass() {
+			return IndexedEntity.class;
+		}
+
+		@Override
+		public Class<ContainingEntity> getContainingClass() {
+			return ContainingEntity.class;
+		}
+
+		@Override
+		public Class<ContainedEntity> getContainedClass() {
+			return ContainedEntity.class;
+		}
+
+		@Override
+		public IndexedEntity newIndexed(int id) {
+			IndexedEntity entity = new IndexedEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public ContainingEntity newContaining(int id) {
+			ContainingEntity entity = new ContainingEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public ContainedEntity newContained(int id) {
+			ContainedEntity entity = new ContainedEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public void setIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setIndexedField( value );
+		}
+
+		@Override
+		public void setChild(ContainingEntity parent, ContainingEntity child) {
+			parent.setChild( child );
+		}
+
+		@Override
+		public void setParent(ContainingEntity child, ContainingEntity parent) {
+			child.setParent( parent );
+
+		}
+
+		@Override
+		public Map<ContainedEntity, String> newContainedAssociation(Map<ContainedEntity, String> original) {
+			return new LinkedHashMap<>( original );
+		}
+
+		@Override
+		public void addContained(Map<ContainedEntity, String> containedEntities, ContainedEntity containedEntity) {
+			containedEntities.put( containedEntity, containedEntity.getIndexedField() + "_value" );
+		}
+
+		@Override
+		public void removeContained(Map<ContainedEntity, String> containedEntities, ContainedEntity containedEntity) {
+			containedEntities.remove( containedEntity );
+		}
+
+		@Override
+		public void addContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
+			containingEntities.add( containingEntity );
+		}
+
+		@Override
+		public void removeContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
+			containingEntities.remove( containingEntity );
+		}
+
+		@Override
+		public Map<ContainedEntity, String> getContainedIndexedEmbedded(ContainingEntity containingEntity) {
+			return containingEntity.getContainedIndexedEmbedded();
+		}
+
+		@Override
+		public void setContainedIndexedEmbedded(ContainingEntity containingEntity,
+				Map<ContainedEntity, String> containedEntities) {
+			containingEntity.setContainedIndexedEmbedded( containedEntities );
+		}
+
+		@Override
+		public List<ContainingEntity> getContainingAsIndexedEmbedded(ContainedEntity containedEntity) {
+			return containedEntity.getContainingAsIndexedEmbedded();
+		}
+
+		@Override
+		public Map<ContainedEntity, String> getContainedNonIndexedEmbedded(ContainingEntity containingEntity) {
+			return containingEntity.getContainedNonIndexedEmbedded();
+		}
+
+		@Override
+		public void setContainedNonIndexedEmbedded(ContainingEntity containingEntity,
+				Map<ContainedEntity, String> containedEntities) {
+			containingEntity.setContainedNonIndexedEmbedded( containedEntities );
+		}
+
+		@Override
+		public List<ContainingEntity> getContainingAsNonIndexedEmbedded(ContainedEntity containedEntity) {
+			return containedEntity.getContainingAsNonIndexedEmbedded();
+		}
 	}
 
 	@Entity(name = "containing")
@@ -774,13 +178,13 @@ public class OrmAutomaticIndexingMapKeysAssociationIT {
 
 		@OneToOne(mappedBy = "parent")
 		@IndexedEmbedded(includePaths = {
-				"containedMapKeys.indexedField"
+				"containedIndexedEmbedded.indexedField"
 		})
 		private ContainingEntity child;
 
 		@ElementCollection
 		@JoinTable(
-				name = "indexed_mapkeys",
+				name = "indexed_containedIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "mapHolder")
 		)
 		@MapKeyJoinColumn(name = "key")
@@ -790,17 +194,17 @@ public class OrmAutomaticIndexingMapKeysAssociationIT {
 				includePaths = "indexedField",
 				extractors = @ContainerValueExtractorBeanReference( type = MapKeyExtractor.class )
 		)
-		private Map<ContainedEntity, String> containedMapKeys = new LinkedHashMap<>();
+		private Map<ContainedEntity, String> containedIndexedEmbedded = new LinkedHashMap<>();
 
 		@ElementCollection
 		@JoinTable(
-				name = "indexed_nonIndexedEmbeddedMapkeys",
+				name = "indexed_containedNonIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "mapHolder")
 		)
 		@MapKeyJoinColumn(name = "key")
 		@Column(name = "value")
 		@OrderBy("key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
-		private Map<ContainedEntity, String> containedNonIndexedEmbeddedMapKeys = new LinkedHashMap<>();
+		private Map<ContainedEntity, String> containedNonIndexedEmbedded = new LinkedHashMap<>();
 
 		public Integer getId() {
 			return id;
@@ -826,21 +230,21 @@ public class OrmAutomaticIndexingMapKeysAssociationIT {
 			this.child = child;
 		}
 
-		public Map<ContainedEntity, String> getContainedMapKeys() {
-			return containedMapKeys;
+		public Map<ContainedEntity, String> getContainedIndexedEmbedded() {
+			return containedIndexedEmbedded;
 		}
 
-		public void setContainedMapKeys(Map<ContainedEntity, String> containedMapKeys) {
-			this.containedMapKeys = containedMapKeys;
+		public void setContainedIndexedEmbedded(Map<ContainedEntity, String> containedIndexedEmbedded) {
+			this.containedIndexedEmbedded = containedIndexedEmbedded;
 		}
 
-		public Map<ContainedEntity, String> getContainedNonIndexedEmbeddedMapKeys() {
-			return containedNonIndexedEmbeddedMapKeys;
+		public Map<ContainedEntity, String> getContainedNonIndexedEmbedded() {
+			return containedNonIndexedEmbedded;
 		}
 
-		public void setContainedNonIndexedEmbeddedMapKeys(
-				Map<ContainedEntity, String> containedNonIndexedEmbeddedMapKeys) {
-			this.containedNonIndexedEmbeddedMapKeys = containedNonIndexedEmbeddedMapKeys;
+		public void setContainedNonIndexedEmbedded(
+				Map<ContainedEntity, String> containedNonIndexedEmbedded) {
+			this.containedNonIndexedEmbedded = containedNonIndexedEmbedded;
 		}
 	}
 
@@ -868,11 +272,11 @@ public class OrmAutomaticIndexingMapKeysAssociationIT {
 		@OrderBy("id asc") // Make sure the iteration order is predictable
 		@AssociationInverseSide(
 				inversePath = @PropertyValue(
-						propertyName = "containedMapKeys",
+						propertyName = "containedIndexedEmbedded",
 						extractors = @ContainerValueExtractorBeanReference(type = MapKeyExtractor.class)
 				)
 		)
-		private List<ContainingEntity> containingAsMapKeys = new ArrayList<>();
+		private List<ContainingEntity> containingAsIndexedEmbedded = new ArrayList<>();
 
 		/*
 		 * No mappedBy here, same reasons as above.
@@ -880,7 +284,7 @@ public class OrmAutomaticIndexingMapKeysAssociationIT {
 		@ManyToMany
 		@JoinTable(name = "contained_nonIndexedMapHolder")
 		@OrderBy("id asc") // Make sure the iteration order is predictable
-		private List<ContainingEntity> containingAsNonIndexedEmbeddedMapKeys = new ArrayList<>();
+		private List<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
 		@Basic
 		@Field
@@ -894,12 +298,12 @@ public class OrmAutomaticIndexingMapKeysAssociationIT {
 			this.id = id;
 		}
 
-		public List<ContainingEntity> getContainingAsMapKeys() {
-			return containingAsMapKeys;
+		public List<ContainingEntity> getContainingAsIndexedEmbedded() {
+			return containingAsIndexedEmbedded;
 		}
 
-		public List<ContainingEntity> getContainingAsNonIndexedEmbeddedMapKeys() {
-			return containingAsNonIndexedEmbeddedMapKeys;
+		public List<ContainingEntity> getContainingAsNonIndexedEmbedded() {
+			return containingAsNonIndexedEmbedded;
 		}
 
 		public String getIndexedField() {

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapValuesAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapValuesAssociationIT.java
@@ -20,25 +20,9 @@ import javax.persistence.MapKeyColumn;
 import javax.persistence.OneToOne;
 import javax.persistence.OrderBy;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
-import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
-import org.hibernate.search.v6poc.util.impl.test.annotation.TestForIssue;
-import org.hibernate.service.ServiceRegistry;
-
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
 
 /**
  * Test automatic indexing based on Hibernate ORM entity events.
@@ -46,714 +30,135 @@ import org.junit.Test;
  * This test only checks updates involving a multi-valued, Map values association.
  * Other tests in the same package check more basic, direct updates or updates involving different associations.
  */
-public class OrmAutomaticIndexingMapValuesAssociationIT {
+public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutomaticIndexingMultiAssociationIT<
+		OrmAutomaticIndexingMapValuesAssociationIT.IndexedEntity,
+		OrmAutomaticIndexingMapValuesAssociationIT.ContainingEntity,
+		OrmAutomaticIndexingMapValuesAssociationIT.ContainedEntity,
+		Map<String, OrmAutomaticIndexingMapValuesAssociationIT.ContainedEntity>,
+		List<OrmAutomaticIndexingMapValuesAssociationIT.ContainingEntity>
+		> {
 
-	private static final String PREFIX = SearchOrmSettings.PREFIX;
-
-	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
-
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
-		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
-				.applySetting( PREFIX + "backend.stubBackend.type", StubBackendFactory.class.getName() )
-				.applySetting( PREFIX + "index.default.backend", "stubBackend" );
-
-		ServiceRegistry serviceRegistry = registryBuilder.build();
-
-		MetadataSources ms = new MetadataSources( serviceRegistry )
-				.addAnnotatedClass( IndexedEntity.class )
-				.addAnnotatedClass( ContainedEntity.class );
-
-		Metadata metadata = ms.buildMetadata();
-
-		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
-
-		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
-				.objectField( "containedMapValues", b2 -> b2
-						.field( "indexedField", String.class )
-				)
-				.objectField( "child", b3 -> b3
-						.objectField( "containedMapValues", b2 -> b2
-								.field( "indexedField", String.class )
-						)
-				)
-		);
-
-		sessionFactory = sfb.build();
-		backendMock.verifyExpectationsMet();
+	public OrmAutomaticIndexingMapValuesAssociationIT() {
+		super( new MapValuesModelPrimitives() );
 	}
 
-	@After
-	public void cleanup() {
-		if ( sessionFactory != null ) {
-			sessionFactory.close();
+	private static class MapValuesModelPrimitives
+			implements ModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
+			Map<String, ContainedEntity>, List<ContainingEntity>> {
+
+		@Override
+		public String getIndexName() {
+			return IndexedEntity.INDEX;
 		}
-	}
 
-	@Test
-	public void directAssociationUpdate_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			entity1.getContainedMapValues().put( "first", containedEntity );
-			containedEntity.getContainingAsMapValues().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedMapValues", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a second value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			entity1.getContainedMapValues().put( "second", containedEntity );
-			containedEntity.getContainingAsMapValues().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedMapValues", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-							.objectField( "containedMapValues", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = entity1.getContainedMapValues().get( "first" );
-
-			containedEntity.getContainingAsMapValues().clear();
-			entity1.getContainedMapValues().values().remove( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedMapValues", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing an IndexedEmbedded association in an indexed entity
-	 * does trigger reindexing of the entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void directAssociationReplace_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-			entity1.getContainedMapValues().put( "first", containedEntity );
-			containedEntity.getContainingAsMapValues().add( entity1 );
-
-			session.persist( containedEntity );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "containedMapValues", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			Map<String, ContainedEntity> newAssociation = new LinkedHashMap<>(
-					entity1.getContainedMapValues()
-			);
-			newAssociation.put( "second", containedEntity );
-			entity1.setContainedMapValues( newAssociation );
-			containedEntity.getContainingAsMapValues().add( entity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "containedMapValues", b2 -> b2
-									.field( "indexedField", "firstValue" )
-							)
-							.objectField( "containedMapValues", b2 -> b2
-									.field( "indexedField", "secondValue" )
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void directAssociationUpdate_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			entity1.getContainedNonIndexedEmbeddedMapValues().put( "first", containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a second value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			entity1.getContainedNonIndexedEmbeddedMapValues().put( "second", containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = entity1.getContainedNonIndexedEmbeddedMapValues().get( "first" );
-
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().clear();
-			entity1.getContainedNonIndexedEmbeddedMapValues().values().remove( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing a non-IndexedEmbedded association in an entity
-	 * whose other properties are indexed
-	 * does not trigger reindexing of the entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3204")
-	public void directAssociationReplace_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 2 );
-			containedEntity.setIndexedField( "firstValue" );
-			entity1.getContainedNonIndexedEmbeddedMapValues().put( "first", containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().add( entity1 );
-
-			session.persist( containedEntity );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			Map<String, ContainedEntity> newAssociation = new LinkedHashMap<>(
-					entity1.getContainedNonIndexedEmbeddedMapValues()
-			);
-			newAssociation.put( "second", containedEntity );
-			entity1.setContainedNonIndexedEmbeddedMapValues( newAssociation );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().add( entity1 );
-
-			session.persist( containedEntity );
-
-			// TODO HSEARCH-3204: remove the statement below to not expect any work
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> { } )
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectAssociationUpdate_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
-
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			containingEntity1.getContainedMapValues().put( "first", containedEntity );
-			containedEntity.getContainingAsMapValues().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding another value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 5 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			containingEntity1.getContainedMapValues().put( "second", containedEntity );
-			containedEntity.getContainingAsMapValues().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity deeplyNestedContainingEntity1 = session.get( ContainingEntity.class, 3 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 6 );
-			containedEntity.setIndexedField( "outOfScopeValue" );
-
-			deeplyNestedContainingEntity1.getContainedMapValues().put( "outOfScopeKey", containedEntity );
-			containedEntity.getContainingAsMapValues().add( deeplyNestedContainingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = containingEntity1.getContainedMapValues().get( "first" );
-
-			containedEntity.getContainingAsMapValues().clear();
-			containingEntity1.getContainedMapValues().values().remove( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing an IndexedEmbedded association in an entity
-	 * that is IndexedEmbedded in an indexed entity
-	 * does trigger reindexing of the indexed entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectAssociationReplace_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "firstValue" );
-			containingEntity1.getContainedMapValues().put( "first", containedEntity );
-			containedEntity.getContainingAsMapValues().add( containingEntity1 );
-
-			session.persist( containedEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			Map<String, ContainedEntity> newAssociation = new LinkedHashMap<>(
-					containingEntity1.getContainedMapValues()
-			);
-			newAssociation.put( "second", containedEntity );
-			containingEntity1.setContainedMapValues( newAssociation );
-			containedEntity.getContainingAsMapValues().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "firstValue" )
-									)
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "secondValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectAssociationUpdate_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "firstValue" );
-
-			containingEntity1.getContainedNonIndexedEmbeddedMapValues().put( "first", containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding another value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 5 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			containingEntity1.getContainedNonIndexedEmbeddedMapValues().put( "second", containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = containingEntity1.getContainedNonIndexedEmbeddedMapValues().get( "first" );
-
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().clear();
-			containingEntity1.getContainedNonIndexedEmbeddedMapValues().values().remove( containedEntity );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing a non-IndexedEmbedded association in an entity
-	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
-	 * does not trigger reindexing of the indexed entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3204")
-	public void indirectAssociationReplace_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 3 );
-			containedEntity.setIndexedField( "firstValue" );
-			containingEntity1.getContainedNonIndexedEmbeddedMapValues().put( "first", containedEntity );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().add( containingEntity1 );
-
-			session.persist( containedEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
-
-			ContainedEntity containedEntity = new ContainedEntity();
-			containedEntity.setId( 4 );
-			containedEntity.setIndexedField( "secondValue" );
-
-			Map<String, ContainedEntity> newAssociation = new LinkedHashMap<>(
-					containingEntity1.getContainedNonIndexedEmbeddedMapValues()
-			);
-			newAssociation.put( "second", containedEntity );
-			containingEntity1.setContainedNonIndexedEmbeddedMapValues( newAssociation );
-			containedEntity.getContainingAsNonIndexedEmbeddedMapValues().add( containingEntity1 );
-
-			session.persist( containedEntity );
-
-			// TODO HSEARCH-3204: remove the statement below to not expect any work
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> { } )
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectValueUpdate() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
-
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.setIndexedField( "initialValue" );
-			containingEntity1.getContainedMapValues().put( "someKey", containedEntity1 );
-			containedEntity1.getContainingAsMapValues().add( containingEntity1 );
-
-			ContainedEntity containedEntity2 = new ContainedEntity();
-			containedEntity2.setId( 5 );
-			containedEntity2.setIndexedField( "initialOutOfScopeValue" );
-			deeplyNestedContainingEntity.getContainedMapValues().put( "someKey", containedEntity2 );
-			containedEntity2.getContainingAsMapValues().add( deeplyNestedContainingEntity );
-
-			session.persist( containedEntity1 );
-			session.persist( containedEntity2 );
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "initialValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.setIndexedField( "updatedValue" );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedMapValues", b3 -> b3
-											.field( "indexedField", "updatedValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
-			containedEntity.setIndexedField( "updatedOutOfScopeValue" );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
+		@Override
+		public Class<IndexedEntity> getIndexedClass() {
+			return IndexedEntity.class;
+		}
+
+		@Override
+		public Class<ContainingEntity> getContainingClass() {
+			return ContainingEntity.class;
+		}
+
+		@Override
+		public Class<ContainedEntity> getContainedClass() {
+			return ContainedEntity.class;
+		}
+
+		@Override
+		public IndexedEntity newIndexed(int id) {
+			IndexedEntity entity = new IndexedEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public ContainingEntity newContaining(int id) {
+			ContainingEntity entity = new ContainingEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public ContainedEntity newContained(int id) {
+			ContainedEntity entity = new ContainedEntity();
+			entity.setId( id );
+			return entity;
+		}
+
+		@Override
+		public void setIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setIndexedField( value );
+		}
+
+		@Override
+		public void setChild(ContainingEntity parent, ContainingEntity child) {
+			parent.setChild( child );
+		}
+
+		@Override
+		public void setParent(ContainingEntity child, ContainingEntity parent) {
+			child.setParent( parent );
+
+		}
+
+		@Override
+		public Map<String, ContainedEntity> newContainedAssociation(Map<String, ContainedEntity> original) {
+			return new LinkedHashMap<>( original );
+		}
+
+		@Override
+		public void addContained(Map<String, ContainedEntity> containedEntities, ContainedEntity containedEntity) {
+			containedEntities.put( containedEntity.getIndexedField() + "_key", containedEntity );
+		}
+
+		@Override
+		public void removeContained(Map<String, ContainedEntity> containedEntities, ContainedEntity containedEntity) {
+			containedEntities.remove( containedEntity.getIndexedField() + "_key" );
+		}
+
+		@Override
+		public void addContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
+			containingEntities.add( containingEntity );
+		}
+
+		@Override
+		public void removeContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
+			containingEntities.remove( containingEntity );
+		}
+
+		@Override
+		public Map<String, ContainedEntity> getContainedIndexedEmbedded(ContainingEntity containingEntity) {
+			return containingEntity.getContainedIndexedEmbedded();
+		}
+
+		@Override
+		public void setContainedIndexedEmbedded(ContainingEntity containingEntity,
+				Map<String, ContainedEntity> containedEntities) {
+			containingEntity.setContainedIndexedEmbedded( containedEntities );
+		}
+
+		@Override
+		public List<ContainingEntity> getContainingAsIndexedEmbedded(ContainedEntity containedEntity) {
+			return containedEntity.getContainingAsIndexedEmbedded();
+		}
+
+		@Override
+		public Map<String, ContainedEntity> getContainedNonIndexedEmbedded(ContainingEntity containingEntity) {
+			return containingEntity.getContainedNonIndexedEmbedded();
+		}
+
+		@Override
+		public void setContainedNonIndexedEmbedded(ContainingEntity containingEntity,
+				Map<String, ContainedEntity> containedEntities) {
+			containingEntity.setContainedNonIndexedEmbedded( containedEntities );
+		}
+
+		@Override
+		public List<ContainingEntity> getContainingAsNonIndexedEmbedded(ContainedEntity containedEntity) {
+			return containedEntity.getContainingAsNonIndexedEmbedded();
+		}
 	}
 
 	@Entity(name = "containing")
@@ -767,30 +172,30 @@ public class OrmAutomaticIndexingMapValuesAssociationIT {
 
 		@OneToOne(mappedBy = "parent")
 		@IndexedEmbedded(includePaths = {
-				"containedMapValues.indexedField"
+				"containedIndexedEmbedded.indexedField"
 		})
 		private ContainingEntity child;
 
 		@ManyToMany
 		@JoinTable(
-				name = "indexed_mapvals",
+				name = "indexed_containedIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "mapHolder"),
 				inverseJoinColumns = @JoinColumn(name = "value")
 		)
 		@MapKeyColumn(name = "key")
 		@IndexedEmbedded(includePaths = "indexedField")
 		@OrderBy("id asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
-		private Map<String, ContainedEntity> containedMapValues = new LinkedHashMap<>();
+		private Map<String, ContainedEntity> containedIndexedEmbedded = new LinkedHashMap<>();
 
 		@ManyToMany
 		@JoinTable(
-				name = "indexed_nonIndexedEmbeddedMapvals",
+				name = "indexed_containedNonIndexedEmbedded",
 				joinColumns = @JoinColumn(name = "mapHolder"),
 				inverseJoinColumns = @JoinColumn(name = "value")
 		)
 		@MapKeyColumn(name = "key")
 		@OrderBy("id asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
-		private Map<String, ContainedEntity> containedNonIndexedEmbeddedMapValues = new LinkedHashMap<>();
+		private Map<String, ContainedEntity> containedNonIndexedEmbedded = new LinkedHashMap<>();
 
 		public Integer getId() {
 			return id;
@@ -816,21 +221,21 @@ public class OrmAutomaticIndexingMapValuesAssociationIT {
 			this.child = child;
 		}
 
-		public Map<String, ContainedEntity> getContainedMapValues() {
-			return containedMapValues;
+		public Map<String, ContainedEntity> getContainedIndexedEmbedded() {
+			return containedIndexedEmbedded;
 		}
 
-		public void setContainedMapValues(Map<String, ContainedEntity> containedMapValues) {
-			this.containedMapValues = containedMapValues;
+		public void setContainedIndexedEmbedded(Map<String, ContainedEntity> containedIndexedEmbedded) {
+			this.containedIndexedEmbedded = containedIndexedEmbedded;
 		}
 
-		public Map<String, ContainedEntity> getContainedNonIndexedEmbeddedMapValues() {
-			return containedNonIndexedEmbeddedMapValues;
+		public Map<String, ContainedEntity> getContainedNonIndexedEmbedded() {
+			return containedNonIndexedEmbedded;
 		}
 
-		public void setContainedNonIndexedEmbeddedMapValues(
-				Map<String, ContainedEntity> containedNonIndexedEmbeddedMapValues) {
-			this.containedNonIndexedEmbeddedMapValues = containedNonIndexedEmbeddedMapValues;
+		public void setContainedNonIndexedEmbedded(
+				Map<String, ContainedEntity> containedNonIndexedEmbedded) {
+			this.containedNonIndexedEmbedded = containedNonIndexedEmbedded;
 		}
 	}
 
@@ -848,13 +253,13 @@ public class OrmAutomaticIndexingMapValuesAssociationIT {
 		@Id
 		private Integer id;
 
-		@ManyToMany(mappedBy = "containedMapValues")
+		@ManyToMany(mappedBy = "containedIndexedEmbedded")
 		@OrderBy("id asc") // Make sure the iteration order is predictable
-		private List<ContainingEntity> containingAsMapValues = new ArrayList<>();
+		private List<ContainingEntity> containingAsIndexedEmbedded = new ArrayList<>();
 
-		@ManyToMany(mappedBy = "containedMapValues")
+		@ManyToMany(mappedBy = "containedNonIndexedEmbedded")
 		@OrderBy("id asc") // Make sure the iteration order is predictable
-		private List<ContainingEntity> containingAsNonIndexedEmbeddedMapValues = new ArrayList<>();
+		private List<ContainingEntity> containingAsNonIndexedEmbedded = new ArrayList<>();
 
 		@Basic
 		@Field
@@ -868,12 +273,12 @@ public class OrmAutomaticIndexingMapValuesAssociationIT {
 			this.id = id;
 		}
 
-		public List<ContainingEntity> getContainingAsMapValues() {
-			return containingAsMapValues;
+		public List<ContainingEntity> getContainingAsIndexedEmbedded() {
+			return containingAsIndexedEmbedded;
 		}
 
-		public List<ContainingEntity> getContainingAsNonIndexedEmbeddedMapValues() {
-			return containingAsNonIndexedEmbeddedMapValues;
+		public List<ContainingEntity> getContainingAsNonIndexedEmbedded() {
+			return containingAsNonIndexedEmbedded;
 		}
 
 		public String getIndexedField() {

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingSingleAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingSingleAssociationIT.java
@@ -67,12 +67,12 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
 
 		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
-				.objectField( "containedSingle", b2 -> b2
+				.objectField( "containedIndexedEmbedded", b2 -> b2
 						.field( "indexedField", String.class )
 						.field( "indexedElementCollectionField", String.class )
 				)
 				.objectField( "child", b3 -> b3
-						.objectField( "containedSingle", b2 -> b2
+						.objectField( "containedIndexedEmbedded", b2 -> b2
 								.field( "indexedField", String.class )
 								.field( "indexedElementCollectionField", String.class )
 						)
@@ -112,14 +112,14 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 2 );
 			containedEntity.setIndexedField( "initialValue" );
 
-			entity1.setContainedSingle( containedEntity );
-			containedEntity.setContainingAsSingle( entity1 );
+			entity1.setContainedIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsIndexedEmbedded( entity1 );
 
 			session.persist( containedEntity );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
-							.objectField( "containedSingle", b2 -> b2
+							.objectField( "containedIndexedEmbedded", b2 -> b2
 									.field( "indexedField", "initialValue" )
 							)
 					)
@@ -135,15 +135,15 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 3 );
 			containedEntity.setIndexedField( "updatedValue" );
 
-			entity1.getContainedSingle().setContainingAsSingle( null );
-			entity1.setContainedSingle( containedEntity );
-			containedEntity.setContainingAsSingle( entity1 );
+			entity1.getContainedIndexedEmbedded().setContainingAsIndexedEmbedded( null );
+			entity1.setContainedIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsIndexedEmbedded( entity1 );
 
 			session.persist( containedEntity );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
-							.objectField( "containedSingle", b2 -> b2
+							.objectField( "containedIndexedEmbedded", b2 -> b2
 									.field( "indexedField", "updatedValue" )
 							)
 					)
@@ -155,8 +155,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
-			entity1.getContainedSingle().setContainingAsSingle( null );
-			entity1.setContainedSingle( null );
+			entity1.getContainedIndexedEmbedded().setContainingAsIndexedEmbedded( null );
+			entity1.setContainedIndexedEmbedded( null );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> { } )
@@ -193,8 +193,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 2 );
 			containedEntity.setNonIndexedField( "initialValue" );
 
-			entity1.setContainedNonIndexedEmbeddedSingle( containedEntity );
-			containedEntity.setContainingAsNonIndexedEmbeddedSingle( entity1 );
+			entity1.setContainedNonIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsNonIndexedEmbedded( entity1 );
 
 			session.persist( containedEntity );
 
@@ -210,9 +210,9 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 3 );
 			containedEntity.setNonIndexedField( "updatedValue" );
 
-			entity1.getContainedNonIndexedEmbeddedSingle().setContainingAsNonIndexedEmbeddedSingle( null );
-			entity1.setContainedNonIndexedEmbeddedSingle( containedEntity );
-			containedEntity.setContainingAsNonIndexedEmbeddedSingle( entity1 );
+			entity1.getContainedNonIndexedEmbedded().setContainingAsNonIndexedEmbedded( null );
+			entity1.setContainedNonIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsNonIndexedEmbedded( entity1 );
 
 			session.persist( containedEntity );
 
@@ -224,8 +224,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			IndexedEntity entity1 = session.get( IndexedEntity.class, 1 );
 
-			entity1.getContainedNonIndexedEmbeddedSingle().setContainingAsNonIndexedEmbeddedSingle( null );
-			entity1.setContainedNonIndexedEmbeddedSingle( null );
+			entity1.getContainedNonIndexedEmbedded().setContainingAsNonIndexedEmbedded( null );
+			entity1.setContainedNonIndexedEmbedded( null );
 
 			// Do not expect any work
 		} );
@@ -268,15 +268,15 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 4 );
 			containedEntity.setIndexedField( "initialValue" );
 
-			containingEntity1.setContainedSingle( containedEntity );
-			containedEntity.setContainingAsSingle( containingEntity1 );
+			containingEntity1.setContainedIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsIndexedEmbedded( containingEntity1 );
 
 			session.persist( containedEntity );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", "initialValue" )
 									)
 							)
@@ -293,16 +293,16 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 5 );
 			containedEntity.setIndexedField( "updatedValue" );
 
-			containingEntity1.getContainedSingle().setContainingAsSingle( null );
-			containingEntity1.setContainedSingle( containedEntity );
-			containedEntity.setContainingAsSingle( containingEntity1 );
+			containingEntity1.getContainedIndexedEmbedded().setContainingAsIndexedEmbedded( null );
+			containingEntity1.setContainedIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsIndexedEmbedded( containingEntity1 );
 
 			session.persist( containedEntity );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", "updatedValue" )
 									)
 							)
@@ -319,8 +319,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 6 );
 			containedEntity.setIndexedField( "outOfScopeValue" );
 
-			deeplyNestedContainingEntity1.setContainedSingle( containedEntity );
-			containedEntity.setContainingAsSingle( deeplyNestedContainingEntity1 );
+			deeplyNestedContainingEntity1.setContainedIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsIndexedEmbedded( deeplyNestedContainingEntity1 );
 
 			session.persist( containedEntity );
 
@@ -332,8 +332,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
 
-			containingEntity1.getContainedSingle().setContainingAsSingle( null );
-			containingEntity1.setContainedSingle( null );
+			containingEntity1.getContainedIndexedEmbedded().setContainingAsIndexedEmbedded( null );
+			containingEntity1.setContainedIndexedEmbedded( null );
 
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
@@ -380,8 +380,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 4 );
 			containedEntity.setIndexedField( "initialValue" );
 
-			containingEntity1.setContainedNonIndexedEmbeddedSingle( containedEntity );
-			containedEntity.setContainingAsNonIndexedEmbeddedSingle( containingEntity1 );
+			containingEntity1.setContainedNonIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsNonIndexedEmbedded( containingEntity1 );
 
 			session.persist( containedEntity );
 
@@ -397,9 +397,9 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			containedEntity.setId( 5 );
 			containedEntity.setIndexedField( "updatedValue" );
 
-			containingEntity1.getContainedNonIndexedEmbeddedSingle().setContainingAsNonIndexedEmbeddedSingle( null );
-			containingEntity1.setContainedNonIndexedEmbeddedSingle( containedEntity );
-			containedEntity.setContainingAsNonIndexedEmbeddedSingle( containingEntity1 );
+			containingEntity1.getContainedNonIndexedEmbedded().setContainingAsNonIndexedEmbedded( null );
+			containingEntity1.setContainedNonIndexedEmbedded( containedEntity );
+			containedEntity.setContainingAsNonIndexedEmbedded( containingEntity1 );
 
 			session.persist( containedEntity );
 
@@ -411,8 +411,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			ContainingEntity containingEntity1 = session.get( ContainingEntity.class, 2 );
 
-			containingEntity1.getContainedNonIndexedEmbeddedSingle().setContainingAsNonIndexedEmbeddedSingle( null );
-			containingEntity1.setContainedNonIndexedEmbeddedSingle( null );
+			containingEntity1.getContainedNonIndexedEmbedded().setContainingAsNonIndexedEmbedded( null );
+			containingEntity1.setContainedNonIndexedEmbedded( null );
 
 			// Do not expect any work
 		} );
@@ -438,14 +438,14 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			ContainedEntity containedEntity1 = new ContainedEntity();
 			containedEntity1.setId( 4 );
 			containedEntity1.setIndexedField( "initialValue" );
-			containingEntity1.setContainedSingle( containedEntity1 );
-			containedEntity1.setContainingAsSingle( containingEntity1 );
+			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
+			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
 
 			ContainedEntity containedEntity2 = new ContainedEntity();
 			containedEntity2.setId( 5 );
 			containedEntity2.setIndexedField( "initialOutOfScopeValue" );
-			deeplyNestedContainingEntity.setContainedSingle( containedEntity2 );
-			containedEntity2.setContainingAsSingle( deeplyNestedContainingEntity );
+			deeplyNestedContainingEntity.setContainedIndexedEmbedded( containedEntity2 );
+			containedEntity2.setContainingAsIndexedEmbedded( deeplyNestedContainingEntity );
 
 			session.persist( containedEntity1 );
 			session.persist( containedEntity2 );
@@ -456,7 +456,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", "initialValue" )
 									)
 							)
@@ -473,7 +473,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", "updatedValue" )
 									)
 							)
@@ -512,8 +512,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			ContainedEntity containedEntity1 = new ContainedEntity();
 			containedEntity1.setId( 4 );
 			containedEntity1.setIndexedField( "initialValue" );
-			containingEntity1.setContainedSingle( containedEntity1 );
-			containedEntity1.setContainingAsSingle( containingEntity1 );
+			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
+			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
 
 			session.persist( containedEntity1 );
 			session.persist( containingEntity1 );
@@ -522,7 +522,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", "initialValue" )
 									)
 							)
@@ -560,14 +560,14 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			ContainedEntity containedEntity1 = new ContainedEntity();
 			containedEntity1.setId( 4 );
 			containedEntity1.getIndexedElementCollectionField().add( "firstValue" );
-			containingEntity1.setContainedSingle( containedEntity1 );
-			containedEntity1.setContainingAsSingle( containingEntity1 );
+			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
+			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
 
 			ContainedEntity containedEntity2 = new ContainedEntity();
 			containedEntity2.setId( 5 );
 			containedEntity2.getIndexedElementCollectionField().add( "firstOutOfScopeValue" );
-			deeplyNestedContainingEntity.setContainedSingle( containedEntity2 );
-			containedEntity2.setContainingAsSingle( deeplyNestedContainingEntity );
+			deeplyNestedContainingEntity.setContainedIndexedEmbedded( containedEntity2 );
+			containedEntity2.setContainingAsIndexedEmbedded( deeplyNestedContainingEntity );
 
 			session.persist( containedEntity1 );
 			session.persist( containedEntity2 );
@@ -578,7 +578,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", null )
 											.field(
 													"indexedElementCollectionField",
@@ -599,7 +599,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", null )
 											.field(
 													"indexedElementCollectionField",
@@ -620,7 +620,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", null )
 											.field(
 													"indexedElementCollectionField",
@@ -671,14 +671,14 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			ContainedEntity containedEntity1 = new ContainedEntity();
 			containedEntity1.setId( 4 );
 			containedEntity1.getIndexedElementCollectionField().add( "firstValue" );
-			containingEntity1.setContainedSingle( containedEntity1 );
-			containedEntity1.setContainingAsSingle( containingEntity1 );
+			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
+			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
 
 			ContainedEntity containedEntity2 = new ContainedEntity();
 			containedEntity2.setId( 5 );
 			containedEntity2.getIndexedElementCollectionField().add( "firstOutOfScopeValue" );
-			deeplyNestedContainingEntity.setContainedSingle( containedEntity2 );
-			containedEntity2.setContainingAsSingle( deeplyNestedContainingEntity );
+			deeplyNestedContainingEntity.setContainedIndexedEmbedded( containedEntity2 );
+			containedEntity2.setContainingAsIndexedEmbedded( deeplyNestedContainingEntity );
 
 			session.persist( containedEntity1 );
 			session.persist( containedEntity2 );
@@ -689,7 +689,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", null )
 											.field(
 													"indexedElementCollectionField",
@@ -712,7 +712,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", null )
 											.field(
 													"indexedElementCollectionField",
@@ -757,8 +757,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			ContainedEntity containedEntity1 = new ContainedEntity();
 			containedEntity1.setId( 4 );
 			containedEntity1.getIndexedElementCollectionField().add( "firstValue" );
-			containingEntity1.setContainedSingle( containedEntity1 );
-			containedEntity1.setContainingAsSingle( containingEntity1 );
+			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
+			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
 
 			session.persist( containedEntity1 );
 			session.persist( containingEntity1 );
@@ -767,7 +767,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", null )
 											.field(
 													"indexedElementCollectionField",
@@ -822,8 +822,8 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			ContainedEntity containedEntity1 = new ContainedEntity();
 			containedEntity1.setId( 4 );
 			containedEntity1.getNonIndexedElementCollectionField().add( "firstValue" );
-			containingEntity1.setContainedSingle( containedEntity1 );
-			containedEntity1.setContainingAsSingle( containingEntity1 );
+			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
+			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
 
 			session.persist( containedEntity1 );
 			session.persist( containingEntity1 );
@@ -832,7 +832,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.add( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", null )
 									)
 							)
@@ -852,7 +852,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			backendMock.expectWorks( IndexedEntity.INDEX )
 					.update( "1", b -> b
 							.objectField( "child", b2 -> b2
-									.objectField( "containedSingle", b3 -> b3
+									.objectField( "containedIndexedEmbedded", b3 -> b3
 											.field( "indexedField", null )
 									)
 							)
@@ -873,17 +873,17 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 
 		@OneToOne(mappedBy = "parent")
 		@IndexedEmbedded(includePaths = {
-				"containedSingle.indexedField",
-				"containedSingle.indexedElementCollectionField"
+				"containedIndexedEmbedded.indexedField",
+				"containedIndexedEmbedded.indexedElementCollectionField"
 		})
 		private ContainingEntity child;
 
 		@OneToOne
 		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField" })
-		private ContainedEntity containedSingle;
+		private ContainedEntity containedIndexedEmbedded;
 
 		@OneToOne
-		private ContainedEntity containedNonIndexedEmbeddedSingle;
+		private ContainedEntity containedNonIndexedEmbedded;
 
 		public Integer getId() {
 			return id;
@@ -909,20 +909,20 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			this.child = child;
 		}
 
-		public ContainedEntity getContainedSingle() {
-			return containedSingle;
+		public ContainedEntity getContainedIndexedEmbedded() {
+			return containedIndexedEmbedded;
 		}
 
-		public void setContainedSingle(ContainedEntity containedSingle) {
-			this.containedSingle = containedSingle;
+		public void setContainedIndexedEmbedded(ContainedEntity containedIndexedEmbedded) {
+			this.containedIndexedEmbedded = containedIndexedEmbedded;
 		}
 
-		public ContainedEntity getContainedNonIndexedEmbeddedSingle() {
-			return containedNonIndexedEmbeddedSingle;
+		public ContainedEntity getContainedNonIndexedEmbedded() {
+			return containedNonIndexedEmbedded;
 		}
 
-		public void setContainedNonIndexedEmbeddedSingle(ContainedEntity containedNonIndexedEmbeddedSingle) {
-			this.containedNonIndexedEmbeddedSingle = containedNonIndexedEmbeddedSingle;
+		public void setContainedNonIndexedEmbedded(ContainedEntity containedNonIndexedEmbedded) {
+			this.containedNonIndexedEmbedded = containedNonIndexedEmbedded;
 		}
 	}
 
@@ -940,11 +940,11 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 		@Id
 		private Integer id;
 
-		@OneToOne(mappedBy = "containedSingle")
-		private ContainingEntity containingAsSingle;
+		@OneToOne(mappedBy = "containedIndexedEmbedded")
+		private ContainingEntity containingAsIndexedEmbedded;
 
-		@OneToOne(mappedBy = "containedNonIndexedEmbeddedSingle")
-		private ContainingEntity containingAsNonIndexedEmbeddedSingle;
+		@OneToOne(mappedBy = "containedNonIndexedEmbedded")
+		private ContainingEntity containingAsNonIndexedEmbedded;
 
 		@Basic
 		@Field
@@ -970,20 +970,20 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			this.id = id;
 		}
 
-		public ContainingEntity getContainingAsSingle() {
-			return containingAsSingle;
+		public ContainingEntity getContainingAsIndexedEmbedded() {
+			return containingAsIndexedEmbedded;
 		}
 
-		public void setContainingAsSingle(ContainingEntity containingAsSingle) {
-			this.containingAsSingle = containingAsSingle;
+		public void setContainingAsIndexedEmbedded(ContainingEntity containingAsIndexedEmbedded) {
+			this.containingAsIndexedEmbedded = containingAsIndexedEmbedded;
 		}
 
-		public ContainingEntity getContainingAsNonIndexedEmbeddedSingle() {
-			return containingAsNonIndexedEmbeddedSingle;
+		public ContainingEntity getContainingAsNonIndexedEmbedded() {
+			return containingAsNonIndexedEmbedded;
 		}
 
-		public void setContainingAsNonIndexedEmbeddedSingle(ContainingEntity containingAsNonIndexedEmbeddedSingle) {
-			this.containingAsNonIndexedEmbeddedSingle = containingAsNonIndexedEmbeddedSingle;
+		public void setContainingAsNonIndexedEmbedded(ContainingEntity containingAsNonIndexedEmbedded) {
+			this.containingAsNonIndexedEmbedded = containingAsNonIndexedEmbedded;
 		}
 
 		public String getIndexedField() {


### PR DESCRIPTION
This is simply a refactoring that factorizes some of the code used in ORM automatic indexing multi-valued association tests.

These tests all do the same thing, but with a slightly different model, mainly because we have some code that is specific to each type of association in the ORM integration.

The main reason to factorize this code is that we are going to add even more test methods in future PRs, and if we don't factorize we'll have to add each test method 3 times in three different classes.

Also, we might want, in the future, to test even more different mappings; for example a `Map<String, Entity>` with `@javax.persistence.MapKey`, which derives the map key from the entity and thus might require special handling. That would require a fourth model, with a fourth test, with a fourth duplication of the test methods...