### PR TITLE
HSEARCH-3176 Use Contracts#assertNotNull()

### DIFF
--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/client/impl/GsonHttpEntity.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/client/impl/GsonHttpEntity.java
@@ -14,12 +14,7 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Objects;
 
-import org.hibernate.search.v6poc.util.SearchException;
-
-import com.google.gson.Gson;
-import com.google.gson.JsonObject;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.entity.ContentType;
@@ -28,6 +23,11 @@ import org.apache.http.nio.ContentEncoder;
 import org.apache.http.nio.IOControl;
 import org.apache.http.nio.entity.HttpAsyncContentProducer;
 import org.apache.http.protocol.HTTP;
+import org.hibernate.search.v6poc.util.SearchException;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 
 /**
  * Optimised adapter to encode GSON objects into HttpEntity instances.
@@ -122,8 +122,8 @@ final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProducer {
 			new ProgressiveCharBufferWriter( CHARSET, CHAR_BUFFER_SIZE, BYTE_BUFFER_PAGE_SIZE );
 
 	public GsonHttpEntity(Gson gson, List<JsonObject> bodyParts) {
-		Objects.requireNonNull( gson );
-		Objects.requireNonNull( bodyParts );
+		Contracts.assertNotNull( gson, "gson" );
+		Contracts.assertNotNull( bodyParts, "bodyParts" );
 		this.gson = gson;
 		this.bodyParts = bodyParts;
 		this.contentLength = -1;
@@ -254,7 +254,7 @@ final class GsonHttpEntity implements HttpEntity, HttpAsyncContentProducer {
 
 	@Override
 	public void produceContent(ContentEncoder encoder, IOControl ioctrl) throws IOException {
-		Objects.requireNonNull( encoder );
+		Contracts.assertNotNull( encoder, "encoder" );
 		// Warning: this method is possibly invoked multiple times, depending on the output buffers
 		// to have available space !
 		// Production of data is expected to complete only after we invoke ContentEncoder#complete.

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/util/impl/URLEncodedString.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/util/impl/URLEncodedString.java
@@ -9,9 +9,9 @@ package org.hibernate.search.v6poc.backend.elasticsearch.util.impl;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
-import java.util.Objects;
 
 import org.hibernate.search.v6poc.util.AssertionFailure;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
 
 import com.google.gson.JsonElement;
 
@@ -68,12 +68,12 @@ public final class URLEncodedString {
 	}
 
 	public static URLEncodedString fromString(String string) {
-		Objects.requireNonNull( string );
+		Contracts.assertNotNull( string, "string" );
 		return new URLEncodedString( string );
 	}
 
 	public static URLEncodedString fromJSon(JsonElement jsonElement) {
-		Objects.requireNonNull( jsonElement );
+		Contracts.assertNotNull( jsonElement, "jsonElement" );
 		return fromString( jsonElement.getAsString() );
 	}
 

--- a/build-config/src/main/resources/forbidden-runtime.txt
+++ b/build-config/src/main/resources/forbidden-runtime.txt
@@ -13,21 +13,21 @@
 java.awt.**
 sun.**
 org.slf4j.**
-junit.framework.**
+junit.framework.** @ Use the classes from org.junit, junit.framework is deprecated
 
 ################################################################################################################
 # Nobody should be using StringBuffer anymore
-java.lang.StringBuffer
+java.lang.StringBuffer @ Do not use StringBuffer: use StringBuilder
 
 ################################################################################################################
 # Probably meant the other Objects:
 
-org.jboss.logging.processor.util.Objects
+org.jboss.logging.processor.util.Objects @ Bad import, use java.util.Objects
 
 ################################################################################################################
 # Methods from Hibernate ORM :
 # This one is only safe to use with specific configurations:
-org.hibernate.SharedSessionContract#getTransaction()
+org.hibernate.SharedSessionContract#getTransaction() @ Using this method is often unsafe
 
 ################################################################################################################
 # Use our Contracts class instead

--- a/build-config/src/main/resources/forbidden-runtime.txt
+++ b/build-config/src/main/resources/forbidden-runtime.txt
@@ -28,3 +28,9 @@ org.jboss.logging.processor.util.Objects
 # Methods from Hibernate ORM :
 # This one is only safe to use with specific configurations:
 org.hibernate.SharedSessionContract#getTransaction()
+
+################################################################################################################
+# Use our Contracts class instead
+com.google.common.base.Preconditions @ Use our Contracts class instead
+java.util.Objects#requireNonNull(java.lang.Object) @ Use our Contracts class instead
+java.util.Objects#requireNonNull(java.lang.Object, java.lang.String) @ Use our Contracts class instead

--- a/engine/src/main/java/org/hibernate/search/v6poc/cfg/impl/MaskedConfigurationPropertySource.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/cfg/impl/MaskedConfigurationPropertySource.java
@@ -6,18 +6,20 @@
  */
 package org.hibernate.search.v6poc.cfg.impl;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import org.hibernate.search.v6poc.cfg.ConfigurationPropertySource;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
 
 public class MaskedConfigurationPropertySource implements ConfigurationPropertySource {
 	private final ConfigurationPropertySource propertiesToMask;
 	private final String radix;
 
-	public MaskedConfigurationPropertySource(ConfigurationPropertySource toMask, String mask) {
-		this.propertiesToMask = Objects.requireNonNull( toMask );
-		this.radix = Objects.requireNonNull( mask ) + ".";
+	public MaskedConfigurationPropertySource(ConfigurationPropertySource propertiesToMask, String mask) {
+		Contracts.assertNotNull( propertiesToMask, "propertiesToMask" );
+		Contracts.assertNotNull( mask, "mask" );
+		this.propertiesToMask = propertiesToMask;
+		this.radix = mask + ".";
 	}
 
 	@Override

--- a/engine/src/main/java/org/hibernate/search/v6poc/cfg/impl/PrefixedConfigurationPropertySource.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/cfg/impl/PrefixedConfigurationPropertySource.java
@@ -6,19 +6,21 @@
  */
 package org.hibernate.search.v6poc.cfg.impl;
 
-import java.util.Objects;
 import java.util.Optional;
 
 import org.hibernate.search.v6poc.cfg.ConfigurationPropertySource;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
 
 public class PrefixedConfigurationPropertySource implements ConfigurationPropertySource {
 	private final ConfigurationPropertySource propertiesToPrefix;
 	private final String radix;
 	private final int radixLength;
 
-	public PrefixedConfigurationPropertySource(ConfigurationPropertySource toPrefix, String mask) {
-		this.propertiesToPrefix = Objects.requireNonNull( toPrefix );
-		this.radix = Objects.requireNonNull( mask ) + ".";
+	public PrefixedConfigurationPropertySource(ConfigurationPropertySource propertiesToPrefix, String prefix) {
+		Contracts.assertNotNull( propertiesToPrefix, "propertiesToPrefix" );
+		Contracts.assertNotNull( prefix, "prefix" );
+		this.propertiesToPrefix = propertiesToPrefix;
+		this.radix = prefix + ".";
 		this.radixLength = radix.length();
 	}
 

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/util/impl/GenericTypeContext.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/util/impl/GenericTypeContext.java
@@ -14,11 +14,11 @@ import java.lang.reflect.TypeVariable;
 import java.lang.reflect.WildcardType;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 
 import org.hibernate.search.v6poc.entity.pojo.logging.impl.Log;
 import org.hibernate.search.v6poc.util.AssertionFailure;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
 import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 
 /**
@@ -69,7 +69,7 @@ public final class GenericTypeContext {
 	}
 
 	public GenericTypeContext(GenericTypeContext declaringContext, Type type) {
-		Objects.requireNonNull( type );
+		Contracts.assertNotNull( type, "type" );
 		if ( declaringContext != null ) {
 			this.resolvedType = declaringContext.resolveType( type );
 		}

--- a/mapper-pojo/src/test/java/org/hibernate/search/v6poc/entity/pojo/util/impl/GenericTypeContextTest.java
+++ b/mapper-pojo/src/test/java/org/hibernate/search/v6poc/entity/pojo/util/impl/GenericTypeContextTest.java
@@ -21,7 +21,6 @@ import org.hibernate.search.v6poc.entity.pojo.test.util.TypeCapture;
 import org.hibernate.search.v6poc.entity.pojo.test.util.WildcardTypeCapture;
 import org.hibernate.search.v6poc.entity.pojo.test.util.WildcardTypeCapture.Of;
 import org.hibernate.search.v6poc.util.SearchException;
-
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -79,13 +78,13 @@ public class GenericTypeContextTest {
 
 	@Test
 	public void nullType() {
-		thrown.expect( NullPointerException.class );
+		thrown.expect( IllegalArgumentException.class );
 		new GenericTypeContext( null );
 	}
 
 	@Test
 	public void nullType_nonNullContext() {
-		thrown.expect( NullPointerException.class );
+		thrown.expect( IllegalArgumentException.class );
 		GenericTypeContext declaringContext = new GenericTypeContext( Object.class );
 		new GenericTypeContext( declaringContext, null );
 	}

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/bootstrap/impl/HibernateOrmBeanContainerBeanResolver.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/bootstrap/impl/HibernateOrmBeanContainerBeanResolver.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.v6poc.entity.orm.bootstrap.impl;
 
-import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 import org.hibernate.resource.beans.container.spi.BeanContainer;
@@ -16,6 +15,7 @@ import org.hibernate.resource.beans.spi.BeanInstanceProducer;
 import org.hibernate.search.v6poc.engine.spi.BeanResolver;
 import org.hibernate.search.v6poc.engine.spi.ReflectionBeanResolver;
 import org.hibernate.search.v6poc.util.impl.common.Closer;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
 
 /**
  * A {@link BeanResolver} relying on a Hibernate ORM {@link BeanContainer} to resolve beans.
@@ -53,7 +53,7 @@ final class HibernateOrmBeanContainerBeanResolver implements BeanResolver {
 	};
 
 	HibernateOrmBeanContainerBeanResolver(BeanContainer beanContainer) {
-		Objects.requireNonNull( beanContainer );
+		Contracts.assertNotNull( beanContainer, "beanContainer" );
 		this.beanContainer = beanContainer;
 	}
 

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/event/impl/OptimalEventsHibernateSearchState.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/event/impl/OptimalEventsHibernateSearchState.java
@@ -6,9 +6,8 @@
  */
 package org.hibernate.search.v6poc.entity.orm.event.impl;
 
-import java.util.Objects;
-
 import org.hibernate.search.v6poc.entity.orm.impl.HibernateSearchContextService;
+import org.hibernate.search.v6poc.util.impl.common.Contracts;
 
 /**
  * The implementation of EventsHibernateSearchState used at runtime,
@@ -22,7 +21,7 @@ final class OptimalEventsHibernateSearchState implements EventsHibernateSearchSt
 	private final HibernateSearchContextService context;
 
 	public OptimalEventsHibernateSearchState(HibernateSearchContextService context) {
-		Objects.requireNonNull( context );
+		Contracts.assertNotNull( context, "context" );
 		this.context = context;
 	}
 

--- a/pom.xml
+++ b/pom.xml
@@ -554,10 +554,6 @@
                                 </bundledSignatures>
                                 <failOnMissingClasses>false</failOnMissingClasses>
                                 <failOnUnresolvableSignatures>false</failOnUnresolvableSignatures>
-                                <!--
-                                The method SharedSessionContract#getTransaction() should never be used
-                                as it is only reliable in certain configurations.
-                                 -->
                                 <signaturesArtifacts>
                                     <signaturesArtifact>
                                         <groupId>org.hibernate.search.v6poc</groupId>


### PR DESCRIPTION
https://hibernate.atlassian.net/browse/HSEARCH-3176

So gson does not depend on Guava but I added it anyway, who knows...

We have a few warnings when building the forbidden-apis configuration:
```
[WARNING] Class 'org.jboss.logging.processor.util.Objects' not found on classpath while parsing signature: org.jboss.logging.processor.util.Objects [signature ignored]
[WARNING] Class 'org.hibernate.SharedSessionContract' not found on classpath while parsing signature: org.hibernate.SharedSessionContract#getTransaction() [signature ignored]
```
and
```
[WARNING] Class 'org.jboss.logging.processor.util.Objects' not found on classpath while parsing signature: org.jboss.logging.processor.util.Objects [signature ignored]
[WARNING] Class 'org.hibernate.search.spi.SearchIntegratorBuilder' not found on classpath while parsing signature: org.hibernate.search.spi.SearchIntegratorBuilder#buildSearchIntegrator() [signature ignored]
```

As for the first one, it doesn't seem to be accessible anymore from our classpath so maybe we should remove it. If not, we should explicitly add a dependency to the build-config pom.

As for the second one, we could add an ORM dependency to the build-config pom.

As for the last one, I suppose it's coming from the old Search considering the package name? We can't really do that anyway as we would have a circular dependency.