### PR TITLE
HSEARCH-3207 Search 6 groundwork - Avoid duplicate clauses when .end() is called unnecessarily

### DIFF
--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/ElasticsearchExtension.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/ElasticsearchExtension.java
@@ -52,7 +52,7 @@ public final class ElasticsearchExtension<N>
 
 	@Override
 	public <C> ElasticsearchSearchPredicateContainerContext<N> extendOrFail(SearchPredicateContainerContext<N> original,
-			SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, C> dslContext) {
+			SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, ? extends C> dslContext) {
 		if ( factory instanceof ElasticsearchSearchPredicateFactory ) {
 			return extendUnsafe( original, (ElasticsearchSearchPredicateFactory) factory, dslContext );
 		}
@@ -64,7 +64,7 @@ public final class ElasticsearchExtension<N>
 	@Override
 	public <C> Optional<ElasticsearchSearchPredicateContainerContext<N>> extendOptional(
 			SearchPredicateContainerContext<N> original, SearchPredicateFactory<C> factory,
-			SearchPredicateDslContext<N, C> dslContext) {
+			SearchPredicateDslContext<N, ? extends C> dslContext) {
 		if ( factory instanceof ElasticsearchSearchPredicateFactory ) {
 			return Optional.of( extendUnsafe( original, (ElasticsearchSearchPredicateFactory) factory, dslContext ) );
 		}
@@ -75,7 +75,7 @@ public final class ElasticsearchExtension<N>
 
 	@Override
 	public <C> ElasticsearchSearchSortContainerContext<N> extendOrFail(SearchSortContainerContext<N> original,
-			SearchSortFactory<C> factory, SearchSortDslContext<N, C> dslContext) {
+			SearchSortFactory<C> factory, SearchSortDslContext<N, ? extends C> dslContext) {
 		if ( factory instanceof ElasticsearchSearchSortFactory ) {
 			return extendUnsafe( original, (ElasticsearchSearchSortFactory) factory, dslContext );
 		}
@@ -87,7 +87,7 @@ public final class ElasticsearchExtension<N>
 	@Override
 	public <C> Optional<ElasticsearchSearchSortContainerContext<N>> extendOptional(
 			SearchSortContainerContext<N> original, SearchSortFactory<C> factory,
-			SearchSortDslContext<N, C> dslContext) {
+			SearchSortDslContext<N, ? extends C> dslContext) {
 		if ( factory instanceof ElasticsearchSearchSortFactory ) {
 			return Optional.of( extendUnsafe( original, (ElasticsearchSearchSortFactory) factory, dslContext ) );
 		}
@@ -109,20 +109,20 @@ public final class ElasticsearchExtension<N>
 	@SuppressWarnings("unchecked") // If the target is Elasticsearch, then we know C = ElasticsearchSearchPredicateCollector
 	private <C> ElasticsearchSearchPredicateContainerContext<N> extendUnsafe(
 			SearchPredicateContainerContext<N> original, ElasticsearchSearchPredicateFactory factory,
-			SearchPredicateDslContext<N, C> dslContext) {
+			SearchPredicateDslContext<N, ? extends C> dslContext) {
 		return new ElasticsearchSearchPredicateContainerContextImpl<>(
 				original, factory,
-				(SearchPredicateDslContext<N, ElasticsearchSearchPredicateCollector>) dslContext
+				(SearchPredicateDslContext<N, ? extends ElasticsearchSearchPredicateCollector>) dslContext
 		);
 	}
 
 	@SuppressWarnings("unchecked") // If the target is Elasticsearch, then we know C = ElasticsearchSearchSortCollector
 	private <C> ElasticsearchSearchSortContainerContext<N> extendUnsafe(
 			SearchSortContainerContext<N> original, ElasticsearchSearchSortFactory factory,
-			SearchSortDslContext<N, C> dslContext) {
+			SearchSortDslContext<N, ? extends C> dslContext) {
 		return new ElasticsearchSearchSortContainerContextImpl<>(
 				original, factory,
-				(SearchSortDslContext<N, ElasticsearchSearchSortCollector>) dslContext
+				(SearchSortDslContext<N, ? extends ElasticsearchSearchSortCollector>) dslContext
 		);
 	}
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/dsl/predicate/impl/ElasticsearchSearchPredicateContainerContextImpl.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/dsl/predicate/impl/ElasticsearchSearchPredicateContainerContextImpl.java
@@ -20,11 +20,11 @@ public class ElasticsearchSearchPredicateContainerContextImpl<N>
 
 	private final ElasticsearchSearchPredicateFactory factory;
 
-	private final SearchPredicateDslContext<N, ElasticsearchSearchPredicateCollector> dslContext;
+	private final SearchPredicateDslContext<N, ? extends ElasticsearchSearchPredicateCollector> dslContext;
 
 	public ElasticsearchSearchPredicateContainerContextImpl(SearchPredicateContainerContext<N> delegate,
 			ElasticsearchSearchPredicateFactory factory,
-			SearchPredicateDslContext<N, ElasticsearchSearchPredicateCollector> dslContext) {
+			SearchPredicateDslContext<N, ? extends ElasticsearchSearchPredicateCollector> dslContext) {
 		super( delegate );
 		this.factory = factory;
 		this.dslContext = dslContext;

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/dsl/sort/impl/ElasticsearchSearchSortContainerContextImpl.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/dsl/sort/impl/ElasticsearchSearchSortContainerContextImpl.java
@@ -21,11 +21,11 @@ public class ElasticsearchSearchSortContainerContextImpl<N>
 
 	private final ElasticsearchSearchSortFactory factory;
 
-	private final SearchSortDslContext<N, ElasticsearchSearchSortCollector> dslContext;
+	private final SearchSortDslContext<N, ? extends ElasticsearchSearchSortCollector> dslContext;
 
 	public ElasticsearchSearchSortContainerContextImpl(SearchSortContainerContext<N> delegate,
 			ElasticsearchSearchSortFactory factory,
-			SearchSortDslContext<N, ElasticsearchSearchSortCollector> dslContext) {
+			SearchSortDslContext<N, ? extends ElasticsearchSearchSortCollector> dslContext) {
 		super( delegate );
 		this.factory = factory;
 		this.dslContext = dslContext;

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/predicate/impl/SearchPredicateFactoryImpl.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/predicate/impl/SearchPredicateFactoryImpl.java
@@ -44,7 +44,7 @@ public class SearchPredicateFactoryImpl implements ElasticsearchSearchPredicateF
 	}
 
 	@Override
-	public SearchPredicate toSearchPredicate(SearchPredicateContributor<ElasticsearchSearchPredicateCollector> contributor) {
+	public SearchPredicate toSearchPredicate(SearchPredicateContributor<? super ElasticsearchSearchPredicateCollector> contributor) {
 		ElasticsearchSearchQueryElementCollector collector = new ElasticsearchSearchQueryElementCollector();
 		contributor.contribute( collector );
 		return new ElasticsearchSearchPredicate( collector.toJsonPredicate() );

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/sort/impl/SearchSortFactoryImpl.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/sort/impl/SearchSortFactoryImpl.java
@@ -40,7 +40,7 @@ public class SearchSortFactoryImpl implements ElasticsearchSearchSortFactory {
 	}
 
 	@Override
-	public SearchSort toSearchSort(SearchSortContributor<ElasticsearchSearchSortCollector> contributor) {
+	public SearchSort toSearchSort(SearchSortContributor<? super ElasticsearchSearchSortCollector> contributor) {
 		ElasticsearchSearchQueryElementCollector collector = new ElasticsearchSearchQueryElementCollector();
 		contributor.contribute( collector );
 		return new ElasticsearchSearchSort( collector.toJsonSort() );

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/LuceneExtension.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/LuceneExtension.java
@@ -52,7 +52,7 @@ public final class LuceneExtension<N>
 
 	@Override
 	public <C> LuceneSearchPredicateContainerContext<N> extendOrFail(SearchPredicateContainerContext<N> original,
-			SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, C> dslContext) {
+			SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, ? extends C> dslContext) {
 		if ( factory instanceof LuceneSearchPredicateFactory ) {
 			return extendUnsafe( original, (LuceneSearchPredicateFactory) factory, dslContext );
 		}
@@ -64,7 +64,7 @@ public final class LuceneExtension<N>
 	@Override
 	public <C> Optional<LuceneSearchPredicateContainerContext<N>> extendOptional(
 			SearchPredicateContainerContext<N> original, SearchPredicateFactory<C> factory,
-			SearchPredicateDslContext<N, C> dslContext) {
+			SearchPredicateDslContext<N, ? extends C> dslContext) {
 		if ( factory instanceof LuceneSearchPredicateFactory ) {
 			return Optional.of( extendUnsafe( original, (LuceneSearchPredicateFactory) factory, dslContext ) );
 		}
@@ -75,7 +75,7 @@ public final class LuceneExtension<N>
 
 	@Override
 	public <C> LuceneSearchSortContainerContext<N> extendOrFail(SearchSortContainerContext<N> original,
-			SearchSortFactory<C> factory, SearchSortDslContext<N, C> dslContext) {
+			SearchSortFactory<C> factory, SearchSortDslContext<N, ? extends C> dslContext) {
 		if ( factory instanceof LuceneSearchSortFactory ) {
 			return extendUnsafe( original, (LuceneSearchSortFactory) factory, dslContext );
 		}
@@ -87,7 +87,7 @@ public final class LuceneExtension<N>
 	@Override
 	public <C> Optional<LuceneSearchSortContainerContext<N>> extendOptional(
 			SearchSortContainerContext<N> original, SearchSortFactory<C> factory,
-			SearchSortDslContext<N, C> dslContext) {
+			SearchSortDslContext<N, ? extends C> dslContext) {
 		if ( factory instanceof LuceneSearchSortFactory ) {
 			return Optional.of( extendUnsafe( original, (LuceneSearchSortFactory) factory, dslContext ) );
 		}
@@ -112,7 +112,7 @@ public final class LuceneExtension<N>
 			SearchPredicateDslContext<N, C> dslContext) {
 		return new LuceneSearchPredicateContainerContextImpl<>(
 				original, factory,
-				(SearchPredicateDslContext<N, LuceneSearchPredicateCollector>) dslContext
+				(SearchPredicateDslContext<N, ? extends LuceneSearchPredicateCollector>) dslContext
 		);
 	}
 
@@ -122,7 +122,7 @@ public final class LuceneExtension<N>
 			SearchSortDslContext<N, C> dslContext) {
 		return new LuceneSearchSortContainerContextImpl<>(
 				original, factory,
-				(SearchSortDslContext<N, LuceneSearchSortCollector>) dslContext
+				(SearchSortDslContext<N, ? extends LuceneSearchSortCollector>) dslContext
 		);
 	}
 }

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/dsl/predicate/impl/LuceneSearchPredicateContainerContextImpl.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/dsl/predicate/impl/LuceneSearchPredicateContainerContextImpl.java
@@ -21,11 +21,11 @@ public class LuceneSearchPredicateContainerContextImpl<N>
 
 	private final LuceneSearchPredicateFactory factory;
 
-	private final SearchPredicateDslContext<N, LuceneSearchPredicateCollector> dslContext;
+	private final SearchPredicateDslContext<N, ? extends LuceneSearchPredicateCollector> dslContext;
 
 	public LuceneSearchPredicateContainerContextImpl(SearchPredicateContainerContext<N> delegate,
 			LuceneSearchPredicateFactory factory,
-			SearchPredicateDslContext<N, LuceneSearchPredicateCollector> dslContext) {
+			SearchPredicateDslContext<N, ? extends LuceneSearchPredicateCollector> dslContext) {
 		super( delegate );
 		this.factory = factory;
 		this.dslContext = dslContext;

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/dsl/sort/impl/LuceneSearchSortContainerContextImpl.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/dsl/sort/impl/LuceneSearchSortContainerContextImpl.java
@@ -23,11 +23,11 @@ public class LuceneSearchSortContainerContextImpl<N>
 
 	private final LuceneSearchSortFactory factory;
 
-	private final SearchSortDslContext<N, LuceneSearchSortCollector> dslContext;
+	private final SearchSortDslContext<N, ? extends LuceneSearchSortCollector> dslContext;
 
 	public LuceneSearchSortContainerContextImpl(SearchSortContainerContext<N> delegate,
 			LuceneSearchSortFactory factory,
-			SearchSortDslContext<N, LuceneSearchSortCollector> dslContext) {
+			SearchSortDslContext<N, ? extends LuceneSearchSortCollector> dslContext) {
 		super( delegate );
 		this.factory = factory;
 		this.dslContext = dslContext;

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/predicate/impl/SearchPredicateFactoryImpl.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/predicate/impl/SearchPredicateFactoryImpl.java
@@ -38,7 +38,7 @@ public class SearchPredicateFactoryImpl implements LuceneSearchPredicateFactory 
 	}
 
 	@Override
-	public SearchPredicate toSearchPredicate(SearchPredicateContributor<LuceneSearchPredicateCollector> contributor) {
+	public SearchPredicate toSearchPredicate(SearchPredicateContributor<? super LuceneSearchPredicateCollector> contributor) {
 		LuceneSearchQueryElementCollector collector = new LuceneSearchQueryElementCollector();
 		contributor.contribute( collector );
 		return new LuceneSearchPredicate( collector.toLuceneQueryPredicate() );

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/sort/impl/SearchSortFactoryImpl.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/search/sort/impl/SearchSortFactoryImpl.java
@@ -36,7 +36,7 @@ public class SearchSortFactoryImpl implements LuceneSearchSortFactory {
 	}
 
 	@Override
-	public SearchSort toSearchSort(SearchSortContributor<LuceneSearchSortCollector> contributor) {
+	public SearchSort toSearchSort(SearchSortContributor<? super LuceneSearchSortCollector> contributor) {
 		LuceneSearchQueryElementCollector collector = new LuceneSearchQueryElementCollector();
 		contributor.contribute( collector );
 		return new LuceneSearchSort( collector.toLuceneSortFields() );

--- a/engine/src/main/java/org/hibernate/search/v6poc/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/logging/impl/Log.java
@@ -69,4 +69,16 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 16, value = "Invalid polygon: the first point '%1$s' should be identical to the last point '%2$s' to properly close the polygon." )
 	IllegalArgumentException invalidGeoPolygonFirstPointNotIdenticalToLastPoint(GeoPoint firstPoint, GeoPoint lastPoint);
+
+	@Message(id = 17, value = "Cannot add a predicate to this DSL context anymore, because the DSL context was already closed."
+			+ " If you want to re-use predicates, do not re-use the predicate DSL context objects,"
+			+ " but rather build SearchPredicate objects."
+	)
+	SearchException cannotAddPredicateToUsedContext();
+
+	@Message(id = 18, value = "Cannot add a sort to this DSL context anymore, because the DSL context was already closed."
+			+ " If you want to re-use sorts, do not re-use the sort DSL context objects,"
+			+ " but rather build SearchSort objects."
+	)
+	SearchException cannotAddSortToUsedContext();
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BooleanJunctionPredicateContextImpl.java
@@ -132,7 +132,7 @@ class BooleanJunctionPredicateContextImpl<N, C>
 	private class OccurContext implements SearchPredicateDslContext<BooleanJunctionPredicateContext<N>, C>,
 			SearchPredicateContributor<C> {
 
-		private final List<SearchPredicateContributor<C>> children = new ArrayList<>();
+		private final List<SearchPredicateContributor<? super C>> children = new ArrayList<>();
 
 		private final SearchPredicateContainerContextImpl<BooleanJunctionPredicateContext<N>, C> containerContext;
 
@@ -142,7 +142,7 @@ class BooleanJunctionPredicateContextImpl<N, C>
 		}
 
 		@Override
-		public void addContributor(SearchPredicateContributor<C> child) {
+		public void addContributor(SearchPredicateContributor<? super C> child) {
 			children.add( child );
 		}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BuildingRootSearchPredicateDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BuildingRootSearchPredicateDslContextImpl.java
@@ -22,14 +22,14 @@ public final class BuildingRootSearchPredicateDslContextImpl<C>
 
 	private final SearchPredicateFactory<C> factory;
 
-	private SearchPredicateContributor<C> singlePredicateContributor;
+	private SearchPredicateContributor<? super C> singlePredicateContributor;
 
 	public BuildingRootSearchPredicateDslContextImpl(SearchPredicateFactory<C> factory) {
 		this.factory = factory;
 	}
 
 	@Override
-	public void addContributor(SearchPredicateContributor<C> child) {
+	public void addContributor(SearchPredicateContributor<? super C> child) {
 		if ( this.singlePredicateContributor != null ) {
 			throw log.cannotAddMultiplePredicatesToQueryRoot();
 		}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BuildingRootSearchPredicateDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BuildingRootSearchPredicateDslContextImpl.java
@@ -6,17 +6,14 @@
  */
 package org.hibernate.search.v6poc.search.dsl.predicate.impl;
 
-import java.lang.invoke.MethodHandles;
 import java.util.function.Consumer;
 
-import org.hibernate.search.v6poc.logging.impl.Log;
 import org.hibernate.search.v6poc.backend.index.spi.IndexSearchTarget;
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.dsl.predicate.spi.SearchPredicateDslContext;
 import org.hibernate.search.v6poc.search.dsl.query.SearchQueryResultContext;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateContributor;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateFactory;
-import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 
 /**
  * A DSL context used when building a {@link SearchPredicate} object,
@@ -25,13 +22,13 @@ import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
  * (in which case the lambda may retrieve the resulting {@link SearchPredicate} object and cache it).
  */
 public final class BuildingRootSearchPredicateDslContextImpl<C>
-		implements SearchPredicateDslContext<SearchPredicate, C>, SearchPredicateContributor<C> {
-
-	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+		implements SearchPredicateDslContext<SearchPredicate, C> {
 
 	private final SearchPredicateFactory<C> factory;
 
-	private SearchPredicateContributor<? super C> singlePredicateContributor;
+	private final SearchPredicateContributorAggregator<C> aggregator = new SearchPredicateContributorAggregator<>();
+
+	private SearchPredicate built;
 
 	public BuildingRootSearchPredicateDslContextImpl(SearchPredicateFactory<C> factory) {
 		this.factory = factory;
@@ -39,19 +36,28 @@ public final class BuildingRootSearchPredicateDslContextImpl<C>
 
 	@Override
 	public void addContributor(SearchPredicateContributor<? super C> child) {
-		if ( this.singlePredicateContributor != null ) {
-			throw log.cannotAddMultiplePredicatesToQueryRoot();
-		}
-		this.singlePredicateContributor = child;
+		aggregator.add( child );
 	}
 
 	@Override
 	public SearchPredicate getNextContext() {
-		return factory.toSearchPredicate( singlePredicateContributor );
+		if ( built == null ) {
+			built = factory.toSearchPredicate( aggregator );
+		}
+		return built;
 	}
 
-	@Override
-	public void contribute(C collector) {
-		singlePredicateContributor.contribute( collector );
+	public SearchPredicateContributor<C> getResultingContributor() {
+		if ( built != null ) {
+			return factory.toContributor( built );
+		}
+		else {
+			/*
+			 * Optimization: we know the user will not be able to request a SearchSort anymore,
+			 * so we don't need to build a SearchSort object in this case,
+			 * we can just use the contributors directly.
+			 */
+			return aggregator;
+		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BuildingRootSearchPredicateDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/BuildingRootSearchPredicateDslContextImpl.java
@@ -7,14 +7,23 @@
 package org.hibernate.search.v6poc.search.dsl.predicate.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.function.Consumer;
 
 import org.hibernate.search.v6poc.logging.impl.Log;
+import org.hibernate.search.v6poc.backend.index.spi.IndexSearchTarget;
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.dsl.predicate.spi.SearchPredicateDslContext;
+import org.hibernate.search.v6poc.search.dsl.query.SearchQueryResultContext;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateContributor;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateFactory;
 import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 
+/**
+ * A DSL context used when building a {@link SearchPredicate} object,
+ * either when calling {@link IndexSearchTarget#predicate()} from a search target
+ * or when calling {@link SearchQueryResultContext#predicate(Consumer)} to build the predicate using a lambda
+ * (in which case the lambda may retrieve the resulting {@link SearchPredicate} object and cache it).
+ */
 public final class BuildingRootSearchPredicateDslContextImpl<C>
 		implements SearchPredicateDslContext<SearchPredicate, C>, SearchPredicateContributor<C> {
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/MatchAllPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/MatchAllPredicateContextImpl.java
@@ -88,7 +88,7 @@ class MatchAllPredicateContextImpl<N, C>
 	private class MatchAllExceptContext implements SearchPredicateDslContext<MatchAllPredicateContext<N>, C>,
 			SearchPredicateContributor<C> {
 
-		private final List<SearchPredicateContributor<C>> children = new ArrayList<>();
+		private final List<SearchPredicateContributor<? super C>> children = new ArrayList<>();
 
 		private final SearchPredicateContainerContextImpl<MatchAllPredicateContext<N>, C> containerContext;
 
@@ -98,7 +98,7 @@ class MatchAllPredicateContextImpl<N, C>
 		}
 
 		@Override
-		public void addContributor(SearchPredicateContributor<C> child) {
+		public void addContributor(SearchPredicateContributor<? super C> child) {
 			children.add( child );
 		}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/NestedPredicateContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/NestedPredicateContextImpl.java
@@ -30,7 +30,7 @@ class NestedPredicateContextImpl<N, C>
 	private final SearchPredicateContainerContextImpl<N, C> containerContext;
 
 	private NestedPredicateBuilder<C> builder;
-	private SearchPredicateContributor<C> singlePredicateContributor;
+	private SearchPredicateContributor<? super C> singlePredicateContributor;
 
 	NestedPredicateContextImpl(SearchPredicateFactory<C> factory, Supplier<N> nextContextProvider) {
 		this.factory = factory;
@@ -51,7 +51,7 @@ class NestedPredicateContextImpl<N, C>
 	}
 
 	@Override
-	public void addContributor(SearchPredicateContributor<C> child) {
+	public void addContributor(SearchPredicateContributor<? super C> child) {
 		if ( this.singlePredicateContributor != null ) {
 			throw log.cannotAddMultiplePredicatesToNestedPredicate();
 		}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/QuerySearchPredicateDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/QuerySearchPredicateDslContextImpl.java
@@ -6,14 +6,11 @@
  */
 package org.hibernate.search.v6poc.search.dsl.predicate.impl;
 
-import java.lang.invoke.MethodHandles;
 import java.util.function.Supplier;
 
-import org.hibernate.search.v6poc.logging.impl.Log;
 import org.hibernate.search.v6poc.search.dsl.predicate.spi.SearchPredicateDslContext;
 import org.hibernate.search.v6poc.search.dsl.query.SearchQueryResultContext;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateContributor;
-import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 
 /**
  * A DSL context used when calling {@link SearchQueryResultContext#predicate()} to build the predicate
@@ -22,29 +19,23 @@ import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 public final class QuerySearchPredicateDslContextImpl<N, C>
 		implements SearchPredicateDslContext<N, C> {
 
-	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+	private final SearchPredicateContributorAggregator<C> aggregator;
 
-	private final C collector;
 	private final Supplier<N> nextContextSupplier;
 
-	private SearchPredicateContributor<? super C> singlePredicateContributor;
-
-	public QuerySearchPredicateDslContextImpl(C collector, Supplier<N> nextContextSupplier) {
-		this.collector = collector;
+	public QuerySearchPredicateDslContextImpl(SearchPredicateContributorAggregator<C> aggregator,
+			Supplier<N> nextContextSupplier) {
+		this.aggregator = aggregator;
 		this.nextContextSupplier = nextContextSupplier;
 	}
 
 	@Override
 	public void addContributor(SearchPredicateContributor<? super C> child) {
-		if ( this.singlePredicateContributor != null ) {
-			throw log.cannotAddMultiplePredicatesToQueryRoot();
-		}
-		this.singlePredicateContributor = child;
+		aggregator.add( child );
 	}
 
 	@Override
 	public N getNextContext() {
-		singlePredicateContributor.contribute( collector );
 		return nextContextSupplier.get();
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/QuerySearchPredicateDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/QuerySearchPredicateDslContextImpl.java
@@ -27,7 +27,7 @@ public final class QuerySearchPredicateDslContextImpl<N, C>
 	private final C collector;
 	private final Supplier<N> nextContextSupplier;
 
-	private SearchPredicateContributor<C> singlePredicateContributor;
+	private SearchPredicateContributor<? super C> singlePredicateContributor;
 
 	public QuerySearchPredicateDslContextImpl(C collector, Supplier<N> nextContextSupplier) {
 		this.collector = collector;
@@ -35,7 +35,7 @@ public final class QuerySearchPredicateDslContextImpl<N, C>
 	}
 
 	@Override
-	public void addContributor(SearchPredicateContributor<C> child) {
+	public void addContributor(SearchPredicateContributor<? super C> child) {
 		if ( this.singlePredicateContributor != null ) {
 			throw log.cannotAddMultiplePredicatesToQueryRoot();
 		}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/SearchPredicateContainerContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/SearchPredicateContainerContextImpl.java
@@ -26,9 +26,10 @@ public class SearchPredicateContainerContextImpl<N, C> implements SearchPredicat
 
 	private final SearchPredicateFactory<C> factory;
 
-	private final SearchPredicateDslContext<N, C> dslContext;
+	private final SearchPredicateDslContext<N, ? extends C> dslContext;
 
-	public SearchPredicateContainerContextImpl(SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, C> dslContext) {
+	public SearchPredicateContainerContextImpl(SearchPredicateFactory<C> factory,
+			SearchPredicateDslContext<N, ? extends C> dslContext) {
 		this.factory = factory;
 		this.dslContext = dslContext;
 	}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/SearchPredicateContributorAggregator.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/impl/SearchPredicateContributorAggregator.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.search.dsl.predicate.impl;
+
+import java.lang.invoke.MethodHandles;
+
+import org.hibernate.search.v6poc.logging.impl.Log;
+import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateContributor;
+import org.hibernate.search.v6poc.util.AssertionFailure;
+import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
+
+/**
+ * An aggregator of {@link SearchPredicateContributor}, ensuring aggregated contributors are used appropriately:
+ * <ul>
+ *     <li>at most one predicate must be added</li>
+ *     <li>the predicate must be used at most once</li>
+ *     <li>new contributors cannot be added after the contributor has been used
+ *     (the other constraints already prevent that, but we need a specific error message in this case)</li>
+ * </ul>
+ */
+public final class SearchPredicateContributorAggregator<C>
+		implements SearchPredicateContributor<C> {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private SearchPredicateContributor<? super C> singlePredicateContributor;
+
+	private boolean contributed = false;
+
+	public void add(SearchPredicateContributor<? super C> child) {
+		if ( contributed ) {
+			throw log.cannotAddPredicateToUsedContext();
+		}
+		if ( this.singlePredicateContributor != null ) {
+			throw log.cannotAddMultiplePredicatesToQueryRoot();
+		}
+		this.singlePredicateContributor = child;
+	}
+
+	@Override
+	public void contribute(C collector) {
+		if ( contributed ) {
+			// HSEARCH-3207: we must never call a contribution twice. Contributions may have side-effects.
+			throw new AssertionFailure(
+					"A predicate contributor was called twice. There is a bug in Hibernate Search, please report it."
+			);
+		}
+		contributed = true;
+		singlePredicateContributor.contribute( collector );
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/spi/SearchPredicateContainerContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/spi/SearchPredicateContainerContextExtension.java
@@ -36,7 +36,7 @@ public interface SearchPredicateContainerContextExtension<N, T> {
 	 * search target (incompatible technology).
 	 */
 	<C> T extendOrFail(SearchPredicateContainerContext<N> original,
-			SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, C> dslContext);
+			SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, ? extends C> dslContext);
 
 	/**
 	 * Attempt to extend a given context, returning an empty {@link Optional} in case of failure.
@@ -49,6 +49,6 @@ public interface SearchPredicateContainerContextExtension<N, T> {
 	 * of success, or an empty optional otherwise.
 	 */
 	<C> Optional<T> extendOptional(SearchPredicateContainerContext<N> original,
-			SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, C> dslContext);
+			SearchPredicateFactory<C> factory, SearchPredicateDslContext<N, ? extends C> dslContext);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/spi/SearchPredicateDslContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/predicate/spi/SearchPredicateDslContext.java
@@ -19,7 +19,7 @@ public interface SearchPredicateDslContext<N, C> {
 	 *
 	 * @param child The contributor to add.
 	 */
-	void addContributor(SearchPredicateContributor<C> child);
+	void addContributor(SearchPredicateContributor<? super C> child);
 
 	/**
 	 * @return The context that should be exposed to the user after the current predicate has been fully defined.

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/query/impl/SearchQueryContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/query/impl/SearchQueryContextImpl.java
@@ -60,32 +60,27 @@ public final class SearchQueryContextImpl<T, Q, C> implements SearchQueryContext
 	}
 
 	@Override
-	public SearchQueryContext<Q> sort(Consumer<? super SearchSortContainerContext<SearchSort>> sortContributor) {
-		toContributor( targetContext.getSearchSortFactory(), sortContributor )
+	public SearchQueryContext<Q> sort(Consumer<? super SearchSortContainerContext<SearchSort>> dslSortContributor) {
+		toContributor( targetContext.getSearchSortFactory(), dslSortContributor )
 				.contribute( searchQueryBuilder.getQueryElementCollector() );
 		return this;
 	}
 
 	@Override
 	public SearchSortContainerContext<SearchQueryContext<Q>> sort() {
-		return toSortContainerContext( targetContext.getSearchSortFactory(),
-				searchQueryBuilder.getQueryElementCollector(), this );
+		SearchSortDslContext<SearchQueryContext<Q>, C> dslContext =
+				new QuerySearchSortDslContextImpl<>( searchQueryBuilder.getQueryElementCollector(), this );
+		return new SearchSortContainerContextImpl<>( targetContext.getSearchSortFactory(), dslContext );
 	}
 
 	private <SC> SearchSortContributor<SC> toContributor(SearchSortFactory<SC> factory,
-			Consumer<? super SearchSortContainerContext<SearchSort>> sortContributor) {
+			Consumer<? super SearchSortContainerContext<SearchSort>> dslSortContributor) {
 		BuildingRootSearchSortDslContextImpl<SC> dslContext =
 				new BuildingRootSearchSortDslContextImpl<>( factory );
 		SearchSortContainerContext<SearchSort> containerContext =
 				new SearchSortContainerContextImpl<>( factory, dslContext );
-		sortContributor.accept( containerContext );
+		dslSortContributor.accept( containerContext );
 		return dslContext;
-	}
-
-	private <N, PC> SearchSortContainerContext<N> toSortContainerContext(
-			SearchSortFactory<PC> factory, PC collector, N nextContext) {
-		SearchSortDslContext<N, PC> dslContext = new QuerySearchSortDslContextImpl<>( collector, nextContext );
-		return new SearchSortContainerContextImpl<>( factory, dslContext );
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/query/impl/SearchQueryContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/query/impl/SearchQueryContextImpl.java
@@ -17,8 +17,10 @@ import org.hibernate.search.v6poc.search.dsl.sort.SearchSortContainerContext;
 import org.hibernate.search.v6poc.search.dsl.sort.impl.BuildingRootSearchSortDslContextImpl;
 import org.hibernate.search.v6poc.search.dsl.sort.impl.QuerySearchSortDslContextImpl;
 import org.hibernate.search.v6poc.search.dsl.sort.impl.SearchSortContainerContextImpl;
+import org.hibernate.search.v6poc.search.dsl.sort.impl.SearchSortContributorAggregator;
 import org.hibernate.search.v6poc.search.dsl.sort.spi.SearchSortDslContext;
 import org.hibernate.search.v6poc.search.dsl.spi.SearchTargetContext;
+import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateContributor;
 import org.hibernate.search.v6poc.search.query.spi.SearchQueryBuilder;
 import org.hibernate.search.v6poc.search.sort.spi.SearchSortContributor;
 import org.hibernate.search.v6poc.search.sort.spi.SearchSortFactory;
@@ -32,12 +34,17 @@ public final class SearchQueryContextImpl<T, Q, C> implements SearchQueryContext
 	private final SearchTargetContext<C> targetContext;
 	private final SearchQueryBuilder<T, C> searchQueryBuilder;
 	private final Function<SearchQuery<T>, Q> searchQueryWrapperFactory;
+	private final SearchPredicateContributor<? super C> searchPredicateContributor;
+	private final SearchSortContributorAggregator<C> searchSortContributorAggregator;
 
-	public SearchQueryContextImpl(SearchTargetContext<C> targetContext, SearchQueryBuilder<T, C> searchQueryBuilder,
-			Function<SearchQuery<T>, Q> searchQueryWrapperFactory) {
+	SearchQueryContextImpl(SearchTargetContext<C> targetContext, SearchQueryBuilder<T, C> searchQueryBuilder,
+			Function<SearchQuery<T>, Q> searchQueryWrapperFactory,
+			SearchPredicateContributor<? super C> searchPredicateContributor) {
 		this.targetContext = targetContext;
 		this.searchQueryBuilder = searchQueryBuilder;
 		this.searchQueryWrapperFactory = searchQueryWrapperFactory;
+		this.searchPredicateContributor = searchPredicateContributor;
+		this.searchSortContributorAggregator = new SearchSortContributorAggregator<>();
 	}
 
 	@Override
@@ -55,36 +62,51 @@ public final class SearchQueryContextImpl<T, Q, C> implements SearchQueryContext
 	@Override
 	public SearchQueryContext<Q> sort(SearchSort sort) {
 		SearchSortFactory<? super C> factory = targetContext.getSearchSortFactory();
-		factory.toContributor( sort ).contribute( searchQueryBuilder.getQueryElementCollector() );
+		searchSortContributorAggregator.add( factory.toContributor( sort ) );
 		return this;
 	}
 
 	@Override
 	public SearchQueryContext<Q> sort(Consumer<? super SearchSortContainerContext<SearchSort>> dslSortContributor) {
-		toContributor( targetContext.getSearchSortFactory(), dslSortContributor )
-				.contribute( searchQueryBuilder.getQueryElementCollector() );
+		searchSortContributorAggregator.add(
+				toContributor( targetContext.getSearchSortFactory(), dslSortContributor )
+		);
 		return this;
 	}
 
 	@Override
 	public SearchSortContainerContext<SearchQueryContext<Q>> sort() {
 		SearchSortDslContext<SearchQueryContext<Q>, C> dslContext =
-				new QuerySearchSortDslContextImpl<>( searchQueryBuilder.getQueryElementCollector(), this );
+				new QuerySearchSortDslContextImpl<>( searchSortContributorAggregator, this );
 		return new SearchSortContainerContextImpl<>( targetContext.getSearchSortFactory(), dslContext );
 	}
 
-	private <SC> SearchSortContributor<SC> toContributor(SearchSortFactory<SC> factory,
+	private <C extends SC, SC> SearchSortContributor<? super C> toContributor(SearchSortFactory<SC> factory,
 			Consumer<? super SearchSortContainerContext<SearchSort>> dslSortContributor) {
 		BuildingRootSearchSortDslContextImpl<SC> dslContext =
 				new BuildingRootSearchSortDslContextImpl<>( factory );
 		SearchSortContainerContext<SearchSort> containerContext =
 				new SearchSortContainerContextImpl<>( factory, dslContext );
 		dslSortContributor.accept( containerContext );
-		return dslContext;
+		return dslContext.getResultingContributor();
 	}
 
 	@Override
 	public Q build() {
+		/*
+		 * HSEARCH-3207: we must never call a contribution twice.
+		 * Contributions may have side-effects, such as finishing the building of a boolean predicate by adding
+		 * should clauses. Thus it's really not a good idea to execute a contribution twice,
+		 * and delaying the contribution until the very end of the query building prevents that from ever happening.
+		 *
+		 * This means we must delay the contribution to some time when the user cannot use the DSL anymore
+		 * (i.e. when this build() method is called),
+		 * otherwise we'd need to execute the contribution upon some DSL method being called
+		 * (an end() method for example), and this method could be called twice by the user.
+		 */
+		C collector = searchQueryBuilder.getQueryElementCollector();
+		searchPredicateContributor.contribute( collector );
+		searchSortContributorAggregator.contribute( collector );
 		return searchQueryBuilder.build( searchQueryWrapperFactory );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/query/impl/SearchQueryWrappingDefinitionResultContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/query/impl/SearchQueryWrappingDefinitionResultContextImpl.java
@@ -8,18 +8,17 @@ package org.hibernate.search.v6poc.search.dsl.query.impl;
 
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.function.Supplier;
 
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.SearchQuery;
+import org.hibernate.search.v6poc.search.dsl.predicate.SearchPredicateContainerContext;
 import org.hibernate.search.v6poc.search.dsl.predicate.impl.BuildingRootSearchPredicateDslContextImpl;
 import org.hibernate.search.v6poc.search.dsl.predicate.impl.QuerySearchPredicateDslContextImpl;
 import org.hibernate.search.v6poc.search.dsl.predicate.impl.SearchPredicateContainerContextImpl;
 import org.hibernate.search.v6poc.search.dsl.predicate.spi.SearchPredicateDslContext;
-import org.hibernate.search.v6poc.search.dsl.query.SearchQueryWrappingDefinitionResultContext;
-import org.hibernate.search.v6poc.search.dsl.predicate.SearchPredicateContainerContext;
 import org.hibernate.search.v6poc.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.v6poc.search.dsl.query.SearchQueryResultContext;
+import org.hibernate.search.v6poc.search.dsl.query.SearchQueryWrappingDefinitionResultContext;
 import org.hibernate.search.v6poc.search.dsl.spi.SearchTargetContext;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateContributor;
 import org.hibernate.search.v6poc.search.predicate.spi.SearchPredicateFactory;
@@ -64,33 +63,27 @@ public final class SearchQueryWrappingDefinitionResultContextImpl<T, C, Q>
 	}
 
 	@Override
-	public SearchQueryContext<Q> predicate(Consumer<? super SearchPredicateContainerContext<SearchPredicate>> predicateContributor) {
-		toContributor( targetContext.getSearchPredicateFactory(), predicateContributor )
+	public SearchQueryContext<Q> predicate(Consumer<? super SearchPredicateContainerContext<SearchPredicate>> dslPredicateContributor) {
+		toContributor( targetContext.getSearchPredicateFactory(), dslPredicateContributor )
 				.contribute( searchQueryBuilder.getQueryElementCollector() );
 		return getNext();
 	}
 
 	@Override
 	public SearchPredicateContainerContext<SearchQueryContext<Q>> predicate() {
-		return toPredicateContainerContext( targetContext.getSearchPredicateFactory(),
-				searchQueryBuilder.getQueryElementCollector(), this::getNext );
+		SearchPredicateDslContext<SearchQueryContext<Q>, C> dslContext =
+				new QuerySearchPredicateDslContextImpl<>( searchQueryBuilder.getQueryElementCollector(), this::getNext );
+		return new SearchPredicateContainerContextImpl<>( targetContext.getSearchPredicateFactory(), dslContext );
 	}
 
 	private <PC> SearchPredicateContributor<PC> toContributor(SearchPredicateFactory<PC> factory,
-			Consumer<? super SearchPredicateContainerContext<SearchPredicate>> predicateContributor) {
+			Consumer<? super SearchPredicateContainerContext<SearchPredicate>> dslPredicateContributor) {
 		BuildingRootSearchPredicateDslContextImpl<PC> dslContext =
 				new BuildingRootSearchPredicateDslContextImpl<>( factory );
 		SearchPredicateContainerContext<SearchPredicate> containerContext =
 				new SearchPredicateContainerContextImpl<>( factory, dslContext );
-		predicateContributor.accept( containerContext );
+		dslPredicateContributor.accept( containerContext );
 		return dslContext;
-	}
-
-	private <N, PC> SearchPredicateContainerContext<N> toPredicateContainerContext(
-			SearchPredicateFactory<PC> factory, PC collector, Supplier<N> nextContextSupplier) {
-		SearchPredicateDslContext<N, PC> dslContext =
-				new QuerySearchPredicateDslContextImpl<>( collector, nextContextSupplier );
-		return new SearchPredicateContainerContextImpl<>( factory, dslContext );
 	}
 
 	private SearchQueryContext<Q> getNext() {

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/query/impl/SearchQueryWrappingDefinitionResultContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/query/impl/SearchQueryWrappingDefinitionResultContextImpl.java
@@ -15,6 +15,7 @@ import org.hibernate.search.v6poc.search.dsl.predicate.SearchPredicateContainerC
 import org.hibernate.search.v6poc.search.dsl.predicate.impl.BuildingRootSearchPredicateDslContextImpl;
 import org.hibernate.search.v6poc.search.dsl.predicate.impl.QuerySearchPredicateDslContextImpl;
 import org.hibernate.search.v6poc.search.dsl.predicate.impl.SearchPredicateContainerContextImpl;
+import org.hibernate.search.v6poc.search.dsl.predicate.impl.SearchPredicateContributorAggregator;
 import org.hibernate.search.v6poc.search.dsl.predicate.spi.SearchPredicateDslContext;
 import org.hibernate.search.v6poc.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.v6poc.search.dsl.query.SearchQueryResultContext;
@@ -34,12 +35,15 @@ public final class SearchQueryWrappingDefinitionResultContextImpl<T, C, Q>
 
 	private final Function<SearchQuery<T>, Q> searchQueryWrapperFactory;
 
+	private final SearchPredicateContributorAggregator<C> searchPredicateContributorAggregator;
+
 	public SearchQueryWrappingDefinitionResultContextImpl(SearchTargetContext<C> targetContext,
 			SearchQueryBuilder<T, C> searchQueryBuilder,
 			Function<SearchQuery<T>, Q> searchQueryWrapperFactory) {
 		this.targetContext = targetContext;
 		this.searchQueryBuilder = searchQueryBuilder;
 		this.searchQueryWrapperFactory = searchQueryWrapperFactory;
+		this.searchPredicateContributorAggregator = new SearchPredicateContributorAggregator<>();
 	}
 
 	public SearchQueryWrappingDefinitionResultContextImpl(
@@ -57,22 +61,25 @@ public final class SearchQueryWrappingDefinitionResultContextImpl<T, C, Q>
 	@Override
 	public SearchQueryContext<Q> predicate(SearchPredicate predicate) {
 		SearchPredicateFactory<? super C> factory = targetContext.getSearchPredicateFactory();
-		factory.toContributor( predicate )
-				.contribute( searchQueryBuilder.getQueryElementCollector() );
+		SearchPredicateContributor<? super C> contributor = factory.toContributor( predicate );
+		searchPredicateContributorAggregator.add( contributor );
 		return getNext();
 	}
 
 	@Override
 	public SearchQueryContext<Q> predicate(Consumer<? super SearchPredicateContainerContext<SearchPredicate>> dslPredicateContributor) {
-		toContributor( targetContext.getSearchPredicateFactory(), dslPredicateContributor )
-				.contribute( searchQueryBuilder.getQueryElementCollector() );
+		SearchPredicateContributor<? super C> contributor = toContributor(
+				targetContext.getSearchPredicateFactory(), dslPredicateContributor
+		);
+		searchPredicateContributorAggregator.add( contributor );
 		return getNext();
 	}
 
 	@Override
 	public SearchPredicateContainerContext<SearchQueryContext<Q>> predicate() {
-		SearchPredicateDslContext<SearchQueryContext<Q>, C> dslContext =
-				new QuerySearchPredicateDslContextImpl<>( searchQueryBuilder.getQueryElementCollector(), this::getNext );
+		SearchPredicateDslContext<SearchQueryContext<Q>, C> dslContext = new QuerySearchPredicateDslContextImpl<>(
+				searchPredicateContributorAggregator, this::getNext
+		);
 		return new SearchPredicateContainerContextImpl<>( targetContext.getSearchPredicateFactory(), dslContext );
 	}
 
@@ -83,11 +90,14 @@ public final class SearchQueryWrappingDefinitionResultContextImpl<T, C, Q>
 		SearchPredicateContainerContext<SearchPredicate> containerContext =
 				new SearchPredicateContainerContextImpl<>( factory, dslContext );
 		dslPredicateContributor.accept( containerContext );
-		return dslContext;
+		return dslContext.getResultingContributor();
 	}
 
 	private SearchQueryContext<Q> getNext() {
-		return new SearchQueryContextImpl<>( targetContext, searchQueryBuilder, searchQueryWrapperFactory );
+		return new SearchQueryContextImpl<>(
+				targetContext, searchQueryBuilder, searchQueryWrapperFactory,
+				searchPredicateContributorAggregator
+		);
 	}
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/BuildingRootSearchSortDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/BuildingRootSearchSortDslContextImpl.java
@@ -19,14 +19,14 @@ public final class BuildingRootSearchSortDslContextImpl<C>
 
 	private final SearchSortFactory<C> factory;
 
-	private List<SearchSortContributor<C>> sortContributors = new ArrayList<>();
+	private List<SearchSortContributor<? super C>> sortContributors = new ArrayList<>();
 
 	public BuildingRootSearchSortDslContextImpl(SearchSortFactory<C> factory) {
 		this.factory = factory;
 	}
 
 	@Override
-	public void addContributor(SearchSortContributor<C> child) {
+	public void addContributor(SearchSortContributor<? super C> child) {
 		sortContributors.add( child );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/BuildingRootSearchSortDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/BuildingRootSearchSortDslContextImpl.java
@@ -8,12 +8,21 @@ package org.hibernate.search.v6poc.search.dsl.sort.impl;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Consumer;
 
+import org.hibernate.search.v6poc.backend.index.spi.IndexSearchTarget;
 import org.hibernate.search.v6poc.search.SearchSort;
+import org.hibernate.search.v6poc.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.v6poc.search.dsl.sort.spi.SearchSortDslContext;
 import org.hibernate.search.v6poc.search.sort.spi.SearchSortContributor;
 import org.hibernate.search.v6poc.search.sort.spi.SearchSortFactory;
 
+/**
+ * A DSL context used when building a {@link SearchSort} object,
+ * either when calling {@link IndexSearchTarget#sort()} from a search target
+ * or when calling {@link SearchQueryContext#sort(Consumer)} to build the sort using a lambda
+ * (in which case the lambda may retrieve the resulting {@link SearchSort} object and cache it).
+ */
 public final class BuildingRootSearchSortDslContextImpl<C>
 		implements SearchSortDslContext<SearchSort, C>, SearchSortContributor<C> {
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/BuildingRootSearchSortDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/BuildingRootSearchSortDslContextImpl.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.v6poc.search.dsl.sort.impl;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.function.Consumer;
 
 import org.hibernate.search.v6poc.backend.index.spi.IndexSearchTarget;
@@ -24,11 +22,13 @@ import org.hibernate.search.v6poc.search.sort.spi.SearchSortFactory;
  * (in which case the lambda may retrieve the resulting {@link SearchSort} object and cache it).
  */
 public final class BuildingRootSearchSortDslContextImpl<C>
-		implements SearchSortDslContext<SearchSort, C>, SearchSortContributor<C> {
+		implements SearchSortDslContext<SearchSort, C> {
 
 	private final SearchSortFactory<C> factory;
 
-	private List<SearchSortContributor<? super C>> sortContributors = new ArrayList<>();
+	private final SearchSortContributorAggregator<C> aggregator = new SearchSortContributorAggregator<>();
+
+	private SearchSort built;
 
 	public BuildingRootSearchSortDslContextImpl(SearchSortFactory<C> factory) {
 		this.factory = factory;
@@ -36,16 +36,28 @@ public final class BuildingRootSearchSortDslContextImpl<C>
 
 	@Override
 	public void addContributor(SearchSortContributor<? super C> child) {
-		sortContributors.add( child );
+		aggregator.add( child );
 	}
 
 	@Override
 	public SearchSort getNextContext() {
-		return factory.toSearchSort( this );
+		if ( built == null ) {
+			built = factory.toSearchSort( aggregator );
+		}
+		return built;
 	}
 
-	@Override
-	public void contribute(C collector) {
-		sortContributors.forEach( c -> c.contribute( collector ) );
+	public SearchSortContributor<C> getResultingContributor() {
+		if ( built != null ) {
+			return factory.toContributor( built );
+		}
+		else {
+			/*
+			 * Optimization: we know the user will not be able to request a SearchSort anymore,
+			 * so we don't need to build a SearchSort object in this case,
+			 * we can just use the contributors directly.
+ 			 */
+			return aggregator;
+		}
 	}
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/QuerySearchSortDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/QuerySearchSortDslContextImpl.java
@@ -6,9 +6,6 @@
  */
 package org.hibernate.search.v6poc.search.dsl.sort.impl;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import org.hibernate.search.v6poc.search.dsl.query.SearchQueryContext;
 import org.hibernate.search.v6poc.search.dsl.sort.spi.SearchSortDslContext;
 import org.hibernate.search.v6poc.search.sort.spi.SearchSortContributor;
@@ -20,24 +17,22 @@ import org.hibernate.search.v6poc.search.sort.spi.SearchSortContributor;
 public final class QuerySearchSortDslContextImpl<N, C>
 		implements SearchSortDslContext<N, C> {
 
-	private final C collector;
+	private final SearchSortContributorAggregator<C> searchSortContributorAggregator;
 	private final N nextContext;
 
-	private List<SearchSortContributor<? super C>> sortContributors = new ArrayList<>();
-
-	public QuerySearchSortDslContextImpl(C collector, N nextContext) {
-		this.collector = collector;
+	public QuerySearchSortDslContextImpl(SearchSortContributorAggregator<C> searchSortContributorAggregator,
+			N nextContext) {
+		this.searchSortContributorAggregator = searchSortContributorAggregator;
 		this.nextContext = nextContext;
 	}
 
 	@Override
 	public void addContributor(SearchSortContributor<? super C> child) {
-		this.sortContributors.add( child );
+		this.searchSortContributorAggregator.add( child );
 	}
 
 	@Override
 	public N getNextContext() {
-		sortContributors.forEach( c -> c.contribute( collector ) );
 		return nextContext;
 	}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/QuerySearchSortDslContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/QuerySearchSortDslContextImpl.java
@@ -23,7 +23,7 @@ public final class QuerySearchSortDslContextImpl<N, C>
 	private final C collector;
 	private final N nextContext;
 
-	private List<SearchSortContributor<C>> sortContributors = new ArrayList<>();
+	private List<SearchSortContributor<? super C>> sortContributors = new ArrayList<>();
 
 	public QuerySearchSortDslContextImpl(C collector, N nextContext) {
 		this.collector = collector;
@@ -31,7 +31,7 @@ public final class QuerySearchSortDslContextImpl<N, C>
 	}
 
 	@Override
-	public void addContributor(SearchSortContributor<C> child) {
+	public void addContributor(SearchSortContributor<? super C> child) {
 		this.sortContributors.add( child );
 	}
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/SearchSortContainerContextImpl.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/SearchSortContainerContextImpl.java
@@ -25,9 +25,9 @@ public class SearchSortContainerContextImpl<N, C> implements SearchSortContainer
 
 	private final SearchSortFactory<C> factory;
 
-	private final SearchSortDslContext<N, C> dslContext;
+	private final SearchSortDslContext<N, ? extends C> dslContext;
 
-	public SearchSortContainerContextImpl(SearchSortFactory<C> factory, SearchSortDslContext<N, C> dslContext) {
+	public SearchSortContainerContextImpl(SearchSortFactory<C> factory, SearchSortDslContext<N, ? extends C> dslContext) {
 		this.factory = factory;
 		this.dslContext = dslContext;
 	}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/SearchSortContributorAggregator.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/impl/SearchSortContributorAggregator.java
@@ -1,0 +1,55 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.search.dsl.sort.impl;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.hibernate.search.v6poc.logging.impl.Log;
+import org.hibernate.search.v6poc.search.sort.spi.SearchSortContributor;
+import org.hibernate.search.v6poc.util.AssertionFailure;
+import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
+
+/**
+ * An aggregator of {@link SearchSortContributor}, ensuring aggregated contributors
+ * are used appropriately:
+ * <ul>
+ *     <li>they must be used at most once</li>
+ *     <li>new contributors cannot be added after the other contributors have been used</li>
+ * </ul>
+ */
+public final class SearchSortContributorAggregator<C>
+		implements SearchSortContributor<C> {
+
+	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
+
+	private final List<SearchSortContributor<? super C>> sortContributors = new ArrayList<>();
+
+	private boolean contributed = false;
+
+	public void add(SearchSortContributor<? super C> child) {
+		if ( contributed ) {
+			throw log.cannotAddSortToUsedContext();
+		}
+		sortContributors.add( child );
+	}
+
+	@Override
+	public void contribute(C collector) {
+		if ( contributed ) {
+			// HSEARCH-3207: we must never call a contribution twice. Contributions may have side-effects.
+			throw new AssertionFailure(
+					"A sort contributor was called twice. There is a bug in Hibernate Search, please report it."
+			);
+		}
+		contributed = true;
+		for ( SearchSortContributor<? super C> sortContributor : sortContributors ) {
+			sortContributor.contribute( collector );
+		}
+	}
+}

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/spi/SearchSortContainerContextExtension.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/spi/SearchSortContainerContextExtension.java
@@ -37,7 +37,7 @@ public interface SearchSortContainerContextExtension<N, T> {
 	 */
 	<C> T extendOrFail(
 			SearchSortContainerContext<N> original,
-			SearchSortFactory<C> factory, SearchSortDslContext<N, C> dslContext);
+			SearchSortFactory<C> factory, SearchSortDslContext<N, ? extends C> dslContext);
 
 	/**
 	 * Attempt to extend a given context, returning an empty {@link Optional} in case of failure.
@@ -51,6 +51,6 @@ public interface SearchSortContainerContextExtension<N, T> {
 	 */
 	<C> Optional<T> extendOptional(
 			SearchSortContainerContext<N> original,
-			SearchSortFactory<C> factory, SearchSortDslContext<N, C> dslContext);
+			SearchSortFactory<C> factory, SearchSortDslContext<N, ? extends C> dslContext);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/spi/SearchSortDslContext.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/dsl/sort/spi/SearchSortDslContext.java
@@ -19,7 +19,7 @@ public interface SearchSortDslContext<N, C> {
 	 *
 	 * @param child The contributor to add.
 	 */
-	void addContributor(SearchSortContributor<C> child);
+	void addContributor(SearchSortContributor<? super C> child);
 
 	/**
 	 * @return The context that should be exposed to the user after the current predicate has been fully defined.

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/predicate/spi/SearchPredicateFactory.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/predicate/spi/SearchPredicateFactory.java
@@ -19,7 +19,7 @@ import org.hibernate.search.v6poc.search.SearchPredicate;
  */
 public interface SearchPredicateFactory<C> {
 
-	SearchPredicate toSearchPredicate(SearchPredicateContributor<C> contributor);
+	SearchPredicate toSearchPredicate(SearchPredicateContributor<? super C> contributor);
 
 	SearchPredicateContributor<C> toContributor(SearchPredicate predicate);
 

--- a/engine/src/main/java/org/hibernate/search/v6poc/search/sort/spi/SearchSortFactory.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/search/sort/spi/SearchSortFactory.java
@@ -20,7 +20,7 @@ import org.hibernate.search.v6poc.spatial.GeoPoint;
  */
 public interface SearchSortFactory<C> {
 
-	SearchSort toSearchSort(SearchSortContributor<C> contributor);
+	SearchSort toSearchSort(SearchSortContributor<? super C> contributor);
 
 	SearchSortContributor<C> toContributor(SearchSort predicate);
 

--- a/integrationtest/backend-elasticsearch/src/test/resources/backend-tck-multi-tenancy.properties
+++ b/integrationtest/backend-elasticsearch/src/test/resources/backend-tck-multi-tenancy.properties
@@ -1,2 +1,3 @@
 backend.type org.hibernate.search.v6poc.backend.elasticsearch.impl.ElasticsearchBackendFactory
+backend.log.json_pretty_printing true
 backend.multi_tenancy_strategy discriminator

--- a/integrationtest/backend-elasticsearch/src/test/resources/backend-tck.properties
+++ b/integrationtest/backend-elasticsearch/src/test/resources/backend-tck.properties
@@ -1,1 +1,2 @@
 backend.type org.hibernate.search.v6poc.backend.elasticsearch.impl.ElasticsearchBackendFactory
+backend.log.json_pretty_printing true

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchSortIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchSortIT.java
@@ -12,6 +12,7 @@ import static org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.m
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
@@ -43,6 +44,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+
+import org.assertj.core.api.Assertions;
 
 public class SearchSortIT {
 
@@ -80,7 +83,7 @@ public class SearchSortIT {
 		initData();
 	}
 
-	private SearchQuery<DocumentReference> simpleQuery(Consumer<? super SearchSortContainerContext<?>> sortContributor) {
+	private SearchQuery<DocumentReference> simpleQuery(Consumer<? super SearchSortContainerContext<SearchSort>> sortContributor) {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 		return searchTarget.query( sessionContext )
 				.asReferences()
@@ -254,6 +257,36 @@ public class SearchSortIT {
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasReferencesHitsExactOrder( indexName, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID );
+	}
+	@Test
+	public void lambda_caching() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		AtomicReference<SearchSort> cache = new AtomicReference<>();
+
+		Consumer<? super SearchSortContainerContext<SearchSort>> cachingContributor = c -> {
+			if ( cache.get() == null ) {
+				SearchSort result = c.byField( "string" ).onMissingValue().sortLast().end();
+				cache.set( result );
+			}
+			else {
+				c.by( cache.get() );
+			}
+		};
+
+		Assertions.assertThat( cache ).hasValue( null );
+
+		SearchQuery<DocumentReference> query;
+
+		query = simpleQuery( cachingContributor );
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+
+		Assertions.assertThat( cache ).doesNotHaveValue( null );
+
+		query = simpleQuery( cachingContributor );
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 	}
 
 	@Test

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -9,6 +9,9 @@ package org.hibernate.search.v6poc.integrationtest.backend.tck.search.predicate;
 import static org.hibernate.search.v6poc.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert.assertThat;
 import static org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.mapper.StubMapperUtils.referenceProvider;
 
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Consumer;
+
 import org.hibernate.search.v6poc.backend.document.DocumentElement;
 import org.hibernate.search.v6poc.backend.document.IndexFieldAccessor;
 import org.hibernate.search.v6poc.backend.document.model.dsl.IndexSchemaElement;
@@ -20,11 +23,15 @@ import org.hibernate.search.v6poc.integrationtest.backend.tck.util.rule.SearchSe
 import org.hibernate.search.v6poc.search.DocumentReference;
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.SearchQuery;
+import org.hibernate.search.v6poc.search.dsl.predicate.SearchPredicateContainerContext;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.assertion.DocumentReferencesSearchResultAssert;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.StubSessionContext;
+
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
+
+import org.assertj.core.api.Assertions;
 
 public class SearchPredicateIT {
 
@@ -95,6 +102,43 @@ public class SearchPredicateIT {
 		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
 				.asReferences()
 				.predicate( c -> c.match().onField( "string" ).matching( MATCHING_STRING ) )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+	}
+
+	@Test
+	public void match_lambda_caching() {
+		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
+
+		AtomicReference<SearchPredicate> cache = new AtomicReference<>();
+
+		Consumer<? super SearchPredicateContainerContext<SearchPredicate>> cachingContributor = c -> {
+			if ( cache.get() == null ) {
+				SearchPredicate result = c.match().onField( "string" ).matching( MATCHING_STRING );
+				cache.set( result );
+			}
+			else {
+				c.predicate( cache.get() );
+			}
+		};
+
+		Assertions.assertThat( cache ).hasValue( null );
+
+		SearchQuery<DocumentReference> query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate( cachingContributor )
+				.build();
+
+		DocumentReferencesSearchResultAssert.assertThat( query )
+				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+
+		Assertions.assertThat( cache ).doesNotHaveValue( null );
+
+		query = searchTarget.query( sessionContext )
+				.asReferences()
+				.predicate( cachingContributor )
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )

--- a/integrationtest/showcase/library/src/test/java/org/hibernate/search/v6poc/integrationtest/showcase/OrmElasticsearchLibraryShowcaseIT.java
+++ b/integrationtest/showcase/library/src/test/java/org/hibernate/search/v6poc/integrationtest/showcase/OrmElasticsearchLibraryShowcaseIT.java
@@ -121,6 +121,7 @@ public class OrmElasticsearchLibraryShowcaseIT {
 		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
 				.applySetting( PREFIX + "backend.elasticsearchBackend_1.type", ElasticsearchBackendFactory.class.getName() )
 				.applySetting( PREFIX + "index.default.backend", "elasticsearchBackend_1" )
+				.applySetting( PREFIX + "backend.elasticsearchBackend_1.log.json_pretty_printing", true )
 				.applySetting( org.hibernate.cfg.AvailableSettings.HBM2DDL_AUTO, Action.CREATE_DROP );
 
 		if ( MappingMode.PROGRAMMATIC_MAPPING.equals( mappingMode ) ) {

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/search/predicate/impl/StubSearchPredicateFactory.java
@@ -22,7 +22,7 @@ import org.hibernate.search.v6poc.search.predicate.spi.SpatialWithinPolygonPredi
 public class StubSearchPredicateFactory implements SearchPredicateFactory<StubQueryElementCollector> {
 
 	@Override
-	public SearchPredicate toSearchPredicate(SearchPredicateContributor<StubQueryElementCollector> contributor) {
+	public SearchPredicate toSearchPredicate(SearchPredicateContributor<? super StubQueryElementCollector> contributor) {
 		contributor.contribute( StubQueryElementCollector.get() );
 		return new StubSearchPredicate();
 	}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/search/sort/StubSearchSortFactory.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/search/sort/StubSearchSortFactory.java
@@ -17,7 +17,7 @@ import org.hibernate.search.v6poc.spatial.GeoPoint;
 
 public class StubSearchSortFactory implements SearchSortFactory<StubQueryElementCollector> {
 	@Override
-	public SearchSort toSearchSort(SearchSortContributor<StubQueryElementCollector> contributor) {
+	public SearchSort toSearchSort(SearchSortContributor<? super StubQueryElementCollector> contributor) {
 		contributor.contribute( StubQueryElementCollector.get() );
 		return new StubSearchSort();
 	}


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3207

I couldn't add a test for the specific problem you encountered, @gsmet, since the only symptom was that a clause was duplicated in the resulting search query, which didn't have any effect on search results.

However, I did check manually that calling `.end()` on the parent context from inside a lambda does not duplicate clauses anymore. I also added an internal check that will trigger an `AssertionFailure` if we ever try to use a contributor twice again. See `org.hibernate.search.v6poc.search.dsl.predicate.impl.SearchPredicateContributorAggregator#contribute` for example.