### PR TITLE
 Limit code duplication in ORM automatic indexing association tests

### DIFF
--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/AbstractOrmAutomaticIndexingAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/AbstractOrmAutomaticIndexingAssociationIT.java
@@ -1,0 +1,568 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.integrationtest.orm;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.hibernate.SessionFactory;
+import org.hibernate.boot.Metadata;
+import org.hibernate.boot.MetadataSources;
+import org.hibernate.boot.SessionFactoryBuilder;
+import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
+import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
+import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
+import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
+import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
+import org.hibernate.search.v6poc.util.impl.test.annotation.TestForIssue;
+import org.hibernate.service.ServiceRegistry;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * An abstract base for tests dealing with automatic indexing based on Hibernate ORM entity events
+ * and involving an association.
+ * <p>
+ * We use a contrived design based on a {@link AssociationModelPrimitives} class that defines all the factory methods,
+ * setters and getters we need,
+ * because we want to have separate model classes for every test,
+ * in order to avoid introducing exotic situations that would arise
+ * when using generics or superclasses in an ORM model.
+ * <p>
+ * Generally all models follow these guidelines:
+ * <ul>
+ *     <li>TIndexed is an @Indexed entity type</li>
+ *     <li>TContained is a non-@Indexed entity type</li>
+ *     <li>
+ *         TContaining is a non-abstract supertype of TIndexed which defines, in particular,
+ *         a one-to-one, @IndexedEmbedded, child association to TContaining,
+ *         and several @IndexedEmbedded associations (the ones under test) to TContained.
+ *     </li>
+ * </ul>
+ * <p>
+ * Most tests defined in this class use a very simple setup when it comes to associations,
+ * with one parent TIndexed linked to one child TContaining linked to one TContained.
+ * Subclasses define other tests with more advanced setups, with more assumptions as to what the associations allow.
+ */
+public abstract class AbstractOrmAutomaticIndexingAssociationIT<
+		TIndexed extends TContaining, TContaining, TContained
+		> {
+
+	private static final String PREFIX = SearchOrmSettings.PREFIX;
+
+	@Rule
+	public BackendMock backendMock = new BackendMock( "stubBackend" );
+
+	protected SessionFactory sessionFactory;
+
+	private final AssociationModelPrimitives<TIndexed, TContaining, TContained> primitives;
+
+	AbstractOrmAutomaticIndexingAssociationIT(
+			AssociationModelPrimitives<TIndexed, TContaining, TContained> primitives) {
+		this.primitives = primitives;
+	}
+
+	@Before
+	public void setup() {
+		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
+				.applySetting( PREFIX + "backend.stubBackend.type", StubBackendFactory.class.getName() )
+				.applySetting( PREFIX + "index.default.backend", "stubBackend" );
+
+		ServiceRegistry serviceRegistry = registryBuilder.build();
+
+		MetadataSources ms = new MetadataSources( serviceRegistry )
+				.addAnnotatedClass( primitives.getIndexedClass() )
+				.addAnnotatedClass( primitives.getContainedClass() );
+
+		Metadata metadata = ms.buildMetadata();
+
+		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
+
+		backendMock.expectSchema( primitives.getIndexName(), b -> b
+				.objectField( "containedIndexedEmbedded", b2 -> b2
+						.field( "indexedField", String.class )
+						.field( "indexedElementCollectionField", String.class )
+				)
+				.objectField( "child", b3 -> b3
+						.objectField( "containedIndexedEmbedded", b2 -> b2
+								.field( "indexedField", String.class )
+								.field( "indexedElementCollectionField", String.class )
+						)
+				)
+		);
+
+		sessionFactory = sfb.build();
+		backendMock.verifyExpectationsMet();
+	}
+
+	@After
+	public void cleanup() {
+		if ( sessionFactory != null ) {
+			sessionFactory.close();
+		}
+	}
+
+	@Test
+	public void indirectValueUpdate_singleValue_indexed() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContaining deeplyNestedContainingEntity = primitives.newContaining( 3 );
+			primitives.setChild( containingEntity1, deeplyNestedContainingEntity );
+			primitives.setParent( deeplyNestedContainingEntity, containingEntity1 );
+
+			TContained contained1 = primitives.newContained( 4 );
+			primitives.setIndexedField( contained1, "initialValue" );
+			primitives.setContainedIndexedEmbeddedSingle( containingEntity1, contained1 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained1, containingEntity1 );
+
+			TContained contained2 = primitives.newContained( 5 );
+			primitives.setIndexedField( contained2, "initialOutOfScopeValue" );
+			primitives.setContainedIndexedEmbeddedSingle( deeplyNestedContainingEntity, contained2 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained2, deeplyNestedContainingEntity );
+
+			session.persist( contained1 );
+			session.persist( contained2 );
+			session.persist( deeplyNestedContainingEntity );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "initialValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test updating the value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.setIndexedField( contained, "updatedValue" );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", "updatedValue" )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 5 );
+			primitives.setIndexedField( contained, "updatedOutOfScopeValue" );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that updating a non-indexed, basic property in an entity
+	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
+	 * does not trigger reindexing of the indexed entity.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3199")
+	public void indirectValueUpdate_singleValue_nonIndexed() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContained contained1 = primitives.newContained( 4 );
+			primitives.setNonIndexedField( contained1, "initialValue" );
+			primitives.setContainedIndexedEmbeddedSingle( containingEntity1, contained1 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained1, containingEntity1 );
+
+			session.persist( contained1 );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test updating the value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.setNonIndexedField( contained, "updatedValue" );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	@Test
+	public void indirectValueUpdate_elementCollectionValue_indexed() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContaining deeplyNestedContainingEntity = primitives.newContaining( 3 );
+			primitives.setChild( containingEntity1, deeplyNestedContainingEntity );
+			primitives.setParent( deeplyNestedContainingEntity, containingEntity1 );
+
+			TContained contained1 = primitives.newContained( 4 );
+			primitives.getIndexedElementCollectionField( contained1 ).add( "firstValue" );
+			primitives.setContainedIndexedEmbeddedSingle( containingEntity1, contained1 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained1, containingEntity1 );
+
+			TContained contained2 = primitives.newContained( 5 );
+			primitives.getIndexedElementCollectionField( contained2 ).add( "firstOutOfScopeValue" );
+			primitives.setContainedIndexedEmbeddedSingle( deeplyNestedContainingEntity, contained2 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained2, deeplyNestedContainingEntity );
+
+			session.persist( contained1 );
+			session.persist( contained2 );
+			session.persist( deeplyNestedContainingEntity );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+											.field(
+													"indexedElementCollectionField",
+													"firstValue"
+											)
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.getIndexedElementCollectionField( contained ).add( "secondValue" );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+											.field(
+													"indexedElementCollectionField",
+													"firstValue", "secondValue"
+											)
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test removing a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.getIndexedElementCollectionField( contained ).remove( 0 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+											.field(
+													"indexedElementCollectionField",
+													"secondValue"
+											)
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 5 );
+			primitives.getIndexedElementCollectionField( contained ).add( "secondOutOfScopeValue" );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that replacing a non-indexed, ElementCollection property in an entity
+	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
+	 * does trigger reindexing of the indexed entity.
+	 * <p>
+	 * We need dedicated tests for this because Hibernate ORM does not handle
+	 * replaced collections the same way as it does updated collections.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3199")
+	public void indirectValueReplace_elementCollectionValue_indexed() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContaining deeplyNestedContainingEntity = primitives.newContaining( 3 );
+			primitives.setChild( containingEntity1, deeplyNestedContainingEntity );
+			primitives.setParent( deeplyNestedContainingEntity, containingEntity1 );
+
+			TContained contained1 = primitives.newContained( 4 );
+			primitives.getIndexedElementCollectionField( contained1 ).add( "firstValue" );
+			primitives.setContainedIndexedEmbeddedSingle( containingEntity1, contained1 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained1, containingEntity1 );
+
+			TContained contained2 = primitives.newContained( 5 );
+			primitives.getIndexedElementCollectionField( contained2 ).add( "firstOutOfScopeValue" );
+			primitives.setContainedIndexedEmbeddedSingle( deeplyNestedContainingEntity, contained2 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained2, deeplyNestedContainingEntity );
+
+			session.persist( contained1 );
+			session.persist( contained2 );
+			session.persist( deeplyNestedContainingEntity );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+											.field(
+													"indexedElementCollectionField",
+													"firstValue"
+											)
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test replacing a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.setIndexedElementCollectionField( contained, new ArrayList<>( Arrays.asList(
+					"newFirstValue", "newSecondValue"
+			) ) );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+											.field(
+													"indexedElementCollectionField",
+													"newFirstValue", "newSecondValue"
+											)
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test replacing a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 5 );
+			primitives.setIndexedElementCollectionField( contained, new ArrayList<>( Arrays.asList(
+					"newFirstOutOfScopeValue", "newSecondOutOfScopeValue"
+			) ) );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that updating a non-indexed, ElementCollection property in an entity
+	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
+	 * does not trigger reindexing of the indexed entity.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3199")
+	public void indirectValueUpdate_elementCollectionValue_nonIndexed() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContained contained1 = primitives.newContained( 4 );
+			primitives.getNonIndexedElementCollectionField( contained1 ).add( "firstValue" );
+			primitives.setContainedIndexedEmbeddedSingle( containingEntity1, contained1 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained1, containingEntity1 );
+
+			session.persist( contained1 );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test adding a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.getNonIndexedElementCollectionField( contained ).add( "secondValue" );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test removing a value
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.getNonIndexedElementCollectionField( contained ).remove( 0 );
+
+			// Do not expect any work
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	/**
+	 * Test that replacing a non-indexed, ElementCollection property in an entity
+	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
+	 * does not trigger reindexing of the indexed entity.
+	 * <p>
+	 * We need dedicated tests for this because Hibernate ORM does not handle
+	 * replaced collections the same way as it does updated collections.
+	 */
+	@Test
+	@TestForIssue(jiraKey = "HSEARCH-3204")
+	public void indirectValueReplace_elementCollectionValue_nonIndexed() {
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TIndexed entity1 = primitives.newIndexed( 1 );
+
+			TContaining containingEntity1 = primitives.newContaining( 2 );
+			primitives.setChild( entity1, containingEntity1 );
+			primitives.setParent( containingEntity1, entity1 );
+
+			TContained contained1 = primitives.newContained( 4 );
+			primitives.getNonIndexedElementCollectionField( contained1 ).add( "firstValue" );
+			primitives.setContainedIndexedEmbeddedSingle( containingEntity1, contained1 );
+			primitives.setContainingAsIndexedEmbeddedSingle( contained1, containingEntity1 );
+
+			session.persist( contained1 );
+			session.persist( containingEntity1 );
+			session.persist( entity1 );
+
+			backendMock.expectWorks( primitives.getIndexName() )
+					.add( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+
+		// Test replacing the values
+		OrmUtils.withinTransaction( sessionFactory, session -> {
+			TContained contained = session.get( primitives.getContainedClass(), 4 );
+			primitives.setNonIndexedElementCollectionField( contained, new ArrayList<>( Arrays.asList(
+					"newFirstValue", "newSecondValue"
+			) ) );
+
+			// TODO HSEARCH-3204: remove the statement below to not expect any work
+			backendMock.expectWorks( primitives.getIndexName() )
+					.update( "1", b -> b
+							.objectField( "child", b2 -> b2
+									.objectField( "containedIndexedEmbedded", b3 -> b3
+											.field( "indexedField", null )
+									)
+							)
+					)
+					.preparedThenExecuted();
+		} );
+		backendMock.verifyExpectationsMet();
+	}
+
+	interface AssociationModelPrimitives<
+			TIndexed extends TContaining,
+			TContaining,
+			TContained
+			> {
+		String getIndexName();
+
+		Class<TIndexed> getIndexedClass();
+
+		Class<TContaining> getContainingClass();
+
+		Class<TContained> getContainedClass();
+
+		TIndexed newIndexed(int id);
+
+		TContaining newContaining(int id);
+
+		TContained newContained(int id);
+
+		void setChild(TContaining parent, TContaining child);
+
+		void setParent(TContaining child, TContaining parent);
+
+		void setContainedIndexedEmbeddedSingle(TContaining containing, TContained contained);
+
+		void setContainingAsIndexedEmbeddedSingle(TContained contained, TContaining containing);
+
+		void setIndexedField(TContained contained, String value);
+
+		void setNonIndexedField(TContained contained, String value);
+
+		List<String> getIndexedElementCollectionField(TContained contained);
+
+		void setIndexedElementCollectionField(TContained contained, List<String> value);
+
+		List<String> getNonIndexedElementCollectionField(TContained contained);
+
+		void setNonIndexedElementCollectionField(TContained contained, List<String> value);
+	}
+
+}

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/AbstractOrmAutomaticIndexingAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/AbstractOrmAutomaticIndexingAssociationIT.java
@@ -51,6 +51,40 @@ import org.junit.Test;
  * Most tests defined in this class use a very simple setup when it comes to associations,
  * with one parent TIndexed linked to one child TContaining linked to one TContained.
  * Subclasses define other tests with more advanced setups, with more assumptions as to what the associations allow.
+ * <p>
+ * Tests in this class and subclasses follow these naming conventions:
+ * <ul>
+ *     <li>the test method is a sequence of camel-case tokens separated by underscores</li>
+ *     <li>
+ *         the first token defines what operation we are testing:
+ *         <ul>
+ *             <li>
+ *                 indirectValueUpdate: set the value of a basic field,
+ *                 add/remove elements to/from an element-collection field
+ *             </li>
+ *             <li>
+ *                 indirectValueReplace: replace the entire value of an element-collection field
+ *                 (not clear/add, but really use a different collection)
+ *             </li>
+ *             <li>
+ *                 indirectAssociationReplace: replace the entire value of a collection
+ *                 (not clear/add, but really use a different collection)
+ *             </li>
+ *         </ul>
+ *      </li>
+ *     <li>
+ *         the second token defines how the association between TContaining and TContained is indexed:
+ *         indexed-embedded, non-indexed-embedded.
+ *     </li>
+ *     <li>
+ *         the third token (if any) defines which type of value is being updated/replaced:
+ *         singleValue or elementCollectionValue.
+ *     </li>
+ *     <li>
+ *         the fourth token (if any) defines whether the updated/replaced value is indexed
+ *         (i.e. included in the @IndexedEmbedded.includePath) or not.
+ *     </li>
+ * </ul>
  */
 public abstract class AbstractOrmAutomaticIndexingAssociationIT<
 		TIndexed extends TContaining, TContaining, TContained
@@ -111,7 +145,7 @@ public abstract class AbstractOrmAutomaticIndexingAssociationIT<
 	}
 
 	@Test
-	public void indirectValueUpdate_singleValue_indexed() {
+	public void indirectValueUpdate_indexedEmbedded_singleValue_indexed() {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
@@ -185,7 +219,7 @@ public abstract class AbstractOrmAutomaticIndexingAssociationIT<
 	 */
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectValueUpdate_singleValue_nonIndexed() {
+	public void indirectValueUpdate_indexedEmbedded_singleValue_nonIndexed() {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
@@ -225,7 +259,7 @@ public abstract class AbstractOrmAutomaticIndexingAssociationIT<
 	}
 
 	@Test
-	public void indirectValueUpdate_elementCollectionValue_indexed() {
+	public void indirectValueUpdate_indexedEmbedded_elementCollectionValue_indexed() {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
@@ -331,7 +365,7 @@ public abstract class AbstractOrmAutomaticIndexingAssociationIT<
 	 */
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectValueReplace_elementCollectionValue_indexed() {
+	public void indirectValueReplace_indexedEmbedded_elementCollectionValue_indexed() {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
@@ -417,7 +451,7 @@ public abstract class AbstractOrmAutomaticIndexingAssociationIT<
 	 */
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectValueUpdate_elementCollectionValue_nonIndexed() {
+	public void indirectValueUpdate_indexedEmbedded_elementCollectionValue_nonIndexed() {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 
@@ -475,7 +509,7 @@ public abstract class AbstractOrmAutomaticIndexingAssociationIT<
 	 */
 	@Test
 	@TestForIssue(jiraKey = "HSEARCH-3204")
-	public void indirectValueReplace_elementCollectionValue_nonIndexed() {
+	public void indirectValueReplace_indexedEmbedded_elementCollectionValue_nonIndexed() {
 		OrmUtils.withinTransaction( sessionFactory, session -> {
 			TIndexed entity1 = primitives.newIndexed( 1 );
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/AbstractOrmAutomaticIndexingMultiAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/AbstractOrmAutomaticIndexingMultiAssociationIT.java
@@ -6,90 +6,33 @@
  */
 package org.hibernate.search.v6poc.integrationtest.orm;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
 import org.hibernate.search.v6poc.util.impl.test.annotation.TestForIssue;
-import org.hibernate.service.ServiceRegistry;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
  * An abstract base for tests dealing with automatic indexing based on Hibernate ORM entity events
  * and involving a multi-valued association.
  * <p>
- * We use a contrived design based on a {@link ModelPrimitives} class that defines all the factory methods,
- * setters and getters we need,
- * because we want to have separate model classes for every test,
- * in order to avoid introducing exotic situations that would arise
- * when using generics or superclasses in an ORM model.
+ * See {@link AbstractOrmAutomaticIndexingAssociationIT} for more details on how this test is designed.
  */
 public abstract class AbstractOrmAutomaticIndexingMultiAssociationIT<
 		TIndexed extends TContaining, TContaining, TContained,
 		TContainedAssociation, TContainingAssociation
+		>
+		extends AbstractOrmAutomaticIndexingAssociationIT<
+		TIndexed, TContaining, TContained
 		> {
 
-	private static final String PREFIX = SearchOrmSettings.PREFIX;
-
-	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
-
-	private SessionFactory sessionFactory;
-
-	private final ModelPrimitives<TIndexed, TContaining, TContained,
-				TContainedAssociation, TContainingAssociation> primitives;
+	private final MultiAssociationModelPrimitives<TIndexed, TContaining, TContained,
+			TContainedAssociation, TContainingAssociation> primitives;
 
 	AbstractOrmAutomaticIndexingMultiAssociationIT(
-			ModelPrimitives<TIndexed, TContaining, TContained,
-								TContainedAssociation, TContainingAssociation> primitives) {
+			MultiAssociationModelPrimitives<TIndexed, TContaining, TContained,
+					TContainedAssociation, TContainingAssociation> primitives) {
+		super( primitives );
 		this.primitives = primitives;
-	}
-
-	@Before
-	public void setup() {
-		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
-				.applySetting( PREFIX + "backend.stubBackend.type", StubBackendFactory.class.getName() )
-				.applySetting( PREFIX + "index.default.backend", "stubBackend" );
-
-		ServiceRegistry serviceRegistry = registryBuilder.build();
-
-		MetadataSources ms = new MetadataSources( serviceRegistry )
-				.addAnnotatedClass( primitives.getIndexedClass() )
-				.addAnnotatedClass( primitives.getContainedClass() );
-
-		Metadata metadata = ms.buildMetadata();
-
-		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
-
-		backendMock.expectSchema( primitives.getIndexName(), b -> b
-				.objectField( "containedIndexedEmbedded", b2 -> b2
-						.field( "indexedField", String.class )
-				)
-				.objectField( "child", b3 -> b3
-						.objectField( "containedIndexedEmbedded", b2 -> b2
-								.field( "indexedField", String.class )
-						)
-				)
-		);
-
-		sessionFactory = sfb.build();
-		backendMock.verifyExpectationsMet();
-	}
-
-	@After
-	public void cleanup() {
-		if ( sessionFactory != null ) {
-			sessionFactory.close();
-		}
 	}
 
 	@Test
@@ -666,100 +609,27 @@ public abstract class AbstractOrmAutomaticIndexingMultiAssociationIT<
 		backendMock.verifyExpectationsMet();
 	}
 
-	@Test
-	public void indirectValueUpdate() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			TIndexed entity1 = primitives.newIndexed( 1 );
-
-			TContaining containingEntity1 = primitives.newContaining( 2 );
-			primitives.setChild( entity1, containingEntity1 );
-			primitives.setParent( containingEntity1, entity1 );
-
-			TContaining deeplyNestedContainingEntity = primitives.newContaining( 3 );
-			primitives.setChild( containingEntity1, deeplyNestedContainingEntity );
-			primitives.setParent( deeplyNestedContainingEntity, containingEntity1 );
-
-			TContained contained1 = primitives.newContained( 4 );
-			primitives.setIndexedField( contained1, "initialValue" );
-			primitives.addContained( primitives.getContainedIndexedEmbedded( containingEntity1 ), contained1 );
-			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained1 ), containingEntity1 );
-
-			TContained contained2 = primitives.newContained( 5 );
-			primitives.setIndexedField( contained2, "initialOutOfScopeValue" );
-			primitives.addContained( primitives.getContainedIndexedEmbedded( deeplyNestedContainingEntity ), contained2 );
-			primitives.addContaining( primitives.getContainingAsIndexedEmbedded( contained2 ), deeplyNestedContainingEntity );
-
-			session.persist( contained1 );
-			session.persist( contained2 );
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( primitives.getIndexName() )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", "initialValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			TContained contained = session.get( primitives.getContainedClass(), 4 );
-			primitives.setIndexedField( contained, "updatedValue" );
-
-			backendMock.expectWorks( primitives.getIndexName() )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", "updatedValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			TContained contained = session.get( primitives.getContainedClass(), 5 );
-			primitives.setIndexedField( contained, "updatedOutOfScopeValue" );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	interface ModelPrimitives<
+	interface MultiAssociationModelPrimitives<
 			TIndexed extends TContaining,
 			TContaining,
 			TContained,
 			TContainedAssociation,
 			TContainingAssociation
-			> {
-		String getIndexName();
+			> extends AssociationModelPrimitives<TIndexed, TContaining, TContained> {
 
-		Class<TIndexed> getIndexedClass();
+		@Override
+		default void setContainedIndexedEmbeddedSingle(TContaining containing, TContained contained) {
+			TContainedAssociation containedAssociation = getContainedIndexedEmbedded( containing );
+			clearContained( containedAssociation );
+			addContained( containedAssociation, contained );
+		}
 
-		Class<TContaining> getContainingClass();
-
-		Class<TContained> getContainedClass();
-
-		TIndexed newIndexed(int id);
-
-		TContaining newContaining(int id);
-
-		TContained newContained(int id);
-
-		void setIndexedField(TContained contained, String value);
-
-		void setChild(TContaining parent, TContaining child);
-
-		void setParent(TContaining child, TContaining parent);
+		@Override
+		default void setContainingAsIndexedEmbeddedSingle(TContained contained, TContaining containing) {
+			TContainingAssociation containingAssociation = getContainingAsIndexedEmbedded( contained );
+			clearContaining( containingAssociation );
+			addContaining( containingAssociation, containing );
+		}
 
 		TContainedAssociation newContainedAssociation(TContainedAssociation original);
 
@@ -767,9 +637,13 @@ public abstract class AbstractOrmAutomaticIndexingMultiAssociationIT<
 
 		void removeContained(TContainedAssociation association, TContained contained);
 
+		void clearContained(TContainedAssociation association);
+
 		void addContaining(TContainingAssociation association, TContaining containing);
 
 		void removeContaining(TContainingAssociation association, TContaining containing);
+
+		void clearContaining(TContainingAssociation association);
 
 		TContainedAssociation getContainedIndexedEmbedded(TContaining containing);
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingListAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingListAssociationIT.java
@@ -9,6 +9,7 @@ package org.hibernate.search.v6poc.integrationtest.orm;
 import java.util.ArrayList;
 import java.util.List;
 import javax.persistence.Basic;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinTable;
@@ -21,10 +22,10 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Inde
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 
 /**
- * Test automatic indexing based on Hibernate ORM entity events.
- *
- * This test only checks updates involving a multi-valued, List association.
- * Other tests in the same package check more basic, direct updates or updates involving different associations.
+ * Test automatic indexing based on Hibernate ORM entity events
+ * when a List association is involved.
+ * <p>
+ * See {@link AbstractOrmAutomaticIndexingAssociationIT} for more details on how this test is designed.
  */
 public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticIndexingMultiAssociationIT<
 		OrmAutomaticIndexingListAssociationIT.IndexedEntity,
@@ -35,12 +36,12 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 		> {
 
 	public OrmAutomaticIndexingListAssociationIT() {
-		super( new ListModelPrimitives() );
+		super( new ListAssociationModelPrimitives() );
 	}
 
-	private static class ListModelPrimitives
-			implements ModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
-			List<ContainedEntity>, List<ContainingEntity>> {
+	private static class ListAssociationModelPrimitives
+			implements MultiAssociationModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
+						List<ContainedEntity>, List<ContainingEntity>> {
 
 		@Override
 		public String getIndexName() {
@@ -84,11 +85,6 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 		}
 
 		@Override
-		public void setIndexedField(ContainedEntity containedEntity, String value) {
-			containedEntity.setIndexedField( value );
-		}
-
-		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -96,7 +92,6 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 		@Override
 		public void setParent(ContainingEntity child, ContainingEntity parent) {
 			child.setParent( parent );
-
 		}
 
 		@Override
@@ -115,6 +110,11 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 		}
 
 		@Override
+		public void clearContained(List<ContainedEntity> containedEntities) {
+			containedEntities.clear();
+		}
+
+		@Override
 		public void addContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
 			containingEntities.add( containingEntity );
 		}
@@ -122,6 +122,11 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 		@Override
 		public void removeContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
 			containingEntities.remove( containingEntity );
+		}
+
+		@Override
+		public void clearContaining(List<ContainingEntity> containingEntities) {
+			containingEntities.clear();
 		}
 
 		@Override
@@ -155,6 +160,36 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 		public List<ContainingEntity> getContainingAsNonIndexedEmbedded(ContainedEntity containedEntity) {
 			return containedEntity.getContainingAsNonIndexedEmbedded();
 		}
+
+		@Override
+		public void setIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setIndexedField( value );
+		}
+
+		@Override
+		public void setNonIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setNonIndexedField( value );
+		}
+
+		@Override
+		public List<String> getIndexedElementCollectionField(ContainedEntity containedEntity) {
+			return containedEntity.getIndexedElementCollectionField();
+		}
+
+		@Override
+		public void setIndexedElementCollectionField(ContainedEntity containedEntity, List<String> value) {
+			containedEntity.setIndexedElementCollectionField( value );
+		}
+
+		@Override
+		public List<String> getNonIndexedElementCollectionField(ContainedEntity containedEntity) {
+			return containedEntity.getNonIndexedElementCollectionField();
+		}
+
+		@Override
+		public void setNonIndexedElementCollectionField(ContainedEntity containedEntity, List<String> value) {
+			containedEntity.setNonIndexedElementCollectionField( value );
+		}
 	}
 
 	@Entity(name = "containing")
@@ -168,13 +203,14 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 
 		@OneToOne(mappedBy = "parent")
 		@IndexedEmbedded(includePaths = {
-				"containedIndexedEmbedded.indexedField"
+				"containedIndexedEmbedded.indexedField",
+				"containedIndexedEmbedded.indexedElementCollectionField"
 		})
 		private ContainingEntity child;
 
 		@ManyToMany
 		@JoinTable(name = "indexed_containedIndexedEmbedded")
-		@IndexedEmbedded(includePaths = "indexedField")
+		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField" })
 		private List<ContainedEntity> containedIndexedEmbedded = new ArrayList<>();
 
 		@ManyToMany
@@ -248,6 +284,18 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 		@Field
 		private String indexedField;
 
+		@ElementCollection
+		@Field
+		private List<String> indexedElementCollectionField = new ArrayList<>();
+
+		@Basic
+		@Field // Keep this annotation, it should be ignored because the field is not included in the @IndexedEmbedded
+		private String nonIndexedField;
+
+		@ElementCollection
+		@Field // Keep this annotation, it should be ignored because the field is not included in the @IndexedEmbedded
+		private List<String> nonIndexedElementCollectionField = new ArrayList<>();
+
 		public Integer getId() {
 			return id;
 		}
@@ -270,6 +318,30 @@ public class OrmAutomaticIndexingListAssociationIT extends AbstractOrmAutomaticI
 
 		public void setIndexedField(String indexedField) {
 			this.indexedField = indexedField;
+		}
+
+		public List<String> getIndexedElementCollectionField() {
+			return indexedElementCollectionField;
+		}
+
+		public void setIndexedElementCollectionField(List<String> indexedElementCollectionField) {
+			this.indexedElementCollectionField = indexedElementCollectionField;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
+		}
+
+		public List<String> getNonIndexedElementCollectionField() {
+			return nonIndexedElementCollectionField;
+		}
+
+		public void setNonIndexedElementCollectionField(List<String> nonIndexedElementCollectionField) {
+			this.nonIndexedElementCollectionField = nonIndexedElementCollectionField;
 		}
 
 	}

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapKeysAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapKeysAssociationIT.java
@@ -31,10 +31,10 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Inde
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.PropertyValue;
 
 /**
- * Test automatic indexing based on Hibernate ORM entity events.
- *
- * This test only checks updates involving a multi-valued, Map keys association.
- * Other tests in the same package check more basic, direct updates or updates involving different associations.
+ * Test automatic indexing based on Hibernate ORM entity events
+ * when a Map-keys association is involved.
+ * <p>
+ * See {@link AbstractOrmAutomaticIndexingAssociationIT} for more details on how this test is designed.
  */
 public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomaticIndexingMultiAssociationIT<
 		OrmAutomaticIndexingMapKeysAssociationIT.IndexedEntity,
@@ -45,12 +45,12 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 		> {
 
 	public OrmAutomaticIndexingMapKeysAssociationIT() {
-		super( new MapKeysModelPrimitives() );
+		super( new MapKeysAssociationModelPrimitives() );
 	}
 
-	private static class MapKeysModelPrimitives
-			implements ModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
-			Map<ContainedEntity, String>, List<ContainingEntity>> {
+	private static class MapKeysAssociationModelPrimitives
+			implements MultiAssociationModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
+						Map<ContainedEntity, String>, List<ContainingEntity>> {
 
 		@Override
 		public String getIndexName() {
@@ -94,11 +94,6 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 		}
 
 		@Override
-		public void setIndexedField(ContainedEntity containedEntity, String value) {
-			containedEntity.setIndexedField( value );
-		}
-
-		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -106,7 +101,6 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 		@Override
 		public void setParent(ContainingEntity child, ContainingEntity parent) {
 			child.setParent( parent );
-
 		}
 
 		@Override
@@ -125,6 +119,11 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 		}
 
 		@Override
+		public void clearContained(Map<ContainedEntity, String> containedEntities) {
+			containedEntities.clear();
+		}
+
+		@Override
 		public void addContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
 			containingEntities.add( containingEntity );
 		}
@@ -132,6 +131,11 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 		@Override
 		public void removeContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
 			containingEntities.remove( containingEntity );
+		}
+
+		@Override
+		public void clearContaining(List<ContainingEntity> containingEntities) {
+			containingEntities.clear();
 		}
 
 		@Override
@@ -165,6 +169,36 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 		public List<ContainingEntity> getContainingAsNonIndexedEmbedded(ContainedEntity containedEntity) {
 			return containedEntity.getContainingAsNonIndexedEmbedded();
 		}
+
+		@Override
+		public void setIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setIndexedField( value );
+		}
+
+		@Override
+		public void setNonIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setNonIndexedField( value );
+		}
+
+		@Override
+		public List<String> getIndexedElementCollectionField(ContainedEntity containedEntity) {
+			return containedEntity.getIndexedElementCollectionField();
+		}
+
+		@Override
+		public void setIndexedElementCollectionField(ContainedEntity containedEntity, List<String> value) {
+			containedEntity.setIndexedElementCollectionField( value );
+		}
+
+		@Override
+		public List<String> getNonIndexedElementCollectionField(ContainedEntity containedEntity) {
+			return containedEntity.getNonIndexedElementCollectionField();
+		}
+
+		@Override
+		public void setNonIndexedElementCollectionField(ContainedEntity containedEntity, List<String> value) {
+			containedEntity.setNonIndexedElementCollectionField( value );
+		}
 	}
 
 	@Entity(name = "containing")
@@ -178,7 +212,8 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 
 		@OneToOne(mappedBy = "parent")
 		@IndexedEmbedded(includePaths = {
-				"containedIndexedEmbedded.indexedField"
+				"containedIndexedEmbedded.indexedField",
+				"containedIndexedEmbedded.indexedElementCollectionField"
 		})
 		private ContainingEntity child;
 
@@ -191,7 +226,7 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 		@Column(name = "value")
 		@OrderBy("key asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		@IndexedEmbedded(
-				includePaths = "indexedField",
+				includePaths = { "indexedField", "indexedElementCollectionField" },
 				extractors = @ContainerValueExtractorBeanReference( type = MapKeyExtractor.class )
 		)
 		private Map<ContainedEntity, String> containedIndexedEmbedded = new LinkedHashMap<>();
@@ -290,6 +325,18 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 		@Field
 		private String indexedField;
 
+		@ElementCollection
+		@Field
+		private List<String> indexedElementCollectionField = new ArrayList<>();
+
+		@Basic
+		@Field // Keep this annotation, it should be ignored because the field is not included in the @IndexedEmbedded
+		private String nonIndexedField;
+
+		@ElementCollection
+		@Field // Keep this annotation, it should be ignored because the field is not included in the @IndexedEmbedded
+		private List<String> nonIndexedElementCollectionField = new ArrayList<>();
+
 		public Integer getId() {
 			return id;
 		}
@@ -312,6 +359,30 @@ public class OrmAutomaticIndexingMapKeysAssociationIT extends AbstractOrmAutomat
 
 		public void setIndexedField(String indexedField) {
 			this.indexedField = indexedField;
+		}
+
+		public List<String> getIndexedElementCollectionField() {
+			return indexedElementCollectionField;
+		}
+
+		public void setIndexedElementCollectionField(List<String> indexedElementCollectionField) {
+			this.indexedElementCollectionField = indexedElementCollectionField;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
+		}
+
+		public List<String> getNonIndexedElementCollectionField() {
+			return nonIndexedElementCollectionField;
+		}
+
+		public void setNonIndexedElementCollectionField(List<String> nonIndexedElementCollectionField) {
+			this.nonIndexedElementCollectionField = nonIndexedElementCollectionField;
 		}
 	}
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapValuesAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingMapValuesAssociationIT.java
@@ -11,6 +11,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import javax.persistence.Basic;
+import javax.persistence.ElementCollection;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.JoinColumn;
@@ -25,10 +26,10 @@ import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Inde
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
 
 /**
- * Test automatic indexing based on Hibernate ORM entity events.
- *
- * This test only checks updates involving a multi-valued, Map values association.
- * Other tests in the same package check more basic, direct updates or updates involving different associations.
+ * Test automatic indexing based on Hibernate ORM entity events
+ * when a Map-values association is involved.
+ * <p>
+ * See {@link AbstractOrmAutomaticIndexingAssociationIT} for more details on how this test is designed.
  */
 public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutomaticIndexingMultiAssociationIT<
 		OrmAutomaticIndexingMapValuesAssociationIT.IndexedEntity,
@@ -39,12 +40,12 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 		> {
 
 	public OrmAutomaticIndexingMapValuesAssociationIT() {
-		super( new MapValuesModelPrimitives() );
+		super( new MapValuesAssociationModelPrimitives() );
 	}
 
-	private static class MapValuesModelPrimitives
-			implements ModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
-			Map<String, ContainedEntity>, List<ContainingEntity>> {
+	private static class MapValuesAssociationModelPrimitives
+			implements MultiAssociationModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity,
+						Map<String, ContainedEntity>, List<ContainingEntity>> {
 
 		@Override
 		public String getIndexName() {
@@ -88,11 +89,6 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 		}
 
 		@Override
-		public void setIndexedField(ContainedEntity containedEntity, String value) {
-			containedEntity.setIndexedField( value );
-		}
-
-		@Override
 		public void setChild(ContainingEntity parent, ContainingEntity child) {
 			parent.setChild( child );
 		}
@@ -100,7 +96,6 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 		@Override
 		public void setParent(ContainingEntity child, ContainingEntity parent) {
 			child.setParent( parent );
-
 		}
 
 		@Override
@@ -119,6 +114,11 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 		}
 
 		@Override
+		public void clearContained(Map<String, ContainedEntity> containedEntities) {
+			containedEntities.clear();
+		}
+
+		@Override
 		public void addContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
 			containingEntities.add( containingEntity );
 		}
@@ -126,6 +126,11 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 		@Override
 		public void removeContaining(List<ContainingEntity> containingEntities, ContainingEntity containingEntity) {
 			containingEntities.remove( containingEntity );
+		}
+
+		@Override
+		public void clearContaining(List<ContainingEntity> containingEntities) {
+			containingEntities.clear();
 		}
 
 		@Override
@@ -159,6 +164,36 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 		public List<ContainingEntity> getContainingAsNonIndexedEmbedded(ContainedEntity containedEntity) {
 			return containedEntity.getContainingAsNonIndexedEmbedded();
 		}
+
+		@Override
+		public void setIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setIndexedField( value );
+		}
+
+		@Override
+		public void setNonIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setNonIndexedField( value );
+		}
+
+		@Override
+		public List<String> getIndexedElementCollectionField(ContainedEntity containedEntity) {
+			return containedEntity.getIndexedElementCollectionField();
+		}
+
+		@Override
+		public void setIndexedElementCollectionField(ContainedEntity containedEntity, List<String> value) {
+			containedEntity.setIndexedElementCollectionField( value );
+		}
+
+		@Override
+		public List<String> getNonIndexedElementCollectionField(ContainedEntity containedEntity) {
+			return containedEntity.getNonIndexedElementCollectionField();
+		}
+
+		@Override
+		public void setNonIndexedElementCollectionField(ContainedEntity containedEntity, List<String> value) {
+			containedEntity.setNonIndexedElementCollectionField( value );
+		}
 	}
 
 	@Entity(name = "containing")
@@ -172,7 +207,8 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 
 		@OneToOne(mappedBy = "parent")
 		@IndexedEmbedded(includePaths = {
-				"containedIndexedEmbedded.indexedField"
+				"containedIndexedEmbedded.indexedField",
+				"containedIndexedEmbedded.indexedElementCollectionField"
 		})
 		private ContainingEntity child;
 
@@ -183,7 +219,7 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 				inverseJoinColumns = @JoinColumn(name = "value")
 		)
 		@MapKeyColumn(name = "key")
-		@IndexedEmbedded(includePaths = "indexedField")
+		@IndexedEmbedded(includePaths = { "indexedField", "indexedElementCollectionField" })
 		@OrderBy("id asc") // Forces Hibernate ORM to use a LinkedHashMap; we make sure to insert entries in the correct order
 		private Map<String, ContainedEntity> containedIndexedEmbedded = new LinkedHashMap<>();
 
@@ -265,6 +301,18 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 		@Field
 		private String indexedField;
 
+		@ElementCollection
+		@Field
+		private List<String> indexedElementCollectionField = new ArrayList<>();
+
+		@Basic
+		@Field // Keep this annotation, it should be ignored because the field is not included in the @IndexedEmbedded
+		private String nonIndexedField;
+
+		@ElementCollection
+		@Field // Keep this annotation, it should be ignored because the field is not included in the @IndexedEmbedded
+		private List<String> nonIndexedElementCollectionField = new ArrayList<>();
+
 		public Integer getId() {
 			return id;
 		}
@@ -287,6 +335,30 @@ public class OrmAutomaticIndexingMapValuesAssociationIT extends AbstractOrmAutom
 
 		public void setIndexedField(String indexedField) {
 			this.indexedField = indexedField;
+		}
+
+		public List<String> getIndexedElementCollectionField() {
+			return indexedElementCollectionField;
+		}
+
+		public void setIndexedElementCollectionField(List<String> indexedElementCollectionField) {
+			this.indexedElementCollectionField = indexedElementCollectionField;
+		}
+
+		public String getNonIndexedField() {
+			return nonIndexedField;
+		}
+
+		public void setNonIndexedField(String nonIndexedField) {
+			this.nonIndexedField = nonIndexedField;
+		}
+
+		public List<String> getNonIndexedElementCollectionField() {
+			return nonIndexedElementCollectionField;
+		}
+
+		public void setNonIndexedElementCollectionField(List<String> nonIndexedElementCollectionField) {
+			this.nonIndexedElementCollectionField = nonIndexedElementCollectionField;
 		}
 	}
 

--- a/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingSingleAssociationIT.java
+++ b/integrationtest/orm/src/test/java/org/hibernate/search/v6poc/integrationtest/orm/OrmAutomaticIndexingSingleAssociationIT.java
@@ -7,7 +7,6 @@
 package org.hibernate.search.v6poc.integrationtest.orm;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import javax.persistence.Basic;
 import javax.persistence.ElementCollection;
@@ -15,79 +14,28 @@ import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.OneToOne;
 
-import org.hibernate.SessionFactory;
-import org.hibernate.boot.Metadata;
-import org.hibernate.boot.MetadataSources;
-import org.hibernate.boot.SessionFactoryBuilder;
-import org.hibernate.boot.registry.StandardServiceRegistryBuilder;
-import org.hibernate.search.v6poc.entity.orm.cfg.SearchOrmSettings;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Field;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.Indexed;
 import org.hibernate.search.v6poc.entity.pojo.mapping.definition.annotation.IndexedEmbedded;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.rule.BackendMock;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.impl.StubBackendFactory;
 import org.hibernate.search.v6poc.util.impl.integrationtest.orm.OrmUtils;
 import org.hibernate.search.v6poc.util.impl.test.annotation.TestForIssue;
-import org.hibernate.service.ServiceRegistry;
 
-import org.junit.After;
-import org.junit.Before;
-import org.junit.Rule;
 import org.junit.Test;
 
 /**
- * Test automatic indexing based on Hibernate ORM entity events.
- *
- * This test only checks updates involving a single-valued association.
- * Other tests in the same package check more basic, direct updates or updates involving different associations.
+ * Test automatic indexing based on Hibernate ORM entity events
+ * when a ToOne association is involved.
+ * <p>
+ * See {@link AbstractOrmAutomaticIndexingAssociationIT} for more details on how this test is designed.
  */
-public class OrmAutomaticIndexingSingleAssociationIT {
+public class OrmAutomaticIndexingSingleAssociationIT extends AbstractOrmAutomaticIndexingAssociationIT<
+		OrmAutomaticIndexingSingleAssociationIT.IndexedEntity,
+		OrmAutomaticIndexingSingleAssociationIT.ContainingEntity,
+		OrmAutomaticIndexingSingleAssociationIT.ContainedEntity
+		> {
 
-	private static final String PREFIX = SearchOrmSettings.PREFIX;
-
-	@Rule
-	public BackendMock backendMock = new BackendMock( "stubBackend" );
-
-	private SessionFactory sessionFactory;
-
-	@Before
-	public void setup() {
-		StandardServiceRegistryBuilder registryBuilder = new StandardServiceRegistryBuilder()
-				.applySetting( PREFIX + "backend.stubBackend.type", StubBackendFactory.class.getName() )
-				.applySetting( PREFIX + "index.default.backend", "stubBackend" );
-
-		ServiceRegistry serviceRegistry = registryBuilder.build();
-
-		MetadataSources ms = new MetadataSources( serviceRegistry )
-				.addAnnotatedClass( IndexedEntity.class )
-				.addAnnotatedClass( ContainedEntity.class );
-
-		Metadata metadata = ms.buildMetadata();
-
-		final SessionFactoryBuilder sfb = metadata.getSessionFactoryBuilder();
-
-		backendMock.expectSchema( IndexedEntity.INDEX, b -> b
-				.objectField( "containedIndexedEmbedded", b2 -> b2
-						.field( "indexedField", String.class )
-						.field( "indexedElementCollectionField", String.class )
-				)
-				.objectField( "child", b3 -> b3
-						.objectField( "containedIndexedEmbedded", b2 -> b2
-								.field( "indexedField", String.class )
-								.field( "indexedElementCollectionField", String.class )
-						)
-				)
-		);
-
-		sessionFactory = sfb.build();
-		backendMock.verifyExpectationsMet();
-	}
-
-	@After
-	public void cleanup() {
-		if ( sessionFactory != null ) {
-			sessionFactory.close();
-		}
+	public OrmAutomaticIndexingSingleAssociationIT() {
+		super( new SingleAssociationModelPrimitives() );
 	}
 
 	@Test
@@ -419,447 +367,99 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 		backendMock.verifyExpectationsMet();
 	}
 
-	@Test
-	public void indirectValueUpdate_singleValue_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
+	private static class SingleAssociationModelPrimitives
+			implements AssociationModelPrimitives<IndexedEntity, ContainingEntity, ContainedEntity> {
 
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
+		@Override
+		public String getIndexName() {
+			return IndexedEntity.INDEX;
+		}
 
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
+		@Override
+		public Class<IndexedEntity> getIndexedClass() {
+			return IndexedEntity.class;
+		}
 
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.setIndexedField( "initialValue" );
-			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
-			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
+		@Override
+		public Class<ContainingEntity> getContainingClass() {
+			return ContainingEntity.class;
+		}
 
-			ContainedEntity containedEntity2 = new ContainedEntity();
-			containedEntity2.setId( 5 );
-			containedEntity2.setIndexedField( "initialOutOfScopeValue" );
-			deeplyNestedContainingEntity.setContainedIndexedEmbedded( containedEntity2 );
-			containedEntity2.setContainingAsIndexedEmbedded( deeplyNestedContainingEntity );
+		@Override
+		public Class<ContainedEntity> getContainedClass() {
+			return ContainedEntity.class;
+		}
 
-			session.persist( containedEntity1 );
-			session.persist( containedEntity2 );
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
+		@Override
+		public IndexedEntity newIndexed(int id) {
+			IndexedEntity entity = new IndexedEntity();
+			entity.setId( id );
+			return entity;
+		}
 
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", "initialValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
+		@Override
+		public ContainingEntity newContaining(int id) {
+			ContainingEntity entity = new ContainingEntity();
+			entity.setId( id );
+			return entity;
+		}
 
-		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.setIndexedField( "updatedValue" );
+		@Override
+		public ContainedEntity newContained(int id) {
+			ContainedEntity entity = new ContainedEntity();
+			entity.setId( id );
+			return entity;
+		}
 
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", "updatedValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
+		@Override
+		public void setChild(ContainingEntity parent, ContainingEntity child) {
+			parent.setChild( child );
+		}
 
-		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
-			containedEntity.setIndexedField( "updatedOutOfScopeValue" );
+		@Override
+		public void setParent(ContainingEntity child, ContainingEntity parent) {
+			child.setParent( parent );
+		}
 
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
+		@Override
+		public void setContainedIndexedEmbeddedSingle(ContainingEntity containingEntity, ContainedEntity containedEntity) {
+			containingEntity.setContainedIndexedEmbedded( containedEntity );
+		}
 
-	/**
-	 * Test that updating a non-IndexedEmbedded, basic property in an entity
-	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
-	 * does not trigger reindexing of the indexed entity.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectValueUpdate_singleValue_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
+		@Override
+		public void setContainingAsIndexedEmbeddedSingle(ContainedEntity containedEntity, ContainingEntity containingEntity) {
+			containedEntity.setContainingAsIndexedEmbedded( containingEntity );
+		}
 
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
+		@Override
+		public void setIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setIndexedField( value );
+		}
 
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.setIndexedField( "initialValue" );
-			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
-			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
+		@Override
+		public void setNonIndexedField(ContainedEntity containedEntity, String value) {
+			containedEntity.setNonIndexedField( value );
+		}
 
-			session.persist( containedEntity1 );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
+		@Override
+		public List<String> getIndexedElementCollectionField(ContainedEntity containedEntity) {
+			return containedEntity.getIndexedElementCollectionField();
+		}
 
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", "initialValue" )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
+		@Override
+		public void setIndexedElementCollectionField(ContainedEntity containedEntity, List<String> value) {
+			containedEntity.setIndexedElementCollectionField( value );
+		}
 
-		// Test updating the value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.setNonIndexedField( "updatedValue" );
+		@Override
+		public List<String> getNonIndexedElementCollectionField(ContainedEntity containedEntity) {
+			return containedEntity.getNonIndexedElementCollectionField();
+		}
 
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	@Test
-	public void indirectValueUpdate_elementCollectionValue_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
-
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.getIndexedElementCollectionField().add( "firstValue" );
-			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
-			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
-
-			ContainedEntity containedEntity2 = new ContainedEntity();
-			containedEntity2.setId( 5 );
-			containedEntity2.getIndexedElementCollectionField().add( "firstOutOfScopeValue" );
-			deeplyNestedContainingEntity.setContainedIndexedEmbedded( containedEntity2 );
-			containedEntity2.setContainingAsIndexedEmbedded( deeplyNestedContainingEntity );
-
-			session.persist( containedEntity1 );
-			session.persist( containedEntity2 );
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", null )
-											.field(
-													"indexedElementCollectionField",
-													"firstValue"
-											)
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.getIndexedElementCollectionField().add( "secondValue" );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", null )
-											.field(
-													"indexedElementCollectionField",
-													"firstValue", "secondValue"
-											)
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.getIndexedElementCollectionField().remove( 0 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", null )
-											.field(
-													"indexedElementCollectionField",
-													"secondValue"
-											)
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test updating a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
-			containedEntity.getIndexedElementCollectionField().add( "secondOutOfScopeValue" );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing a non-IndexedEmbedded, ElementCollection property in an entity
-	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
-	 * does trigger reindexing of the indexed entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectValueReplace_elementCollectionValue_indexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainingEntity deeplyNestedContainingEntity = new ContainingEntity();
-			deeplyNestedContainingEntity.setId( 3 );
-			containingEntity1.setChild( deeplyNestedContainingEntity );
-			deeplyNestedContainingEntity.setParent( containingEntity1 );
-
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.getIndexedElementCollectionField().add( "firstValue" );
-			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
-			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
-
-			ContainedEntity containedEntity2 = new ContainedEntity();
-			containedEntity2.setId( 5 );
-			containedEntity2.getIndexedElementCollectionField().add( "firstOutOfScopeValue" );
-			deeplyNestedContainingEntity.setContainedIndexedEmbedded( containedEntity2 );
-			containedEntity2.setContainingAsIndexedEmbedded( deeplyNestedContainingEntity );
-
-			session.persist( containedEntity1 );
-			session.persist( containedEntity2 );
-			session.persist( deeplyNestedContainingEntity );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", null )
-											.field(
-													"indexedElementCollectionField",
-													"firstValue"
-											)
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test replacing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.setIndexedElementCollectionField( new ArrayList<>( Arrays.asList(
-					"newFirstValue", "newSecondValue"
-			) ) );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", null )
-											.field(
-													"indexedElementCollectionField",
-													"newFirstValue", "newSecondValue"
-											)
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test replacing a value that is too deeply nested to matter (it's out of the IndexedEmbedded scope)
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 5 );
-			containedEntity.setIndexedElementCollectionField( new ArrayList<>( Arrays.asList(
-					"newFirstOutOfScopeValue", "newSecondOutOfScopeValue"
-			) ) );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that updating a non-IndexedEmbedded, ElementCollection property in an entity
-	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
-	 * does not trigger reindexing of the indexed entity.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3199")
-	public void indirectValueUpdate_elementCollectionValue_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.getIndexedElementCollectionField().add( "firstValue" );
-			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
-			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
-
-			session.persist( containedEntity1 );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", null )
-											.field(
-													"indexedElementCollectionField",
-													"firstValue"
-											)
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test adding a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.getNonIndexedElementCollectionField().add( "secondValue" );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test removing a value
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.getNonIndexedElementCollectionField().remove( 0 );
-
-			// Do not expect any work
-		} );
-		backendMock.verifyExpectationsMet();
-	}
-
-	/**
-	 * Test that replacing a non-IndexedEmbedded, ElementCollection property in an entity
-	 * whose properties are otherwise used in an IndexedEmbedded from an indexed entity
-	 * does not trigger reindexing of the indexed entity.
-	 * <p>
-	 * We need dedicated tests for this because Hibernate ORM does not handle
-	 * replaced collections the same way as it does updated collections.
-	 */
-	@Test
-	@TestForIssue(jiraKey = "HSEARCH-3204")
-	public void indirectValueReplace_elementCollectionValue_nonIndexedEmbedded() {
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			IndexedEntity entity1 = new IndexedEntity();
-			entity1.setId( 1 );
-
-			ContainingEntity containingEntity1 = new ContainingEntity();
-			containingEntity1.setId( 2 );
-			entity1.setChild( containingEntity1 );
-			containingEntity1.setParent( entity1 );
-
-			ContainedEntity containedEntity1 = new ContainedEntity();
-			containedEntity1.setId( 4 );
-			containedEntity1.getNonIndexedElementCollectionField().add( "firstValue" );
-			containingEntity1.setContainedIndexedEmbedded( containedEntity1 );
-			containedEntity1.setContainingAsIndexedEmbedded( containingEntity1 );
-
-			session.persist( containedEntity1 );
-			session.persist( containingEntity1 );
-			session.persist( entity1 );
-
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.add( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", null )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
-
-		// Test replacing the values
-		OrmUtils.withinTransaction( sessionFactory, session -> {
-			ContainedEntity containedEntity = session.get( ContainedEntity.class, 4 );
-			containedEntity.setNonIndexedElementCollectionField( new ArrayList<>( Arrays.asList(
-					"newFirstValue", "newSecondValue"
-			) ) );
-
-			// TODO HSEARCH-3204: remove the statement below to not expect any work
-			backendMock.expectWorks( IndexedEntity.INDEX )
-					.update( "1", b -> b
-							.objectField( "child", b2 -> b2
-									.objectField( "containedIndexedEmbedded", b3 -> b3
-											.field( "indexedField", null )
-									)
-							)
-					)
-					.preparedThenExecuted();
-		} );
-		backendMock.verifyExpectationsMet();
+		@Override
+		public void setNonIndexedElementCollectionField(ContainedEntity containedEntity, List<String> value) {
+			containedEntity.setNonIndexedElementCollectionField( value );
+		}
 	}
 
 	@Entity(name = "containing")
@@ -1014,8 +614,7 @@ public class OrmAutomaticIndexingSingleAssociationIT {
 			return nonIndexedElementCollectionField;
 		}
 
-		public void setNonIndexedElementCollectionField(
-				List<String> nonIndexedElementCollectionField) {
+		public void setNonIndexedElementCollectionField(List<String> nonIndexedElementCollectionField) {
 			this.nonIndexedElementCollectionField = nonIndexedElementCollectionField;
 		}
 	}


### PR DESCRIPTION
We already factorized code for multi-valued association tests, now let's
factorize code for tests of any association (single-valued or
multi-valued).

As a side-effect, this adds a few test methods to the multi-valued association tests that were previously missing.