### PR TITLE
Backend dependency upgrades

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,7 +51,7 @@
         <version.org.elasticsearch.client>5.6.6</version.org.elasticsearch.client>
         <version.com.google.code.gson>2.8.0</version.com.google.code.gson>
         <version.com.google.protobuf>3.0.2</version.com.google.protobuf>
-        <version.org.apache.lucene>7.2.1</version.org.apache.lucene>
+        <version.org.apache.lucene>7.4.0</version.org.apache.lucene>
 
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.log4j>1.2.16</version.log4j>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,7 @@
         <version.javax.persistence>2.2</version.javax.persistence>
         <version.javax.enterprise>2.0</version.javax.enterprise>
 
-        <version.org.elasticsearch.client>5.6.6</version.org.elasticsearch.client>
+        <version.org.elasticsearch.client>6.3.1</version.org.elasticsearch.client>
         <version.com.google.code.gson>2.8.0</version.com.google.code.gson>
         <version.com.google.protobuf>3.0.2</version.com.google.protobuf>
         <version.org.apache.lucene>7.4.0</version.org.apache.lucene>
@@ -1303,6 +1303,51 @@
                                 <timeout>90</timeout><!-- Make it work on our slow CI -->
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/5.0/configuration/</pathConf>
                                 <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/5.0/init/init.script</pathInitScript>
+                                <autoCreateIndex>false</autoCreateIndex>
+                            </configuration>
+                            <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->
+                            <executions>
+                                <execution >
+                                    <id>start-elasticsearch</id>
+                                    <phase>pre-integration-test</phase>
+                                    <goals>
+                                        <goal>runforked</goal>
+                                    </goals>
+                                </execution>
+                                <execution>
+                                    <id>stop-elasticsearch</id>
+                                    <phase>post-integration-test</phase>
+                                    <goals>
+                                        <goal>stop</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+
+        <!-- Elasticsearch 6.0+ test environment -->
+        <profile>
+            <id>elasticsearch-6.0</id>
+            <properties>
+                <test.elasticsearch.mavenPlugin.version>6.6</test.elasticsearch.mavenPlugin.version>
+                <test.elasticsearch.host.version>6.3.1</test.elasticsearch.host.version>
+            </properties>
+            <build>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.github.alexcojocaru</groupId>
+                            <artifactId>elasticsearch-maven-plugin</artifactId>
+                            <version>${test.elasticsearch.mavenPlugin.version}</version>
+                            <configuration>
+                                <skip>${test.elasticsearch.host.provided}</skip>
+                                <version>${test.elasticsearch.host.version}</version>
+                                <timeout>90</timeout><!-- Make it work on our slow CI -->
+                                <pathConf>${project.build.directory}/elasticsearch-maven-plugin/6.0/configuration/</pathConf>
+                                <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/6.0/init/init.script</pathInitScript>
                                 <autoCreateIndex>false</autoCreateIndex>
                             </configuration>
                             <!-- Different executions from 2.x: the "start" goal has been renamed in version 5  -->

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/elasticsearch.yml
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/elasticsearch.yml
@@ -1,0 +1,66 @@
+# ======================== Elasticsearch Configuration =========================
+#
+# NOTE: Elasticsearch comes with reasonable defaults for most settings.
+#       Before you set out to tweak and tune the configuration, make sure you
+#       understand what are you trying to accomplish and the consequences.
+#
+# The primary way of configuring a node is via this file. This template lists
+# the most important settings you may want to configure for a production cluster.
+#
+# Please consult the documentation for further information on configuration options:
+# https://www.elastic.co/guide/en/elasticsearch/reference/index.html
+#
+# ----------------------------------- Memory -----------------------------------
+#
+# Lock the memory on startup:
+#
+bootstrap.memory_lock: true
+#
+# Make sure that the heap size is set to about half the memory available
+# on the system and that the owner of the process is allowed to use this
+# limit.
+#
+# Elasticsearch performs poorly when the system is swapping the memory.
+#
+# ---------------------------------- Network -----------------------------------
+#
+# Set the bind address to a specific IP (IPv4 or IPv6):
+#
+network.host: _local_
+#
+# Set a custom port for HTTP:
+#
+http.port: 9200
+#
+# For more information, consult the network module documentation.
+#
+# --------------------------------- Discovery ----------------------------------
+#
+# Pass an initial list of hosts to perform discovery when new node is started:
+# The default list of hosts is ["127.0.0.1", "[::1]"]
+#
+#discovery.zen.ping.unicast.hosts: ["host1", "host2"]
+#
+# Prevent the "split brain" by configuring the majority of nodes (total number of master-eligible nodes / 2 + 1):
+#
+discovery.zen.minimum_master_nodes: 1
+#
+# For more information, consult the zen discovery module documentation.
+#
+# ---------------------------------- Gateway -----------------------------------
+#
+# Block initial recovery after a full cluster restart until N nodes are started:
+#
+#gateway.recover_after_nodes: 3
+#
+# For more information, consult the gateway module documentation.
+#
+# ---------------------------------- Various -----------------------------------
+#
+# Require explicit names when deleting indices:
+#
+#action.destructive_requires_name: true
+#
+# Disable starting multiple nodes on a single system:
+#
+node.max_local_storage_nodes: 1

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/jvm.options
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/jvm.options
@@ -1,0 +1,105 @@
+## JVM configuration
+
+################################################################
+## IMPORTANT: JVM heap size
+################################################################
+##
+## You should always set the min and max JVM heap
+## size to the same value. For example, to set
+## the heap to 4 GB, set:
+##
+## -Xms4g
+## -Xmx4g
+##
+## See https://www.elastic.co/guide/en/elasticsearch/reference/current/heap-size.html
+## for more information
+##
+################################################################
+
+# Xms represents the initial size of total heap space
+# Xmx represents the maximum size of total heap space
+
+# For Hibernate Search, we don't need as much as the default 2g
+# Let's keep it low, so that we'll be able to run tests
+# on memory-constrained CI slaves
+-Xms256m
+-Xmx256m
+
+################################################################
+## Expert settings
+################################################################
+##
+## All settings below this section are considered
+## expert settings. Don't tamper with them unless
+## you understand what you are doing
+##
+################################################################
+
+## GC configuration
+-XX:+UseConcMarkSweepGC
+-XX:CMSInitiatingOccupancyFraction=75
+-XX:+UseCMSInitiatingOccupancyOnly
+
+## optimizations
+
+# pre-touch memory pages used by the JVM during initialization
+-XX:+AlwaysPreTouch
+
+## basic
+
+# explicitly set the stack size
+-Xss1m
+
+# set to headless, just in case
+-Djava.awt.headless=true
+
+# ensure UTF-8 encoding by default (e.g. filenames)
+-Dfile.encoding=UTF-8
+
+# use our provided JNA always versus the system one
+-Djna.nosys=true
+
+# turn off a JDK optimization that throws away stack traces for common
+# exceptions because stack traces are important for debugging
+-XX:-OmitStackTraceInFastThrow
+
+# flags to configure Netty
+-Dio.netty.noUnsafe=true
+-Dio.netty.noKeySetOptimization=true
+-Dio.netty.recycler.maxCapacityPerThread=0
+
+# log4j 2
+-Dlog4j.shutdownHookEnabled=false
+-Dlog4j2.disable.jmx=true
+
+-Djava.io.tmpdir=${ES_TMPDIR}
+
+## heap dumps
+
+# generate a heap dump when an allocation from the Java heap fails
+# heap dumps are created in the working directory of the JVM
+-XX:+HeapDumpOnOutOfMemoryError
+
+# specify an alternative path for heap dumps; ensure the directory exists and
+# has sufficient space
+#${heap.dump.path}
+
+# specify an alternative path for JVM fatal error logs
+#${error.file}
+
+## JDK 8 GC logging
+
+#8:-XX:+PrintGCDetails
+#8:-XX:+PrintGCDateStamps
+#8:-XX:+PrintTenuringDistribution
+#8:-XX:+PrintGCApplicationStoppedTime
+#8:-Xloggc:${loggc}
+#8:-XX:+UseGCLogFileRotation
+#8:-XX:NumberOfGCLogFiles=32
+#8:-XX:GCLogFileSize=64m
+
+# JDK 9+ GC logging
+#9-:-Xlog:gc*,gc+age=trace,safepoint:file=${loggc}:utctime,pid,tags:filecount=32,filesize=64m
+# due to internationalization enhancements in JDK 9 Elasticsearch need to set the provider to COMPAT otherwise
+# time/date parsing will break in an incompatible way for some date patterns and locals
+#9-:-Djava.locale.providers=COMPAT

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/log4j2.properties
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/configuration/log4j2.properties
@@ -1,0 +1,36 @@
+status = error
+appenders = console
+loggers = action, metadata, cluster, settings, deprecation, slow_search, slow_indexing
+
+# log action execution errors for easier debugging
+logger.action.name = org.elasticsearch.action
+logger.action.level = info
+
+# do not log metadata too much as we generate a log of noise
+logger.metadata.name = org.elasticsearch.cluster.metadata
+logger.metadata.level = warn
+
+logger.cluster.name = org.elasticsearch.cluster.routing.allocation
+logger.cluster.level = warn
+
+logger.settings.name = org.elasticsearch.common.settings
+logger.settings.level = warn
+
+logger.deprecation.name = org.elasticsearch.deprecation
+logger.deprecation.level = warn
+
+# Warn us about using inefficient Search operations
+logger.slow_search.name = index.search.slowlog
+logger.slow_search.level = trace
+
+# Warn us about using inefficient indexing actions
+logger.slow_indexing.name = index.indexing.slowlog
+logger.slow_indexing.level = trace
+
+appender.console.type = Console
+appender.console.name = console
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{ABSOLUTE} (%t) %5p %c{1}:%L - %m%n
+
+rootLogger.level = info
+rootLogger.appenderRef.console.ref = console

--- a/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/init/init.script
+++ b/util/internal/integrationtest/sharedresources/src/main/elasticsearch-maven-plugin/6.0/init/init.script
@@ -1,0 +1,6 @@
+PUT:_template/lightweight_index:{ "template" : "*", "order": -9999, "settings" : { "number_of_shards" : 1, "number_of_replicas" : 0 } }
+PUT:_template/slowlogs_search_level:{ "template" : "*", "order": -9999, "settings" : { "index.search.slowlog.level": "debug" } }
+PUT:_template/slowlogs_indexing_level:{ "template" : "*", "order": -9999, "settings" : { "index.indexing.slowlog.level": "debug" } }
+PUT:_template/slowlogs_search_threshold_query:{ "template" : "*", "order": -9999, "settings" : { "index.search.slowlog.threshold.query.warn": "5s", "index.search.slowlog.threshold.query.info": "500ms", "index.search.slowlog.threshold.query.debug": "100ms", "index.search.slowlog.threshold.query.trace": "10ms" } }
+PUT:_template/slowlogs_search_threshold_fetch:{ "template" : "*", "order": -9999, "settings" : { "index.search.slowlog.threshold.fetch.warn": "1s", "index.search.slowlog.threshold.fetch.info": "200ms", "index.search.slowlog.threshold.fetch.debug": "100ms", "index.search.slowlog.threshold.fetch.trace": "10ms" } }
+PUT:_template/slowlogs_indexing_threshold_index:{ "template" : "*", "order": -9999, "settings" : { "index.indexing.slowlog.threshold.index.warn": "2s", "index.indexing.slowlog.threshold.index.info": "500ms", "index.indexing.slowlog.threshold.index.debug": "100ms", "index.indexing.slowlog.threshold.index.trace": "10ms" } }


### PR DESCRIPTION
 * https://hibernate.atlassian.net/browse/HSEARCH-3229
 * https://hibernate.atlassian.net/browse/HSEARCH-3227

I copied the 5.0 init script and config to a 6.0 directory, thinking it would be better to have one per major version. But we can use the 5.0 directory if you prefer.