### PR TITLE
HSEARCH-3231 Search 6 groundwork - Internalize index name normalization

### DIFF
--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/document/model/impl/ElasticsearchIndexModel.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/document/model/impl/ElasticsearchIndexModel.java
@@ -17,13 +17,16 @@ import org.hibernate.search.v6poc.backend.elasticsearch.document.model.impl.esna
  */
 public class ElasticsearchIndexModel {
 
-	private final URLEncodedString indexName;
+	private final String hibernateSearchIndexName;
+	private final URLEncodedString elasticsearchIndexName;
 	private final RootTypeMapping mapping;
 	private final Map<String, ElasticsearchIndexSchemaObjectNode> objectNodes = new HashMap<>();
 	private final Map<String, ElasticsearchIndexSchemaFieldNode> fieldNodes = new HashMap<>();
 
-	public ElasticsearchIndexModel(URLEncodedString indexName, ElasticsearchRootIndexSchemaContributor contributor) {
-		this.indexName = indexName;
+	public ElasticsearchIndexModel(String hibernateSearchIndexName, URLEncodedString elasticsearchIndexName,
+			ElasticsearchRootIndexSchemaContributor contributor) {
+		this.hibernateSearchIndexName = hibernateSearchIndexName;
+		this.elasticsearchIndexName = elasticsearchIndexName;
 		this.mapping = contributor.contribute( new ElasticsearchIndexSchemaNodeCollector() {
 			@Override
 			public void collect(String absolutePath, ElasticsearchIndexSchemaObjectNode node) {
@@ -37,8 +40,12 @@ public class ElasticsearchIndexModel {
 		} );
 	}
 
-	public URLEncodedString getIndexName() {
-		return indexName;
+	public String getHibernateSearchIndexName() {
+		return hibernateSearchIndexName;
+	}
+
+	public URLEncodedString getElasticsearchIndexName() {
+		return elasticsearchIndexName;
 	}
 
 	public RootTypeMapping getMapping() {
@@ -57,7 +64,7 @@ public class ElasticsearchIndexModel {
 	public String toString() {
 		return new StringBuilder( getClass().getSimpleName() )
 				.append( "[" )
-				.append( "indexName=" ).append( indexName )
+				.append( "elasticsearchIndexName=" ).append( elasticsearchIndexName )
 				.append( ", mapping=" ).append( mapping )
 				.append( "]" )
 				.toString();

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/impl/ElasticsearchBackendImpl.java
@@ -8,6 +8,9 @@ package org.hibernate.search.v6poc.backend.elasticsearch.impl;
 
 import java.io.IOException;
 import java.lang.invoke.MethodHandles;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
 
 import org.hibernate.search.v6poc.backend.Backend;
 import org.hibernate.search.v6poc.backend.elasticsearch.ElasticsearchBackend;
@@ -48,6 +51,8 @@ class ElasticsearchBackendImpl implements BackendImplementor<ElasticsearchDocume
 	private final ElasticsearchWorkOrchestrator streamOrchestrator;
 	private final ElasticsearchWorkOrchestrator queryOrchestrator;
 
+	private final Map<String, String> hibernateSearchIndexNamesByElasticsearchIndexNames = new ConcurrentHashMap<>();
+
 	private final IndexingBackendContext indexingContext;
 	private final SearchBackendContext searchContext;
 
@@ -62,7 +67,18 @@ class ElasticsearchBackendImpl implements BackendImplementor<ElasticsearchDocume
 				this, client, workFactory, multiTenancyStrategy, streamOrchestrator
 		);
 		this.searchContext = new SearchBackendContext(
-				this, workFactory, multiTenancyStrategy, queryOrchestrator
+				this, workFactory,
+				new Function<String, String>() {
+					@Override
+					public String apply(String elasticsearchIndexName) {
+						String result = hibernateSearchIndexNamesByElasticsearchIndexNames.get( elasticsearchIndexName );
+						if ( result == null ) {
+							throw log.elasticsearchResponseUnknownIndexName( elasticsearchIndexName );
+						}
+						return result;
+					}
+				},
+				multiTenancyStrategy, queryOrchestrator
 		);
 	}
 
@@ -85,15 +101,20 @@ class ElasticsearchBackendImpl implements BackendImplementor<ElasticsearchDocume
 	}
 
 	@Override
-	public String normalizeIndexName(String rawIndexName) {
-		return ElasticsearchIndexNameNormalizer.normalize( rawIndexName );
-	}
-
-	@Override
 	public IndexManagerBuilder<ElasticsearchDocumentObjectBuilder> createIndexManagerBuilder(
-			String normalizedIndexName, boolean multiTenancyEnabled, BuildContext buildContext, ConfigurationPropertySource propertySource) {
+			String hibernateSearchIndexName, boolean multiTenancyEnabled, BuildContext buildContext, ConfigurationPropertySource propertySource) {
 		if ( multiTenancyEnabled && !multiTenancyStrategy.isMultiTenancySupported() ) {
-			throw log.multiTenancyRequiredButNotSupportedByBackend( name, normalizedIndexName );
+			throw log.multiTenancyRequiredButNotSupportedByBackend( name, hibernateSearchIndexName );
+		}
+
+		String elasticsearchIndexName = ElasticsearchIndexNameNormalizer.normalize( hibernateSearchIndexName );
+		String existingHibernateSearchIndexName = hibernateSearchIndexNamesByElasticsearchIndexNames.putIfAbsent(
+				elasticsearchIndexName, hibernateSearchIndexName
+		);
+		if ( existingHibernateSearchIndexName != null ) {
+			throw log.duplicateNormalizedIndexNames(
+					existingHibernateSearchIndexName, hibernateSearchIndexName, elasticsearchIndexName
+			);
 		}
 
 		ElasticsearchIndexSchemaRootNodeBuilder indexSchemaRootNodeBuilder =
@@ -101,7 +122,8 @@ class ElasticsearchBackendImpl implements BackendImplementor<ElasticsearchDocume
 
 		return new ElasticsearchIndexManagerBuilder(
 				indexingContext, searchContext,
-				normalizedIndexName, indexSchemaRootNodeBuilder, buildContext, propertySource
+				hibernateSearchIndexName, elasticsearchIndexName,
+				indexSchemaRootNodeBuilder, buildContext, propertySource
 		);
 	}
 

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/index/impl/ElasticsearchIndexManager.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/index/impl/ElasticsearchIndexManager.java
@@ -32,18 +32,20 @@ public class ElasticsearchIndexManager implements IndexManagerImplementor<Elasti
 	private final IndexingBackendContext indexingBackendContext;
 	private final SearchBackendContext searchBackendContext;
 
-	private final URLEncodedString name;
+	private final String hibernateSearchIndexName;
+	private final URLEncodedString elasticsearchIndexName;
 	private final URLEncodedString typeName;
 	private final ElasticsearchIndexModel model;
 
 	private final ElasticsearchWorkOrchestrator changesetOrchestrator;
 
 	ElasticsearchIndexManager(IndexingBackendContext indexingBackendContext, SearchBackendContext searchBackendContext,
-			URLEncodedString name, URLEncodedString typeName,
+			String hibernateSearchIndexName, URLEncodedString elasticsearchIndexName, URLEncodedString typeName,
 			ElasticsearchIndexModel model) {
 		this.indexingBackendContext = indexingBackendContext;
 		this.searchBackendContext = searchBackendContext;
-		this.name = name;
+		this.hibernateSearchIndexName = hibernateSearchIndexName;
+		this.elasticsearchIndexName = elasticsearchIndexName;
 		this.typeName = typeName;
 		this.model = model;
 		this.changesetOrchestrator = indexingBackendContext.createChangesetOrchestrator();
@@ -55,22 +57,18 @@ public class ElasticsearchIndexManager implements IndexManagerImplementor<Elasti
 		changesetOrchestrator.close();
 	}
 
-	public String getName() {
-		return name.original;
-	}
-
 	public ElasticsearchIndexModel getModel() {
 		return model;
 	}
 
 	@Override
 	public ChangesetIndexWorker<ElasticsearchDocumentObjectBuilder> createWorker(SessionContext sessionContext) {
-		return indexingBackendContext.createChangesetIndexWorker( changesetOrchestrator, name, typeName, sessionContext );
+		return indexingBackendContext.createChangesetIndexWorker( changesetOrchestrator, elasticsearchIndexName, typeName, sessionContext );
 	}
 
 	@Override
 	public StreamIndexWorker<ElasticsearchDocumentObjectBuilder> createStreamWorker(SessionContext sessionContext) {
-		return indexingBackendContext.createStreamIndexWorker( name, typeName, sessionContext );
+		return indexingBackendContext.createStreamIndexWorker( elasticsearchIndexName, typeName, sessionContext );
 	}
 
 	@Override
@@ -92,7 +90,8 @@ public class ElasticsearchIndexManager implements IndexManagerImplementor<Elasti
 	public String toString() {
 		return new StringBuilder( getClass().getSimpleName() )
 				.append( "[" )
-				.append( "name=" ).append( name.original )
+				.append( "name=" ).append( hibernateSearchIndexName )
+				.append( "elasticsearchName=" ).append( elasticsearchIndexName.original )
 				.append( "]" )
 				.toString();
 	}

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/index/impl/ElasticsearchIndexSearchTarget.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/index/impl/ElasticsearchIndexSearchTarget.java
@@ -34,7 +34,7 @@ class ElasticsearchIndexSearchTarget extends IndexSearchTargetBase {
 	public String toString() {
 		return new StringBuilder( getClass().getSimpleName() )
 				.append( "[" )
-				.append( "indexNames=" ).append( searchTargetModel.getIndexNames() )
+				.append( "indexNames=" ).append( searchTargetModel.getHibernateSearchIndexNames() )
 				.append( "]" )
 				.toString();
 	}

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/logging/impl/Log.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/logging/impl/Log.java
@@ -13,13 +13,13 @@ import java.util.Map;
 import org.hibernate.search.v6poc.backend.elasticsearch.document.model.impl.ElasticsearchIndexSchemaFieldNode;
 import org.hibernate.search.v6poc.backend.elasticsearch.document.model.impl.esnative.DataType;
 import org.hibernate.search.v6poc.backend.elasticsearch.index.impl.ElasticsearchIndexManager;
-import org.hibernate.search.v6poc.backend.elasticsearch.util.impl.URLEncodedString;
 import org.hibernate.search.v6poc.backend.index.spi.IndexSearchTargetBuilder;
 import org.hibernate.search.v6poc.backend.spi.BackendImplementor;
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.SearchSort;
 import org.hibernate.search.v6poc.util.AssertionFailure;
 import org.hibernate.search.v6poc.util.SearchException;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger.Level;
 import org.jboss.logging.annotations.Cause;
@@ -75,29 +75,29 @@ public interface Log extends BasicLogger {
 	SearchException cannotMixElasticsearchSearchTargetWithOtherBackend(IndexSearchTargetBuilder firstTarget, ElasticsearchIndexManager otherTarget);
 
 	@Message(id = 504, value = "Unknown field '%1$s' in indexes %2$s." )
-	SearchException unknownFieldForSearch(String absoluteFieldPath, Collection<URLEncodedString> indexNames);
+	SearchException unknownFieldForSearch(String absoluteFieldPath, Collection<String> indexNames);
 
 	@Message(id = 505, value = "Multiple conflicting types for field '%1$s': '%2$s' in index '%3$s', but '%4$s' in index '%5$s'." )
 	SearchException conflictingFieldTypesForSearch(String absoluteFieldPath,
-			ElasticsearchIndexSchemaFieldNode schemaNode1, URLEncodedString indexName1,
-			ElasticsearchIndexSchemaFieldNode schemaNode2, URLEncodedString indexName2);
+			ElasticsearchIndexSchemaFieldNode schemaNode1, String indexName1,
+			ElasticsearchIndexSchemaFieldNode schemaNode2, String indexName2);
 
 	@Message(id = 506, value = "The Elasticsearch extension can only be applied to objects"
 			+ " derived from the Elasticsearch backend. Was applied to '%1$s' instead." )
 	SearchException elasticsearchExtensionOnUnknownType(Object context);
 
 	@Message(id = 507, value = "Unknown projections %1$s in indexes %2$s." )
-	SearchException unknownProjectionForSearch(Collection<String> projections, Collection<URLEncodedString> indexNames);
+	SearchException unknownProjectionForSearch(Collection<String> projections, Collection<String> indexNames);
 
 	@Message(id = 508, value = "An Elasticsearch query cannot include search predicates built using a non-Elasticsearch search target."
 			+ " Given predicate was: '%1$s'" )
 	SearchException cannotMixElasticsearchSearchQueryWithOtherPredicates(SearchPredicate predicate);
 
 	@Message(id = 509, value = "Field '%2$s' is not an object field in index '%1$s'." )
-	SearchException nonObjectFieldForNestedQuery(URLEncodedString indexName, String absoluteFieldPath);
+	SearchException nonObjectFieldForNestedQuery(String indexName, String absoluteFieldPath);
 
 	@Message(id = 510, value = "Object field '%2$s' is not stored as nested in index '%1$s'." )
-	SearchException nonNestedFieldForNestedQuery(URLEncodedString indexName, String absoluteFieldPath);
+	SearchException nonNestedFieldForNestedQuery(String indexName, String absoluteFieldPath);
 
 	@Message(id = 511, value = "An Elasticsearch query cannot include search sorts built using a non-Elasticsearch search target."
 			+ " Given sort was: '%1$s'" )
@@ -156,4 +156,12 @@ public interface Log extends BasicLogger {
 
 	@Message(id = 529, value = "Multiple conflicting minimumShouldMatch constraints for ceiling '%1$s'")
 	SearchException minimumShouldMatchConflictingConstraints(int ceiling);
+
+	@Message(id = 530, value = "Duplicate index names when normalized to conform to Elasticsearch rules:"
+			+ " '%1$s' and '%2$s' both become '%3$s'")
+	SearchException duplicateNormalizedIndexNames(String firstHibernateSearchIndexName,
+			String secondHibernateSearchIndexName, String elasticsearchIndexName);
+
+	@Message(id = 531, value = "Unknown index name encountered in Elasticsearch response: '%1$s'")
+	SearchException elasticsearchResponseUnknownIndexName(String elasticsearchIndexName);
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/impl/ElasticsearchSearchTargetModel.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/impl/ElasticsearchSearchTargetModel.java
@@ -23,17 +23,25 @@ public class ElasticsearchSearchTargetModel {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private final Set<ElasticsearchIndexModel> indexModels;
-	private final Set<URLEncodedString> indexNames;
+	private final Set<String> hibernateSearchIndexNames;
+	private final Set<URLEncodedString> elasticsearchIndexNames;
 
 	public ElasticsearchSearchTargetModel(Set<ElasticsearchIndexModel> indexModels) {
 		this.indexModels = indexModels;
-		this.indexNames = indexModels.stream()
-				.map( ElasticsearchIndexModel::getIndexName )
+		this.hibernateSearchIndexNames = indexModels.stream()
+				.map( ElasticsearchIndexModel::getHibernateSearchIndexName )
+				.collect( Collectors.toSet() );
+		this.elasticsearchIndexNames = indexModels.stream()
+				.map( ElasticsearchIndexModel::getElasticsearchIndexName )
 				.collect( Collectors.toSet() );
 	}
 
-	public Set<URLEncodedString> getIndexNames() {
-		return indexNames;
+	public Set<String> getHibernateSearchIndexNames() {
+		return hibernateSearchIndexNames;
+	}
+
+	public Set<URLEncodedString> getElasticsearchIndexNames() {
+		return elasticsearchIndexNames;
 	}
 
 	public Set<ElasticsearchIndexModel> getIndexModels() {
@@ -54,13 +62,13 @@ public class ElasticsearchSearchTargetModel {
 				else if ( !selectedSchemaNode.isCompatibleWith( schemaNode ) ) {
 					throw log.conflictingFieldTypesForSearch(
 							absoluteFieldPath,
-							selectedSchemaNode, indexModelForSelectedSchemaNode.getIndexName(),
-							schemaNode, indexModel.getIndexName() );
+							selectedSchemaNode, indexModelForSelectedSchemaNode.getHibernateSearchIndexName(),
+							schemaNode, indexModel.getHibernateSearchIndexName() );
 				}
 			}
 		}
 		if ( selectedSchemaNode == null ) {
-			throw log.unknownFieldForSearch( absoluteFieldPath, getIndexNames() );
+			throw log.unknownFieldForSearch( absoluteFieldPath, getHibernateSearchIndexNames() );
 		}
 		return selectedSchemaNode;
 	}
@@ -73,7 +81,7 @@ public class ElasticsearchSearchTargetModel {
 			if ( schemaNode != null ) {
 				found = true;
 				if ( !ObjectFieldStorage.NESTED.equals( schemaNode.getStorage() ) ) {
-					throw log.nonNestedFieldForNestedQuery( indexModel.getIndexName(), absoluteFieldPath );
+					throw log.nonNestedFieldForNestedQuery( indexModel.getHibernateSearchIndexName(), absoluteFieldPath );
 				}
 			}
 		}
@@ -81,10 +89,10 @@ public class ElasticsearchSearchTargetModel {
 			for ( ElasticsearchIndexModel indexModel : indexModels ) {
 				ElasticsearchIndexSchemaFieldNode schemaNode = indexModel.getFieldNode( absoluteFieldPath );
 				if ( schemaNode != null ) {
-					throw log.nonObjectFieldForNestedQuery( indexModel.getIndexName(), absoluteFieldPath );
+					throw log.nonObjectFieldForNestedQuery( indexModel.getHibernateSearchIndexName(), absoluteFieldPath );
 				}
 			}
-			throw log.unknownFieldForSearch( absoluteFieldPath, getIndexNames() );
+			throw log.unknownFieldForSearch( absoluteFieldPath, getHibernateSearchIndexNames() );
 		}
 	}
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/DocumentReferenceExtractorHelper.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/DocumentReferenceExtractorHelper.java
@@ -7,6 +7,7 @@
 package org.hibernate.search.v6poc.backend.elasticsearch.search.query.impl;
 
 import java.lang.invoke.MethodHandles;
+import java.util.function.Function;
 
 import org.hibernate.search.v6poc.backend.elasticsearch.gson.impl.JsonAccessor;
 import org.hibernate.search.v6poc.backend.elasticsearch.logging.impl.Log;
@@ -17,24 +18,27 @@ import org.hibernate.search.v6poc.util.impl.common.LoggerFactory;
 
 import com.google.gson.JsonObject;
 
-abstract class AbstractDocumentReferenceHitExtractor<C> implements HitExtractor<C> {
+class DocumentReferenceExtractorHelper {
 	private static final Log log = LoggerFactory.make( Log.class, MethodHandles.lookup() );
 
 	private static final JsonAccessor<String> HIT_INDEX_NAME_ACCESSOR = JsonAccessor.root().property( "_index" ).asString();
 
+	private final Function<String, String> indexNameConverter;
 	private final MultiTenancyStrategy multiTenancyStrategy;
 
-	protected AbstractDocumentReferenceHitExtractor(MultiTenancyStrategy multiTenancyStrategy) {
+	DocumentReferenceExtractorHelper(Function<String, String> indexNameConverter, MultiTenancyStrategy multiTenancyStrategy) {
+		this.indexNameConverter = indexNameConverter;
 		this.multiTenancyStrategy = multiTenancyStrategy;
 	}
 
-	@Override
-	public void contributeRequest(JsonObject requestBody) {
+	void contributeRequest(JsonObject requestBody) {
 		multiTenancyStrategy.contributeToSearchRequest( requestBody );
 	}
 
-	protected DocumentReference extractDocumentReference(JsonObject hit) {
-		String indexName = HIT_INDEX_NAME_ACCESSOR.get( hit ).orElseThrow( log::elasticsearchResponseMissingData );
+	DocumentReference extractDocumentReference(JsonObject hit) {
+		String indexName = HIT_INDEX_NAME_ACCESSOR.get( hit )
+				.map( indexNameConverter )
+				.orElseThrow( log::elasticsearchResponseMissingData );
 		String id = multiTenancyStrategy.extractTenantScopedDocumentId( hit );
 		return new ElasticsearchDocumentReference( indexName, id );
 	}

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/DocumentReferenceHitExtractor.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/DocumentReferenceHitExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.v6poc.backend.elasticsearch.search.query.impl;
 
-import org.hibernate.search.v6poc.backend.elasticsearch.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.v6poc.engine.spi.SessionContext;
 import org.hibernate.search.v6poc.search.query.spi.DocumentReferenceHitCollector;
 import org.hibernate.search.v6poc.search.query.spi.HitAggregator;
@@ -19,15 +18,22 @@ import com.google.gson.JsonObject;
  *
  * @see SearchQueryFactory#asReferences(SessionContext, HitAggregator)
  */
-class DocumentReferenceHitExtractor extends AbstractDocumentReferenceHitExtractor<DocumentReferenceHitCollector> {
+class DocumentReferenceHitExtractor implements HitExtractor<DocumentReferenceHitCollector> {
 
-	DocumentReferenceHitExtractor(MultiTenancyStrategy multiTenancyStrategy) {
-		super( multiTenancyStrategy );
+	private final DocumentReferenceExtractorHelper helper;
+
+	DocumentReferenceHitExtractor(DocumentReferenceExtractorHelper helper) {
+		this.helper = helper;
+	}
+
+	@Override
+	public void contributeRequest(JsonObject requestBody) {
+		helper.contributeRequest( requestBody );
 	}
 
 	@Override
 	public void extract(DocumentReferenceHitCollector collector, JsonObject responseBody, JsonObject hit) {
-		collector.collectReference( extractDocumentReference( hit ) );
+		collector.collectReference( helper.extractDocumentReference( hit ) );
 	}
 
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/DocumentReferenceProjectionHitExtractor.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/DocumentReferenceProjectionHitExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.v6poc.backend.elasticsearch.search.query.impl;
 
-import org.hibernate.search.v6poc.backend.elasticsearch.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.v6poc.engine.spi.SessionContext;
 import org.hibernate.search.v6poc.search.query.spi.HitAggregator;
 import org.hibernate.search.v6poc.search.query.spi.ProjectionHitCollector;
@@ -22,15 +21,22 @@ import com.google.gson.JsonObject;
  * @see org.hibernate.search.v6poc.search.ProjectionConstants#DOCUMENT_REFERENCE
  * @see SearchQueryFactory#asProjections(SessionContext, HitAggregator, String...)
  */
-class DocumentReferenceProjectionHitExtractor extends AbstractDocumentReferenceHitExtractor<ProjectionHitCollector> {
+class DocumentReferenceProjectionHitExtractor implements HitExtractor<ProjectionHitCollector> {
 
-	DocumentReferenceProjectionHitExtractor(MultiTenancyStrategy multiTenancyStrategy) {
-		super( multiTenancyStrategy );
+	private final DocumentReferenceExtractorHelper helper;
+
+	DocumentReferenceProjectionHitExtractor(DocumentReferenceExtractorHelper helper) {
+		this.helper = helper;
+	}
+
+	@Override
+	public void contributeRequest(JsonObject requestBody) {
+		helper.contributeRequest( requestBody );
 	}
 
 	@Override
 	public void extract(ProjectionHitCollector collector, JsonObject responseBody, JsonObject hit) {
-		collector.collectProjection( extractDocumentReference( hit ) );
+		collector.collectProjection( helper.extractDocumentReference( hit ) );
 	}
 
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/IndexSensitiveHitExtractor.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/IndexSensitiveHitExtractor.java
@@ -29,23 +29,23 @@ class IndexSensitiveHitExtractor<C> implements HitExtractor<C> {
 			.property( "_index" )
 			.asString();
 
-	private final Map<String, HitExtractor<? super C>> extractorByIndex;
+	private final Map<String, HitExtractor<? super C>> extractorByElasticsearchIndexName;
 
-	IndexSensitiveHitExtractor(Map<String, HitExtractor<? super C>> extractorByIndex) {
-		this.extractorByIndex = extractorByIndex;
+	IndexSensitiveHitExtractor(Map<String, HitExtractor<? super C>> extractorByElasticsearchIndexName) {
+		this.extractorByElasticsearchIndexName = extractorByElasticsearchIndexName;
 	}
 
 	@Override
 	public void contributeRequest(JsonObject requestBody) {
-		for ( HitExtractor<?> extractor : extractorByIndex.values() ) {
+		for ( HitExtractor<?> extractor : extractorByElasticsearchIndexName.values() ) {
 			extractor.contributeRequest( requestBody );
 		}
 	}
 
 	@Override
 	public void extract(C collector, JsonObject responseBody, JsonObject hit) {
-		String indexName = HIT_INDEX_NAME_ACCESSOR.get( hit ).orElseThrow( log::elasticsearchResponseMissingData );
-		HitExtractor<? super C> delegate = extractorByIndex.get( indexName );
+		String elasticsearchIndexName = HIT_INDEX_NAME_ACCESSOR.get( hit ).orElseThrow( log::elasticsearchResponseMissingData );
+		HitExtractor<? super C> delegate = extractorByElasticsearchIndexName.get( elasticsearchIndexName );
 		delegate.extract( collector, responseBody, hit );
 	}
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/ObjectHitExtractor.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/ObjectHitExtractor.java
@@ -6,7 +6,6 @@
  */
 package org.hibernate.search.v6poc.backend.elasticsearch.search.query.impl;
 
-import org.hibernate.search.v6poc.backend.elasticsearch.multitenancy.impl.MultiTenancyStrategy;
 import org.hibernate.search.v6poc.engine.spi.SessionContext;
 import org.hibernate.search.v6poc.search.query.spi.HitAggregator;
 import org.hibernate.search.v6poc.search.query.spi.LoadingHitCollector;
@@ -19,15 +18,22 @@ import com.google.gson.JsonObject;
  *
  * @see SearchQueryFactory#asObjects(SessionContext, HitAggregator)
  */
-class ObjectHitExtractor extends AbstractDocumentReferenceHitExtractor<LoadingHitCollector> {
+class ObjectHitExtractor implements HitExtractor<LoadingHitCollector> {
 
-	ObjectHitExtractor(MultiTenancyStrategy multiTenancyStrategy) {
-		super( multiTenancyStrategy );
+	private final DocumentReferenceExtractorHelper helper;
+
+	ObjectHitExtractor(DocumentReferenceExtractorHelper helper) {
+		this.helper = helper;
+	}
+
+	@Override
+	public void contributeRequest(JsonObject requestBody) {
+		helper.contributeRequest( requestBody );
 	}
 
 	@Override
 	public void extract(LoadingHitCollector collector, JsonObject responseBody, JsonObject hit) {
-		collector.collectForLoading( extractDocumentReference( hit ) );
+		collector.collectForLoading( helper.extractDocumentReference( hit ) );
 	}
 
 }

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/SearchBackendContext.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/SearchBackendContext.java
@@ -8,6 +8,7 @@ package org.hibernate.search.v6poc.backend.elasticsearch.search.query.impl;
 
 import java.util.List;
 import java.util.Set;
+import java.util.function.Function;
 
 import org.hibernate.search.v6poc.backend.elasticsearch.util.impl.URLEncodedString;
 import org.hibernate.search.v6poc.backend.elasticsearch.multitenancy.impl.MultiTenancyStrategy;
@@ -32,16 +33,20 @@ public class SearchBackendContext {
 
 	public SearchBackendContext(BackendImplementor<?> backend,
 			ElasticsearchWorkFactory workFactory,
+			Function<String, String> indexNameConverter,
 			MultiTenancyStrategy multiTenancyStrategy,
 			ElasticsearchWorkOrchestrator orchestrator) {
 		this.backend = backend;
-		this.multiTenancyStrategy = multiTenancyStrategy;
 		this.workFactory = workFactory;
+		this.multiTenancyStrategy = multiTenancyStrategy;
 		this.orchestrator = orchestrator;
 
-		this.documentReferenceHitExtractor = new DocumentReferenceHitExtractor( multiTenancyStrategy );
-		this.objectHitExtractor = new ObjectHitExtractor( multiTenancyStrategy );
-		this.documentReferenceProjectionHitExtractor = new DocumentReferenceProjectionHitExtractor( multiTenancyStrategy );
+		DocumentReferenceExtractorHelper documentReferenceExtractorHelper =
+				new DocumentReferenceExtractorHelper( indexNameConverter, multiTenancyStrategy );
+		this.documentReferenceHitExtractor = new DocumentReferenceHitExtractor( documentReferenceExtractorHelper );
+		this.objectHitExtractor = new ObjectHitExtractor( documentReferenceExtractorHelper );
+		this.documentReferenceProjectionHitExtractor =
+				new DocumentReferenceProjectionHitExtractor( documentReferenceExtractorHelper );
 	}
 
 	@Override

--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/SearchQueryFactoryImpl.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/search/query/impl/SearchQueryFactoryImpl.java
@@ -75,20 +75,20 @@ class SearchQueryFactoryImpl
 		}
 		else {
 			// Use LinkedHashMap to ensure stable order when generating requests
-			Map<String, HitExtractor<? super ProjectionHitCollector>> extractorByIndex = new LinkedHashMap<>();
+			Map<String, HitExtractor<? super ProjectionHitCollector>> extractorByElasticsearchIndexName = new LinkedHashMap<>();
 			for ( ElasticsearchIndexModel indexModel : indexModels ) {
 				HitExtractor<? super ProjectionHitCollector> indexHitExtractor =
 						createProjectionHitExtractor( indexModel, projections, projectionFound );
-				extractorByIndex.put( indexModel.getIndexName().original, indexHitExtractor );
+				extractorByElasticsearchIndexName.put( indexModel.getElasticsearchIndexName().original, indexHitExtractor );
 			}
-			hitExtractor = new IndexSensitiveHitExtractor<>( extractorByIndex );
+			hitExtractor = new IndexSensitiveHitExtractor<>( extractorByElasticsearchIndexName );
 		}
 		if ( projectionFound.cardinality() < projections.length ) {
 			projectionFound.flip( 0, projections.length );
 			List<String> unknownProjections = projectionFound.stream()
 					.mapToObj( i -> projections[i] )
 					.collect( Collectors.toList() );
-			throw log.unknownProjectionForSearch( unknownProjections, searchTargetModel.getIndexNames() );
+			throw log.unknownProjectionForSearch( unknownProjections, searchTargetModel.getHibernateSearchIndexNames() );
 		}
 
 		return createSearchQueryBuilder( sessionContext, hitExtractor, hitAggregator );
@@ -131,7 +131,7 @@ class SearchQueryFactoryImpl
 	private <C, T> SearchQueryBuilderImpl<C, T> createSearchQueryBuilder(
 			SessionContext sessionContext, HitExtractor<? super C> hitExtractor, HitAggregator<C, List<T>> hitAggregator) {
 		return searchBackendContext.createSearchQueryBuilder(
-				searchTargetModel.getIndexNames(),
+				searchTargetModel.getElasticsearchIndexNames(),
 				sessionContext,
 				hitExtractor, hitAggregator
 		);

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/impl/LuceneLocalDirectoryBackend.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/impl/LuceneLocalDirectoryBackend.java
@@ -78,19 +78,20 @@ public class LuceneLocalDirectoryBackend implements BackendImplementor<LuceneRoo
 	}
 
 	@Override
-	public String normalizeIndexName(String rawIndexName) {
-		return rawIndexName;
-	}
-
-	@Override
 	public IndexManagerBuilder<LuceneRootDocumentBuilder> createIndexManagerBuilder(
 			String indexName, boolean multiTenancyEnabled, BuildContext context, ConfigurationPropertySource propertySource) {
 		if ( multiTenancyEnabled && !multiTenancyStrategy.isMultiTenancySupported() ) {
 			throw log.multiTenancyRequiredButNotSupportedByBackend( this, indexName );
 		}
 
+		/*
+		 * We do not normalize index names: directory providers are expected to use the exact given index name,
+		 * or a reversible conversion of that name, as an internal key (file names, ...),
+		 * and therefore the internal key should stay unique.
+		 */
 		return new LuceneDirectoryIndexManagerBuilder(
-				indexingContext, searchContext, normalizeIndexName( indexName ), context, propertySource
+				indexingContext, searchContext,
+				indexName, context, propertySource
 		);
 	}
 

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/index/impl/DirectoryProvider.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/index/impl/DirectoryProvider.java
@@ -15,6 +15,22 @@ public interface DirectoryProvider {
 
 	// TODO return an SPI type so that people can easily add behavior to the close() method
 	// (could be useful if they started a thread pool when creating the directory for instance)
+	/**
+	 * Create a {@link Directory} for a given name, allocating internal resources (filesystem directories, ...)
+	 * as necessary.
+	 * <p>
+	 * The provided index names are raw and do not take into account the limitations of the internal representation
+	 * of indexes. If some characters cannot be used in a given {@link DirectoryProvider},
+	 * this provider is expected to escape characters as necessary using a encoding scheme attributing
+	 * a unique representation to each index name,
+	 * so as to avoid two index names to be encoded into identical internal representations.
+	 * Lower-casing the index name, for example, is not an acceptable encoding scheme,
+	 * as two index names differing only in case could end up using the same directory.
+	 *
+	 * @param indexName The name of the index in Hibernate Search.
+	 * @return The directory to use for that index name
+	 * @throws IOException If an error occurs while initializing the directory.
+	 */
 	Directory createDirectory(String indexName) throws IOException;
 
 }

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/index/impl/LuceneDirectoryIndexManagerBuilder.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/index/impl/LuceneDirectoryIndexManagerBuilder.java
@@ -35,7 +35,7 @@ public class LuceneDirectoryIndexManagerBuilder implements IndexManagerBuilder<L
 	private final IndexingBackendContext indexingBackendContext;
 	private final SearchBackendContext searchBackendContext;
 
-	private final String normalizedIndexName;
+	private final String indexName;
 	private final LuceneIndexSchemaRootNodeBuilder schemaRootNodeBuilder = new LuceneIndexSchemaRootNodeBuilder();
 
 	private final BuildContext buildContext;
@@ -43,11 +43,11 @@ public class LuceneDirectoryIndexManagerBuilder implements IndexManagerBuilder<L
 
 	public LuceneDirectoryIndexManagerBuilder(IndexingBackendContext indexingBackendContext,
 			SearchBackendContext searchBackendContext,
-			String normalizedIndexName,
+			String indexName,
 			BuildContext buildContext, ConfigurationPropertySource propertySource) {
 		this.indexingBackendContext = indexingBackendContext;
 		this.searchBackendContext = searchBackendContext;
-		this.normalizedIndexName = normalizedIndexName;
+		this.indexName = indexName;
 		this.buildContext = buildContext;
 		this.propertySource = propertySource;
 	}
@@ -67,10 +67,10 @@ public class LuceneDirectoryIndexManagerBuilder implements IndexManagerBuilder<L
 		LuceneIndexModel model = null;
 		IndexWriter indexWriter = null;
 		try {
-			model = new LuceneIndexModel( normalizedIndexName, schemaRootNodeBuilder );
+			model = new LuceneIndexModel( indexName, schemaRootNodeBuilder );
 			indexWriter = createIndexWriter( model );
 			return new LuceneDirectoryIndexManager(
-					indexingBackendContext, searchBackendContext, normalizedIndexName, model, indexWriter
+					indexingBackendContext, searchBackendContext, indexName, model, indexWriter
 			);
 		}
 		catch (RuntimeException e) {
@@ -84,7 +84,7 @@ public class LuceneDirectoryIndexManagerBuilder implements IndexManagerBuilder<L
 	private IndexWriter createIndexWriter(LuceneIndexModel model) {
 		IndexWriterConfig indexWriterConfig = new IndexWriterConfig( model.getScopedAnalyzer() );
 		try {
-			Directory directory = indexingBackendContext.createDirectory( normalizedIndexName );
+			Directory directory = indexingBackendContext.createDirectory( indexName );
 			try {
 				return new IndexWriter( directory, indexWriterConfig );
 			}

--- a/engine/src/main/java/org/hibernate/search/v6poc/backend/spi/BackendImplementor.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/backend/spi/BackendImplementor.java
@@ -23,16 +23,9 @@ public interface BackendImplementor<D extends DocumentElement> extends AutoClose
 	Backend toAPI();
 
 	/**
-	 * Normalize the name of the index, so that we cannot end up with two index names in Hibernate Search
-	 * that would target the same physical index.
-	 *
-	 * @param rawIndexName The index name to be normalized.
-	 * @return The normalized index name.
-	 */
-	String normalizeIndexName(String rawIndexName);
-
-	/**
-	 * @param normalizedIndexName The (already {@link #normalizeIndexName(String) normalized}) name of the index
+	 * @param indexName The name of the index from the point of view of Hibernate Search.
+	 * A slightly different name may be used by the backend internally,
+	 * but {@code indexName} is the one that will appear everywhere the index is mentioned to the user.
 	 * @param multiTenancyEnabled {@code true} if multi-tenancy is enabled for this index, {@code false} otherwise.
 	 * @param context The build context
 	 * @param propertySource A configuration property source, appropriately masked so that the backend
@@ -41,7 +34,7 @@ public interface BackendImplementor<D extends DocumentElement> extends AutoClose
 	 * <strong>CAUTION:</strong> the property key {@code backend} is reserved for use by the engine.
 	 * @return A builder for index managers targeting this backend.
 	 */
-	IndexManagerBuilder<D> createIndexManagerBuilder(String normalizedIndexName, boolean multiTenancyEnabled, BuildContext context,
+	IndexManagerBuilder<D> createIndexManagerBuilder(String indexName, boolean multiTenancyEnabled, BuildContext context,
 			ConfigurationPropertySource propertySource);
 
 	@Override

--- a/integrationtest/backend-elasticsearch/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/elasticsearch/ExtensionIT.java
+++ b/integrationtest/backend-elasticsearch/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/elasticsearch/ExtensionIT.java
@@ -42,6 +42,7 @@ import org.elasticsearch.client.RestClient;
 public class ExtensionIT {
 
 	private static final String BACKEND_NAME = "myElasticsearchBackend";
+	private static final String INDEX_NAME = "IndexName";
 
 	private static final String FIRST_ID = "1";
 	private static final String SECOND_ID = "2";
@@ -59,19 +60,15 @@ public class ExtensionIT {
 	private SearchMappingRepository mappingRepository;
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		this.mappingRepository = setupHelper.withDefaultConfiguration( BACKEND_NAME )
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -112,7 +109,7 @@ public class ExtensionIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID )
 				.hasHitCount( 4 );
 	}
 
@@ -157,7 +154,7 @@ public class ExtensionIT {
 				.predicate( booleanPredicate )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID )
 				.hasHitCount( 4 );
 	}
 
@@ -186,7 +183,7 @@ public class ExtensionIT {
 				)
 				.build();
 		assertThat( query ).hasReferencesHitsExactOrder(
-				indexName,
+				INDEX_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID
 		);
 
@@ -210,7 +207,7 @@ public class ExtensionIT {
 				)
 				.build();
 		assertThat( query ).hasReferencesHitsExactOrder(
-				indexName,
+				INDEX_NAME,
 				FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID
 		);
 	}
@@ -247,7 +244,7 @@ public class ExtensionIT {
 				.sort().by( sort1 ).then().by( sort2 ).then().by( sort3 ).then().by( sort4 ).end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, EMPTY_ID, FIFTH_ID );
 
 		sort1 = searchTarget.sort()
 				.withExtensionOptional(
@@ -276,7 +273,7 @@ public class ExtensionIT {
 				.sort().by( sort1 ).then().by( sort2 ).then().by( sort3 ).then().by( sort4 ).end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FOURTH_ID, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID, FIFTH_ID );
 	}
 
 	@Test
@@ -361,7 +358,7 @@ public class ExtensionIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder(
-				indexName,
+				INDEX_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID, EMPTY_ID
 		);
 	}

--- a/integrationtest/backend-elasticsearch/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/elasticsearch/search/ElasticsearchSearchSortIT.java
+++ b/integrationtest/backend-elasticsearch/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/elasticsearch/search/ElasticsearchSearchSortIT.java
@@ -33,6 +33,8 @@ import org.junit.Test;
 
 public class ElasticsearchSearchSortIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String FIRST_ID = "1";
 	private static final String SECOND_ID = "2";
 	private static final String THIRD_ID = "3";
@@ -43,19 +45,15 @@ public class ElasticsearchSearchSortIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -76,12 +74,12 @@ public class ElasticsearchSearchSortIT {
 		SearchQuery<DocumentReference> query = simpleQuery( b -> b.byDistance( "geoPoint", new ImmutableGeoPoint( 45.757864, 4.834496 ) ).desc() );
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, EMPTY_ID, FIRST_ID, THIRD_ID, SECOND_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, FIRST_ID, THIRD_ID, SECOND_ID );
 
 		query = simpleQuery( b -> b.byDistance( "geoPoint", 45.757864, 4.834496 ).desc() );
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, EMPTY_ID, FIRST_ID, THIRD_ID, SECOND_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, FIRST_ID, THIRD_ID, SECOND_ID );
 	}
 
 	private void initData() {
@@ -105,7 +103,7 @@ public class ElasticsearchSearchSortIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/ExtensionIT.java
+++ b/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/ExtensionIT.java
@@ -50,6 +50,8 @@ import org.junit.Test;
 
 public class ExtensionIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String FIRST_ID = "1";
 	private static final String SECOND_ID = "2";
 	private static final String THIRD_ID = "3";
@@ -61,19 +63,15 @@ public class ExtensionIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -103,7 +101,7 @@ public class ExtensionIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
 				.hasHitCount( 3 );
 	}
 
@@ -135,7 +133,7 @@ public class ExtensionIT {
 				.predicate( booleanPredicate )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID )
 				.hasHitCount( 3 );
 	}
 
@@ -161,7 +159,7 @@ public class ExtensionIT {
 				)
 				.build();
 		assertThat( query ).hasReferencesHitsExactOrder(
-				indexName,
+				INDEX_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID
 		);
 
@@ -181,7 +179,7 @@ public class ExtensionIT {
 				)
 				.build();
 		assertThat( query ).hasReferencesHitsExactOrder(
-				indexName,
+				INDEX_NAME,
 				THIRD_ID, SECOND_ID, FIRST_ID, FOURTH_ID, FIFTH_ID
 		);
 	}
@@ -213,7 +211,7 @@ public class ExtensionIT {
 				.sort().by( sort1 ).then().by( sort2 ).then().by( sort3 ).end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID );
 
 		SearchSort sort = searchTarget.sort()
 				.withExtensionOptional(
@@ -233,7 +231,7 @@ public class ExtensionIT {
 				.sort().by( sort ).end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, THIRD_ID, SECOND_ID, FIRST_ID, FOURTH_ID, FIFTH_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, THIRD_ID, SECOND_ID, FIRST_ID, FOURTH_ID, FIFTH_ID );
 	}
 
 	@Test
@@ -281,7 +279,7 @@ public class ExtensionIT {
 				.build();
 
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, FIRST_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID );
 	}
 
 	@Test
@@ -310,7 +308,7 @@ public class ExtensionIT {
 				.build();
 
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, FIRST_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID );
 
 		// now, let's check that projecting on the field throws an exception
 		SubTest.expectException(
@@ -338,7 +336,7 @@ public class ExtensionIT {
 				.build();
 
 		assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, THIRD_ID, FIRST_ID, FIFTH_ID, SECOND_ID, FOURTH_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, THIRD_ID, FIRST_ID, FIFTH_ID, SECOND_ID, FOURTH_ID );
 	}
 
 	@Test
@@ -418,7 +416,7 @@ public class ExtensionIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query ).hasReferencesHitsAnyOrder(
-				indexName,
+				INDEX_NAME,
 				FIRST_ID, SECOND_ID, THIRD_ID, FOURTH_ID, FIFTH_ID
 		);
 	}

--- a/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
+++ b/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/search/LuceneSearchMultiIndexIT.java
@@ -41,6 +41,8 @@ public class LuceneSearchMultiIndexIT {
 
 	// Backend 1 / Index 1
 
+	private static final String INDEX_NAME_1_1 = "IndexName_1_1";
+
 	private static final String DOCUMENT_1_1_1 = "1_1_1";
 	private static final String ADDITIONAL_FIELD_1_1_1 = "additional_field_1_1_1";
 
@@ -48,6 +50,8 @@ public class LuceneSearchMultiIndexIT {
 	private static final String ADDITIONAL_FIELD_1_1_2 = "additional_field_1_1_2";
 
 	// Backend 1 / Index 2
+
+	private static final String INDEX_NAME_1_2 = "IndexName_1_2";
 
 	private static final String DOCUMENT_1_2_1 = "1_2_1";
 
@@ -58,13 +62,11 @@ public class LuceneSearchMultiIndexIT {
 
 	private IndexAccessors_1_1 indexAccessors_1_1;
 	private IndexManager<?> indexManager_1_1;
-	private String indexName_1_1;
 
 	// Backend 1 / Index 2
 
 	private IndexAccessors_1_2 indexAccessors_1_2;
 	private IndexManager<?> indexManager_1_2;
-	private String indexName_1_2;
 
 	private SessionContext sessionContext = new StubSessionContext();
 
@@ -72,20 +74,14 @@ public class LuceneSearchMultiIndexIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration( BACKEND_1 )
 				.withIndex(
-						"MappedType_1_1", "IndexName_1_1",
+						"MappedType_1_1", INDEX_NAME_1_1,
 						ctx -> this.indexAccessors_1_1 = new IndexAccessors_1_1( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager_1_1 = indexManager;
-							this.indexName_1_1 = indexName;
-						}
+						indexManager -> this.indexManager_1_1 = indexManager
 				)
 				.withIndex(
-						"MappedType_1_2", "IndexName_1_2",
+						"MappedType_1_2", INDEX_NAME_1_2,
 						ctx -> this.indexAccessors_1_2 = new IndexAccessors_1_2( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager_1_2 = indexManager;
-							this.indexName_1_2 = indexName;
-						}
+						indexManager -> this.indexManager_1_2 = indexManager
 				)
 				.setup();
 
@@ -105,8 +101,8 @@ public class LuceneSearchMultiIndexIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsExactOrder( c -> {
-			c.doc( indexName_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
-			c.doc( indexName_1_2, DOCUMENT_1_2_1 );
+			c.doc( INDEX_NAME_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
+			c.doc( INDEX_NAME_1_2, DOCUMENT_1_2_1 );
 		} );
 
 		query = searchTarget.query( sessionContext )
@@ -116,8 +112,8 @@ public class LuceneSearchMultiIndexIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsExactOrder( c -> {
-			c.doc( indexName_1_1, DOCUMENT_1_1_2, DOCUMENT_1_1_1 );
-			c.doc( indexName_1_2, DOCUMENT_1_2_1 );
+			c.doc( INDEX_NAME_1_1, DOCUMENT_1_1_2, DOCUMENT_1_1_1 );
+			c.doc( INDEX_NAME_1_2, DOCUMENT_1_2_1 );
 		} );
 	}
 
@@ -142,7 +138,7 @@ public class LuceneSearchMultiIndexIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
 
 		// Backend 1 / Index 2
 
@@ -159,7 +155,7 @@ public class LuceneSearchMultiIndexIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_2, DOCUMENT_1_2_1 );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME_1_2, DOCUMENT_1_2_1 );
 	}
 
 	private static class IndexAccessors_1_1 {

--- a/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
+++ b/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
@@ -34,6 +34,8 @@ import org.junit.rules.ExpectedException;
 
 public class LuceneSearchSortIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String FIRST_ID = "1";
 	private static final String SECOND_ID = "2";
 	private static final String THIRD_ID = "3";
@@ -47,19 +49,15 @@ public class LuceneSearchSortIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -104,7 +102,7 @@ public class LuceneSearchSortIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/DocumentModelDslIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/DocumentModelDslIT.java
@@ -27,6 +27,8 @@ import org.junit.Test;
  */
 public class DocumentModelDslIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	@Rule
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
 
@@ -207,9 +209,9 @@ public class DocumentModelDslIT {
 	private void setup(Consumer<IndexModelBindingContext> mappingContributor) {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						mappingContributor,
-						(indexManager, indexName) -> { }
+						indexManager -> { }
 				)
 				.setup();
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/IndexFieldAccessorIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/IndexFieldAccessorIT.java
@@ -45,6 +45,8 @@ import org.junit.Test;
  */
 public class IndexFieldAccessorIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	@Rule
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
 
@@ -56,11 +58,9 @@ public class IndexFieldAccessorIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/MultiTenancyIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/MultiTenancyIT.java
@@ -35,6 +35,8 @@ import org.junit.rules.ExpectedException;
 
 public class MultiTenancyIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String TENANT_1 = "tenant_1";
 	private static final String TENANT_2 = "tenant_2";
 
@@ -61,7 +63,6 @@ public class MultiTenancyIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 
 	private SessionContext tenant1SessionContext = new StubSessionContext( TENANT_1 );
 
@@ -71,12 +72,9 @@ public class MultiTenancyIT {
 	public void setup() {
 		setupHelper.withMultiTenancyConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.withMultiTenancy()
 				.setup();
@@ -128,7 +126,7 @@ public class MultiTenancyIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 
 		SearchQuery<List<?>> projectionQuery = searchTarget.query( tenant2SessionContext )
 				.asProjections( "string", "integer" )
@@ -144,7 +142,7 @@ public class MultiTenancyIT {
 		worker.execute().join();
 
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_2 );
 		projectionQuery = searchTarget.query( tenant2SessionContext )
 				.asProjections( "string", "integer" )
 				.predicate().matchAll().end()
@@ -158,7 +156,7 @@ public class MultiTenancyIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 	}
 
 	@Test
@@ -171,7 +169,7 @@ public class MultiTenancyIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( checkQuery )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 
 		worker.update( referenceProvider( DOCUMENT_ID_2 ), document -> {
 			indexAccessors.string.write( document, UPDATED_STRING );
@@ -234,12 +232,9 @@ public class MultiTenancyIT {
 
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.withMultiTenancy()
 				.setup();
@@ -257,10 +252,7 @@ public class MultiTenancyIT {
 				.withIndex(
 						"MappedType", "IndexName-using_multi_tenancy_for_query_while_disabled_throws_exception",
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -270,7 +262,7 @@ public class MultiTenancyIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 	}
 
 	@Test
@@ -283,10 +275,7 @@ public class MultiTenancyIT {
 				.withIndex(
 						"MappedType", "IndexName-using_multi_tenancy_for_add_while_disabled_throws_exception",
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -314,10 +303,7 @@ public class MultiTenancyIT {
 				.withIndex(
 						"MappedType", "IndexName-using_multi_tenancy_for_update_while_disabled_throws_exception",
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -345,10 +331,7 @@ public class MultiTenancyIT {
 				.withIndex(
 						"MappedType", "IndexName-using_multi_tenancy_for_delete_while_disabled_throws_exception",
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -369,7 +352,7 @@ public class MultiTenancyIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 	}
 
 	@Test
@@ -473,7 +456,7 @@ public class MultiTenancyIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 
 		SearchQuery<List<?>> projectionQuery = searchTarget.query( tenant1SessionContext )
 				.asProjections( "string", "integer" )
@@ -489,7 +472,7 @@ public class MultiTenancyIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_ID_1, DOCUMENT_ID_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_ID_1, DOCUMENT_ID_2 );
 
 		projectionQuery = searchTarget.query( tenant2SessionContext )
 				.asProjections( "string", "integer" )

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/ObjectFieldStorageIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/ObjectFieldStorageIT.java
@@ -33,6 +33,8 @@ import org.junit.rules.ExpectedException;
 
 public class ObjectFieldStorageIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String EXPECTED_NESTED_MATCH_ID = "nestedQueryShouldMatchId";
 	private static final String EXPECTED_NON_NESTED_MATCH_ID = "nonNestedQueryShouldMatchId";
 
@@ -54,19 +56,15 @@ public class ObjectFieldStorageIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private StubSessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -133,7 +131,7 @@ public class ObjectFieldStorageIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, EXPECTED_NON_NESTED_MATCH_ID )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, EXPECTED_NON_NESTED_MATCH_ID )
 				.hasHitCount( 1 );
 
 		query = searchTarget.query( sessionContext )
@@ -146,7 +144,7 @@ public class ObjectFieldStorageIT {
 				)
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, EXPECTED_NESTED_MATCH_ID )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, EXPECTED_NESTED_MATCH_ID )
 				.hasHitCount( 1 );
 	}
 
@@ -166,7 +164,7 @@ public class ObjectFieldStorageIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, EXPECTED_NON_NESTED_MATCH_ID )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, EXPECTED_NON_NESTED_MATCH_ID )
 				.hasHitCount( 1 );
 
 		query = searchTarget.query( sessionContext )
@@ -181,7 +179,7 @@ public class ObjectFieldStorageIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, EXPECTED_NESTED_MATCH_ID )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, EXPECTED_NESTED_MATCH_ID )
 				.hasHitCount( 1 );
 	}
 
@@ -318,7 +316,7 @@ public class ObjectFieldStorageIT {
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder(
-						indexName,
+						INDEX_NAME,
 						EXPECTED_NESTED_MATCH_ID, EXPECTED_NON_NESTED_MATCH_ID, "neverMatching", "empty"
 				);
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/SmokeIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/SmokeIT.java
@@ -37,24 +37,22 @@ import static org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.m
  */
 public class SmokeIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	@Rule
 	public SearchSetupHelper setupHelper = new SearchSetupHelper();
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -70,7 +68,7 @@ public class SmokeIT {
 				.predicate().match().onField( "string" ).matching( "text 1" )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1" )
 				.hasHitCount( 1 );
 
 		query = searchTarget.query( sessionContext )
@@ -78,7 +76,7 @@ public class SmokeIT {
 				.predicate().match().onField( "string_analyzed" ).matching( "text" )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1", "2", "3" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1", "2", "3" )
 				.hasHitCount( 3 );
 
 		query = searchTarget.query( sessionContext )
@@ -86,7 +84,7 @@ public class SmokeIT {
 				.predicate().match().onField( "integer" ).matching( 1 )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1" )
 				.hasHitCount( 1 );
 
 		query = searchTarget.query( sessionContext )
@@ -94,7 +92,7 @@ public class SmokeIT {
 				.predicate().match().onField( "localDate" ).matching( LocalDate.of( 2018, 1, 1 ) )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1" )
 				.hasHitCount( 1 );
 
 		query = searchTarget.query( sessionContext )
@@ -102,7 +100,7 @@ public class SmokeIT {
 				.predicate().match().onField( "flattenedObject.string" ).matching( "text 1_1" )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1" )
 				.hasHitCount( 1 );
 	}
 
@@ -115,7 +113,7 @@ public class SmokeIT {
 				.predicate().range().onField( "string" ).from( "text 2" ).to( "text 42" )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "2", "3" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "2", "3" )
 				.hasHitCount( 2 );
 
 		query = searchTarget.query( sessionContext )
@@ -123,7 +121,7 @@ public class SmokeIT {
 				.predicate().range().onField( "string_analyzed" ).from( "2" ).to( "42" )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "2", "3" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "2", "3" )
 				.hasHitCount( 2 );
 
 		query = searchTarget.query( sessionContext )
@@ -131,7 +129,7 @@ public class SmokeIT {
 				.predicate().range().onField( "integer" ).from( 2 ).to( 42 )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "2", "3" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "2", "3" )
 				.hasHitCount( 2 );
 
 		query = searchTarget.query( sessionContext )
@@ -141,7 +139,7 @@ public class SmokeIT {
 						.to( LocalDate.of( 2018, 2, 23 ) )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "2" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "2" )
 				.hasHitCount( 1 );
 
 		query = searchTarget.query( sessionContext )
@@ -149,7 +147,7 @@ public class SmokeIT {
 				.predicate().range().onField( "flattenedObject.integer" ).from( 201 ).to( 242 )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "2" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "2" )
 				.hasHitCount( 1 );
 	}
 
@@ -165,7 +163,7 @@ public class SmokeIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1", "2" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1", "2" )
 				.hasHitCount( 2 );
 
 		query = searchTarget.query( sessionContext )
@@ -176,7 +174,7 @@ public class SmokeIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1" )
 				.hasHitCount( 1 );
 
 		query = searchTarget.query( sessionContext )
@@ -187,7 +185,7 @@ public class SmokeIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1", "3" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1", "3" )
 				.hasHitCount( 2 );
 	}
 
@@ -204,7 +202,7 @@ public class SmokeIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1" )
 				.hasHitCount( 1 );
 
 		// With nested storage, we expect direct queries to never match
@@ -237,7 +235,7 @@ public class SmokeIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1" )
 				.hasHitCount( 1 );
 	}
 
@@ -251,7 +249,7 @@ public class SmokeIT {
 				.predicate( predicate )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1" )
 				.hasHitCount( 1 );
 
 		predicate = searchTarget.predicate().range().onField( "integer" ).from( 1 ).to( 2 );
@@ -260,7 +258,7 @@ public class SmokeIT {
 				.predicate( predicate )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1", "2" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1", "2" )
 				.hasHitCount( 2 );
 
 		predicate = searchTarget.predicate().bool()
@@ -272,7 +270,7 @@ public class SmokeIT {
 				.predicate( predicate )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1", "2" )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1", "2" )
 				.hasHitCount( 2 );
 	}
 
@@ -345,7 +343,7 @@ public class SmokeIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, "1", "2", "3", "neverMatching", "empty" );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, "1", "2", "3", "neverMatching", "empty" );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchMultiIndexIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchMultiIndexIT.java
@@ -44,6 +44,8 @@ public class SearchMultiIndexIT {
 
 	// Backend 1 / Index 1
 
+	private static final String INDEX_NAME_1_1 = "IndexName_1_1";
+
 	private static final String DOCUMENT_1_1_1 = "1_1_1";
 	private static final String ADDITIONAL_FIELD_1_1_1 = "additional_field_1_1_1";
 	private static final String SORT_FIELD_1_1_1 = "1_1_1";
@@ -56,11 +58,15 @@ public class SearchMultiIndexIT {
 
 	// Backend 1 / Index 2
 
+	private static final String INDEX_NAME_1_2 = "IndexName_1_2";
+
 	private static final String DOCUMENT_1_2_1 = "1_2_1";
 	private static final String SORT_FIELD_1_2_1 = "1_2_1";
 	private static final Integer DIFFERENT_TYPES_FIELD_1_2_1 = 37;
 
 	// Backend 2 / Index 1
+
+	private static final String INDEX_NAME_2_1 = "IndexName_2_1";
 
 	private static final String DOCUMENT_2_1_1 = "2_1_1";
 
@@ -73,19 +79,16 @@ public class SearchMultiIndexIT {
 
 	private IndexAccessors_1_1 indexAccessors_1_1;
 	private IndexManager<?> indexManager_1_1;
-	private String indexName_1_1;
 
 	// Backend 1 / Index 2
 
 	private IndexAccessors_1_2 indexAccessors_1_2;
 	private IndexManager<?> indexManager_1_2;
-	private String indexName_1_2;
 
 	// Backend 2 / Index 1
 
 	private IndexAccessors_2_1 indexAccessors_2_1;
 	private IndexManager<?> indexManager_2_1;
-	private String indexName_2_1;
 
 	private SessionContext sessionContext = new StubSessionContext();
 
@@ -93,31 +96,22 @@ public class SearchMultiIndexIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration( BACKEND_1 )
 				.withIndex(
-						"MappedType_1_1", "IndexName_1_1",
+						"MappedType_1_1", INDEX_NAME_1_1,
 						ctx -> this.indexAccessors_1_1 = new IndexAccessors_1_1( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager_1_1 = indexManager;
-							this.indexName_1_1 = indexName;
-						}
+						indexManager -> this.indexManager_1_1 = indexManager
 				)
 				.withIndex(
-						"MappedType_1_2", "IndexName_1_2",
+						"MappedType_1_2", INDEX_NAME_1_2,
 						ctx -> this.indexAccessors_1_2 = new IndexAccessors_1_2( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager_1_2 = indexManager;
-							this.indexName_1_2 = indexName;
-						}
+						indexManager -> this.indexManager_1_2 = indexManager
 				)
 				.setup();
 
 		setupHelper.withDefaultConfiguration( BACKEND_2 )
 				.withIndex(
-						"MappedType_2_1", "IndexName_2_1",
+						"MappedType_2_1", INDEX_NAME_2_1,
 						ctx -> this.indexAccessors_2_1 = new IndexAccessors_2_1( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager_2_1 = indexManager;
-							this.indexName_2_1 = indexName;
-						}
+						indexManager -> this.indexManager_2_1 = indexManager
 				)
 				.setup();
 
@@ -136,8 +130,8 @@ public class SearchMultiIndexIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( c -> {
-			c.doc( indexName_1_1, DOCUMENT_1_1_1 );
-			c.doc( indexName_1_2, DOCUMENT_1_2_1 );
+			c.doc( INDEX_NAME_1_1, DOCUMENT_1_1_1 );
+			c.doc( INDEX_NAME_1_2, DOCUMENT_1_2_1 );
 		} );
 	}
 
@@ -154,9 +148,9 @@ public class SearchMultiIndexIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsExactOrder( c -> {
-			c.doc( indexName_1_1, DOCUMENT_1_1_1 );
-			c.doc( indexName_1_1, DOCUMENT_1_1_2 );
-			c.doc( indexName_1_2, DOCUMENT_1_2_1 );
+			c.doc( INDEX_NAME_1_1, DOCUMENT_1_1_1 );
+			c.doc( INDEX_NAME_1_1, DOCUMENT_1_1_2 );
+			c.doc( INDEX_NAME_1_2, DOCUMENT_1_2_1 );
 		} );
 
 		query = searchTarget.query( sessionContext )
@@ -166,9 +160,9 @@ public class SearchMultiIndexIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsExactOrder( c -> {
-			c.doc( indexName_1_2, DOCUMENT_1_2_1 );
-			c.doc( indexName_1_1, DOCUMENT_1_1_2 );
-			c.doc( indexName_1_1, DOCUMENT_1_1_1 );
+			c.doc( INDEX_NAME_1_2, DOCUMENT_1_2_1 );
+			c.doc( INDEX_NAME_1_1, DOCUMENT_1_1_2 );
+			c.doc( INDEX_NAME_1_1, DOCUMENT_1_1_1 );
 		} );
 	}
 
@@ -202,7 +196,7 @@ public class SearchMultiIndexIT {
 				.predicate().match().onField( "additionalField" ).matching( ADDITIONAL_FIELD_1_1_1 )
 				.build();
 
-		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_1, DOCUMENT_1_1_1 );
+		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME_1_1, DOCUMENT_1_1_1 );
 
 		// Sort
 
@@ -238,8 +232,8 @@ public class SearchMultiIndexIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "Unknown field 'unknownField' in indexes" )
-				.hasMessageContaining( indexName_1_1 )
-				.hasMessageContaining( indexName_1_2 );
+				.hasMessageContaining( INDEX_NAME_1_1 )
+				.hasMessageContaining( INDEX_NAME_1_2 );
 
 		// Sort
 
@@ -250,8 +244,8 @@ public class SearchMultiIndexIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "Unknown field 'unknownField' in indexes" )
-				.hasMessageContaining( indexName_1_1 )
-				.hasMessageContaining( indexName_1_2 );
+				.hasMessageContaining( INDEX_NAME_1_1 )
+				.hasMessageContaining( INDEX_NAME_1_2 );
 
 		// Projection
 
@@ -262,8 +256,8 @@ public class SearchMultiIndexIT {
 				.assertThrown()
 				.isInstanceOf( SearchException.class )
 				.hasMessageContaining( "Unknown projections [unknownField] in indexes" )
-				.hasMessageContaining( indexName_1_1 )
-				.hasMessageContaining( indexName_1_2 );
+				.hasMessageContaining( INDEX_NAME_1_1 )
+				.hasMessageContaining( INDEX_NAME_1_2 );
 	}
 
 	@Test
@@ -323,7 +317,7 @@ public class SearchMultiIndexIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME_1_1, DOCUMENT_1_1_1, DOCUMENT_1_1_2 );
 
 		// Backend 1 / Index 2
 
@@ -342,7 +336,7 @@ public class SearchMultiIndexIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName_1_2, DOCUMENT_1_2_1 );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME_1_2, DOCUMENT_1_2_1 );
 
 		// Backend 2 / Index 1
 
@@ -362,7 +356,7 @@ public class SearchMultiIndexIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName_2_1, DOCUMENT_2_1_1, DOCUMENT_2_1_2 );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME_2_1, DOCUMENT_2_1_1, DOCUMENT_2_1_2 );
 	}
 
 	private static class IndexAccessors_1_1 {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchQueryIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchQueryIT.java
@@ -29,6 +29,8 @@ import org.junit.rules.ExpectedException;
 
 public class SearchQueryIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String DOCUMENT_1 = "1";
 	private static final String STRING_1 = "aaa";
 
@@ -46,19 +48,15 @@ public class SearchQueryIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -78,7 +76,7 @@ public class SearchQueryIT {
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasHitCount( 3 )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -90,7 +88,7 @@ public class SearchQueryIT {
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasHitCount( 3 )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_2 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -101,7 +99,7 @@ public class SearchQueryIT {
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasHitCount( 3 )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -113,7 +111,7 @@ public class SearchQueryIT {
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasHitCount( 3 )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	@Test
@@ -129,21 +127,21 @@ public class SearchQueryIT {
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasHitCount( 3 )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
 		query.setFirstResult( 1L );
 		query.setMaxResults( 1L );
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasHitCount( 3 )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_2 );
 
 		query.setFirstResult( null );
 		query.setMaxResults( 2L );
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasHitCount( 3 )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -155,7 +153,7 @@ public class SearchQueryIT {
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
 				.hasHitCount( 3 )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	@Test
@@ -203,7 +201,7 @@ public class SearchQueryIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchResultIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchResultIT.java
@@ -50,6 +50,8 @@ import org.easymock.EasyMock;
 
 public class SearchResultIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String MAIN_ID = "main";
 	private static final String EMPTY_ID = "empty";
 
@@ -71,19 +73,15 @@ public class SearchResultIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -99,7 +97,7 @@ public class SearchResultIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MAIN_ID, EMPTY_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MAIN_ID, EMPTY_ID );
 	}
 
 	@Test
@@ -111,7 +109,7 @@ public class SearchResultIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MAIN_ID, EMPTY_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MAIN_ID, EMPTY_ID );
 	}
 
 	@Test
@@ -138,8 +136,8 @@ public class SearchResultIT {
 		} );
 
 		// Special projections without any document transformer nor object loader (those cases are addressed in other methods)
-		DocumentReference mainReference = reference( indexName, MAIN_ID );
-		DocumentReference emptyReference = reference( indexName, EMPTY_ID );
+		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
+		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		query = searchTarget.query( sessionContext )
 				.asProjections( ProjectionConstants.DOCUMENT_REFERENCE, ProjectionConstants.REFERENCE, ProjectionConstants.OBJECT )
 				.predicate().matchAll().end()
@@ -157,7 +155,7 @@ public class SearchResultIT {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Unknown projections" );
 		thrown.expectMessage( "unknownField" );
-		thrown.expectMessage( indexName );
+		thrown.expectMessage( INDEX_NAME );
 
 		searchTarget.query( sessionContext )
 				.asProjections( "unknownField" )
@@ -172,7 +170,7 @@ public class SearchResultIT {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Unknown projections" );
 		thrown.expectMessage( "nestedObject" );
-		thrown.expectMessage( indexName );
+		thrown.expectMessage( INDEX_NAME );
 
 		searchTarget.query( sessionContext )
 				.asProjections( "nestedObject" )
@@ -187,7 +185,7 @@ public class SearchResultIT {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Unknown projections" );
 		thrown.expectMessage( "flattenedObject" );
-		thrown.expectMessage( indexName );
+		thrown.expectMessage( INDEX_NAME );
 
 		searchTarget.query( sessionContext )
 				.asProjections( "flattenedObject" )
@@ -239,8 +237,8 @@ public class SearchResultIT {
 	public void references_referenceTransformer() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		DocumentReference mainReference = reference( indexName, MAIN_ID );
-		DocumentReference emptyReference = reference( indexName, EMPTY_ID );
+		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
+		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		StubTransformedReference mainTransformedReference = new StubTransformedReference( mainReference );
 		StubTransformedReference emptyTransformedReference = new StubTransformedReference( emptyReference );
 
@@ -269,8 +267,8 @@ public class SearchResultIT {
 	public void objects_referencesTransformer_objectLoading() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		DocumentReference mainReference = reference( indexName, MAIN_ID );
-		DocumentReference emptyReference = reference( indexName, EMPTY_ID );
+		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
+		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		StubTransformedReference mainTransformedReference = new StubTransformedReference( mainReference );
 		StubTransformedReference emptyTransformedReference = new StubTransformedReference( emptyReference );
 		StubLoadedObject mainLoadedObject = new StubLoadedObject( mainReference );
@@ -307,8 +305,8 @@ public class SearchResultIT {
 	public void projection_referencesTransformer_objectLoading() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		DocumentReference mainReference = reference( indexName, MAIN_ID );
-		DocumentReference emptyReference = reference( indexName, EMPTY_ID );
+		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
+		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		StubTransformedReference mainTransformedReference = new StubTransformedReference( mainReference );
 		StubTransformedReference emptyTransformedReference = new StubTransformedReference( emptyReference );
 		StubLoadedObject mainLoadedObject = new StubLoadedObject( mainReference );
@@ -353,8 +351,8 @@ public class SearchResultIT {
 	public void projections_hitTransformer() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		DocumentReference mainReference = reference( indexName, MAIN_ID );
-		DocumentReference emptyReference = reference( indexName, EMPTY_ID );
+		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
+		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		StubTransformedHit mainTransformedHit = new StubTransformedHit( mainReference );
 		StubTransformedHit emptyTransformedHit = new StubTransformedHit( emptyReference );
 
@@ -389,8 +387,8 @@ public class SearchResultIT {
 	public void projections_hitTransformer_referencesTransformer_objectLoading() {
 		IndexSearchTarget searchTarget = indexManager.createSearchTarget().build();
 
-		DocumentReference mainReference = reference( indexName, MAIN_ID );
-		DocumentReference emptyReference = reference( indexName, EMPTY_ID );
+		DocumentReference mainReference = reference( INDEX_NAME, MAIN_ID );
+		DocumentReference emptyReference = reference( INDEX_NAME, EMPTY_ID );
 		StubTransformedHit mainTransformedHit = new StubTransformedHit( mainReference );
 		StubTransformedHit emptyTransformedHit = new StubTransformedHit( emptyReference );
 		StubTransformedReference mainTransformedReference = new StubTransformedReference( mainReference );
@@ -471,7 +469,7 @@ public class SearchResultIT {
 				.predicate().matchAll().end()
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MAIN_ID, EMPTY_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MAIN_ID, EMPTY_ID );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchSortIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/SearchSortIT.java
@@ -49,6 +49,8 @@ import org.assertj.core.api.Assertions;
 
 public class SearchSortIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final int INDEX_ORDER_CHECKS = 10;
 
 	private static final String FIRST_ID = "1";
@@ -64,19 +66,15 @@ public class SearchSortIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -101,23 +99,23 @@ public class SearchSortIT {
 
 			query = simpleQuery( b -> b.byField( fieldPath ).onMissingValue().sortLast() );
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+					.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 
 			query = simpleQuery( b -> b.byField( fieldPath ).asc().onMissingValue().sortLast() );
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+					.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 
 			query = simpleQuery( b -> b.byField( fieldPath ).desc().onMissingValue().sortLast() );
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsExactOrder( indexName, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID );
+					.hasReferencesHitsExactOrder( INDEX_NAME, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID );
 
 			query = simpleQuery( b -> b.byField( fieldPath ).asc().onMissingValue().sortFirst() );
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsExactOrder( indexName, EMPTY_ID, FIRST_ID, SECOND_ID, THIRD_ID );
+					.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, FIRST_ID, SECOND_ID, THIRD_ID );
 
 			query = simpleQuery( b -> b.byField( fieldPath ).desc().onMissingValue().sortFirst() );
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsExactOrder( indexName, EMPTY_ID, THIRD_ID, SECOND_ID, FIRST_ID );
+					.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, THIRD_ID, SECOND_ID, FIRST_ID );
 		}
 	}
 
@@ -131,7 +129,7 @@ public class SearchSortIT {
 		SearchQuery<DocumentReference> query = simpleQuery( b -> b.byIndexOrder() );
 		SearchResult<DocumentReference> firstCallResult = query.execute();
 		assertThat( firstCallResult ).fromQuery( query )
-				.hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 		List<DocumentReference> firstCallHits = firstCallResult.getHits();
 
 		for ( int i = 0; i < INDEX_ORDER_CHECKS; ++i ) {
@@ -161,7 +159,7 @@ public class SearchSortIT {
 				.sort().byScore().end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -169,7 +167,7 @@ public class SearchSortIT {
 				.sort().byScore().desc().end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -177,7 +175,7 @@ public class SearchSortIT {
 				.sort().byScore().asc().end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, THIRD_ID, SECOND_ID, FIRST_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, THIRD_ID, SECOND_ID, FIRST_ID );
 	}
 
 	@Test
@@ -189,28 +187,28 @@ public class SearchSortIT {
 				.then().byField( "identicalForLastTwo" ).asc()
 		);
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, EMPTY_ID, FIRST_ID, SECOND_ID, THIRD_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, FIRST_ID, SECOND_ID, THIRD_ID );
 
 		query = simpleQuery( b -> b
 				.byField( "identicalForFirstTwo" ).desc().onMissingValue().sortFirst()
 				.then().byField( "identicalForLastTwo" ).desc()
 		);
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, EMPTY_ID, THIRD_ID, SECOND_ID, FIRST_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, THIRD_ID, SECOND_ID, FIRST_ID );
 
 		query = simpleQuery( b -> b
 				.byField( "identicalForFirstTwo" ).asc().onMissingValue().sortFirst()
 				.then().byField( "identicalForLastTwo" ).desc()
 		);
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, EMPTY_ID, SECOND_ID, FIRST_ID, THIRD_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, SECOND_ID, FIRST_ID, THIRD_ID );
 
 		query = simpleQuery( b -> b
 				.byField( "identicalForFirstTwo" ).desc().onMissingValue().sortFirst()
 				.then().byField( "identicalForLastTwo" ).asc()
 		);
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, EMPTY_ID, THIRD_ID, FIRST_ID, SECOND_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, EMPTY_ID, THIRD_ID, FIRST_ID, SECOND_ID );
 	}
 
 	@Test
@@ -228,7 +226,7 @@ public class SearchSortIT {
 				.sort( sort )
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -236,7 +234,7 @@ public class SearchSortIT {
 				.sort().by( sort ).end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 
 		sort = searchTarget.sort()
 				.byField( "string" ).desc().onMissingValue().sortLast()
@@ -248,7 +246,7 @@ public class SearchSortIT {
 				.sort( sort )
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -256,7 +254,7 @@ public class SearchSortIT {
 				.sort().by( sort ).end()
 				.build();
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, THIRD_ID, SECOND_ID, FIRST_ID, EMPTY_ID );
 	}
 	@Test
 	public void lambda_caching() {
@@ -280,13 +278,13 @@ public class SearchSortIT {
 
 		query = simpleQuery( cachingContributor );
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 
 		Assertions.assertThat( cache ).doesNotHaveValue( null );
 
 		query = simpleQuery( cachingContributor );
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 	}
 
 	@Test
@@ -294,12 +292,12 @@ public class SearchSortIT {
 		SearchQuery<DocumentReference> query = simpleQuery( b -> b.byDistance( "geoPoint", new ImmutableGeoPoint( 45.757864, 4.834496 ) ) );
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, THIRD_ID, SECOND_ID, EMPTY_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, THIRD_ID, SECOND_ID, EMPTY_ID );
 
 		query = simpleQuery( b -> b.byDistance( "geoPoint", 45.757864, 4.834496 ) );
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, FIRST_ID, THIRD_ID, SECOND_ID, EMPTY_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, FIRST_ID, THIRD_ID, SECOND_ID, EMPTY_ID );
 
 		// we don't test the descending order here as it's currently not supported by Lucene
 		// see the additional tests in the specific backend tests
@@ -321,7 +319,7 @@ public class SearchSortIT {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Unknown field" );
 		thrown.expectMessage( "unknownField" );
-		thrown.expectMessage( indexName );
+		thrown.expectMessage( INDEX_NAME );
 
 		searchTarget.query( sessionContext )
 				.asReferences()
@@ -340,7 +338,7 @@ public class SearchSortIT {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Unknown field" );
 		thrown.expectMessage( "nestedObject" );
-		thrown.expectMessage( indexName );
+		thrown.expectMessage( INDEX_NAME );
 
 		searchTarget.query( sessionContext )
 				.asReferences()
@@ -359,7 +357,7 @@ public class SearchSortIT {
 		thrown.expect( SearchException.class );
 		thrown.expectMessage( "Unknown field" );
 		thrown.expectMessage( "flattenedObject" );
-		thrown.expectMessage( indexName );
+		thrown.expectMessage( INDEX_NAME );
 
 		searchTarget.query( sessionContext )
 				.asReferences()
@@ -447,7 +445,7 @@ public class SearchSortIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, FIRST_ID, SECOND_ID, THIRD_ID, EMPTY_ID );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/BoolSearchPredicateIT.java
@@ -34,6 +34,8 @@ import org.junit.Test;
 
 public class BoolSearchPredicateIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String DOCUMENT_1 = "1";
 	private static final String DOCUMENT_2 = "2";
 	private static final String DOCUMENT_3 = "3";
@@ -67,19 +69,15 @@ public class BoolSearchPredicateIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -98,7 +96,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -119,7 +117,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -134,7 +132,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -151,7 +149,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -166,7 +164,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -177,7 +175,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 	}
 
 	@Test
@@ -193,7 +191,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 	}
 
 	@Test
@@ -212,7 +210,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 	}
 
 	@Test
@@ -227,7 +225,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -238,7 +236,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 	}
 
 	@Test
@@ -253,7 +251,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	@Test
@@ -270,7 +268,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 	}
 
 	@Test
@@ -287,7 +285,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
 	}
 
 	@Test
@@ -313,7 +311,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -332,7 +330,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -347,7 +345,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -368,7 +366,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// One matching and one non-matching "should" clause
 		query = searchTarget.query( sessionContext )
@@ -381,7 +379,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 	}
 
 	@Test
@@ -402,7 +400,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// One matching and one non-matching "should" clause
 		query = searchTarget.query( sessionContext )
@@ -415,7 +413,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -451,7 +449,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 	}
 
 	@Test
@@ -469,7 +467,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		// Expect to require 1 "should" clause to match even though there's a "must"
 		query = searchTarget.query( sessionContext )
@@ -483,7 +481,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
 		// Expect to require 2 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -497,7 +495,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// Expect to require all "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -510,7 +508,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -528,7 +526,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		// Expect to require 1 "should" clause to match even though there's a "must"
 		query = searchTarget.query( sessionContext )
@@ -542,7 +540,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
 		// Expect to require 2 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -556,7 +554,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -574,7 +572,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		// Expect to require 1 "should" clause to match even though there's a "must"
 		query = searchTarget.query( sessionContext )
@@ -588,7 +586,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
 		// Expect to require 2 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -602,7 +600,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// Expect to require all "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -615,7 +613,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -633,7 +631,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		// Expect to require 1 "should" clause to match even though there's a "must"
 		query = searchTarget.query( sessionContext )
@@ -647,7 +645,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
 		// Expect to require 2 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -661,7 +659,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -682,7 +680,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 		// 1 "should" clause: expect to require all "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -694,7 +692,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// 2 "should" clauses: expect to require all "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -707,7 +705,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// 3 "should" clauses: expect to require 2 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -721,7 +719,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// 4 "should" clauses: expect to require 3 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -736,7 +734,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// 5 "should" clauses: expect to require 3 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -752,7 +750,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// 6 "should" clauses: expect to require 4 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -769,7 +767,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 	}
 
 	@Test
@@ -792,7 +790,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// 2 "should" clauses: expect to require 1 "should" clause to match
 		query = searchTarget.query( sessionContext )
@@ -805,7 +803,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 		// 3 "should" clauses: expect to require 2 "should" clauses to match
 		query = searchTarget.query( sessionContext )
@@ -819,7 +817,7 @@ public class BoolSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		// The rest should behave exactly as in the other multiple-constraints test
 	}
@@ -898,7 +896,7 @@ public class BoolSearchPredicateIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/MatchAllSearchPredicateIT.java
@@ -27,6 +27,8 @@ import org.junit.Test;
 
 public class MatchAllSearchPredicateIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String DOCUMENT_1 = "1";
 	private static final String STRING_1 = "aaa";
 
@@ -41,19 +43,15 @@ public class MatchAllSearchPredicateIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -70,7 +68,7 @@ public class MatchAllSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	@Test
@@ -83,7 +81,7 @@ public class MatchAllSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -91,7 +89,7 @@ public class MatchAllSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		SearchPredicate searchPredicate = searchTarget.predicate().match().onField( "string" ).matching( STRING_3 );
 
@@ -101,7 +99,7 @@ public class MatchAllSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 	}
 
 	@Test
@@ -117,7 +115,7 @@ public class MatchAllSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -128,7 +126,7 @@ public class MatchAllSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		SearchPredicate searchPredicate1 = searchTarget.predicate().match().onField( "string" ).matching( STRING_3 );
 		SearchPredicate searchPredicate2 = searchTarget.predicate().match().onField( "string" ).matching( STRING_1 );
@@ -139,7 +137,7 @@ public class MatchAllSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 	}
 
 	private void initData() {
@@ -162,7 +160,7 @@ public class MatchAllSearchPredicateIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
+		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3 );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/MatchSearchPredicateIT.java
@@ -36,6 +36,8 @@ import org.junit.Test;
 
 public class MatchSearchPredicateIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String MATCHING_ID = "matching";
 	private static final String NON_MATCHING_ID = "nonMatching";
 	private static final String EMPTY_ID = "empty";
@@ -71,19 +73,15 @@ public class MatchSearchPredicateIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -104,7 +102,7 @@ public class MatchSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 		}
 	}
 
@@ -159,7 +157,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, ADDITIONAL_MATCHING_ID, MATCHING_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, ADDITIONAL_MATCHING_ID, MATCHING_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -171,7 +169,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, MATCHING_ID, ADDITIONAL_MATCHING_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, MATCHING_ID, ADDITIONAL_MATCHING_ID );
 	}
 
 	@Test
@@ -186,7 +184,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -194,7 +192,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 
 		// onField().orFields(...)
 
@@ -204,7 +202,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -212,7 +210,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -220,7 +218,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 
 		// onFields(...)
 
@@ -230,7 +228,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -238,7 +236,7 @@ public class MatchSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 	}
 
 	@Test
@@ -315,7 +313,7 @@ public class MatchSearchPredicateIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName, MATCHING_ID, NON_MATCHING_ID, EMPTY_ID, ADDITIONAL_MATCHING_ID );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID, NON_MATCHING_ID, EMPTY_ID, ADDITIONAL_MATCHING_ID );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/NestedSearchPredicateIT.java
@@ -30,6 +30,8 @@ import org.junit.rules.ExpectedException;
 
 public class NestedSearchPredicateIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String DOCUMENT_1 = "nestedQueryShouldMatchId";
 	private static final String DOCUMENT_2 = "nonNestedQueryShouldMatchId";
 
@@ -53,7 +55,6 @@ public class NestedSearchPredicateIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 
 	private StubSessionContext sessionContext = new StubSessionContext();
 
@@ -61,12 +62,9 @@ public class NestedSearchPredicateIT {
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -97,7 +95,7 @@ public class NestedSearchPredicateIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 )
 				.hasHitCount( 1 );
 	}
 
@@ -125,7 +123,7 @@ public class NestedSearchPredicateIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 )
 				.hasHitCount( 2 );
 	}
 
@@ -147,7 +145,7 @@ public class NestedSearchPredicateIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 )
 				.hasHitCount( 1 );
 	}
 
@@ -179,7 +177,7 @@ public class NestedSearchPredicateIT {
 				} )
 				.build();
 		assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 )
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 )
 				.hasHitCount( 1 );
 	}
 
@@ -307,7 +305,7 @@ public class NestedSearchPredicateIT {
 				.build();
 		assertThat( query )
 				.hasReferencesHitsAnyOrder(
-						indexName,
+						INDEX_NAME,
 						DOCUMENT_1, DOCUMENT_2, "neverMatching", "empty"
 				);
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/RangeSearchPredicateIT.java
@@ -37,6 +37,8 @@ import org.junit.Test;
 
 public class RangeSearchPredicateIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String DOCUMENT_1 = "1";
 	private static final String DOCUMENT_2 = "2";
 	private static final String DOCUMENT_3 = "3";
@@ -86,19 +88,15 @@ public class RangeSearchPredicateIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -119,7 +117,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 		}
 	}
 
@@ -139,7 +137,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
 			// explicit inclusion
 
@@ -149,7 +147,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2, DOCUMENT_3 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2, DOCUMENT_3 );
 
 			// explicit exclusion
 
@@ -159,7 +157,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_3 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
 		}
 	}
 
@@ -177,7 +175,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 		}
 	}
 
@@ -197,7 +195,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 			// explicit inclusion
 
@@ -207,7 +205,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 			// explicit exclusion
 
@@ -217,7 +215,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 		}
 	}
 
@@ -236,7 +234,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 		}
 	}
 
@@ -258,7 +256,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 			// explicit inclusion
 
@@ -270,7 +268,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2 );
 
 			// explicit exclusion for the from clause
 
@@ -282,7 +280,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 
 			// explicit exclusion for the to clause
 
@@ -294,7 +292,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 			// explicit exclusion for both clauses
 
@@ -306,7 +304,7 @@ public class RangeSearchPredicateIT {
 					.build();
 
 			DocumentReferencesSearchResultAssert.assertThat( query )
-					.hasReferencesHitsAnyOrder( indexName, DOCUMENT_2 );
+					.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_2 );
 		}
 	}
 
@@ -343,7 +341,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_1, DOCUMENT_3 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_3 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -355,7 +353,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, DOCUMENT_3, DOCUMENT_1 );
+				.hasReferencesHitsExactOrder( INDEX_NAME, DOCUMENT_3, DOCUMENT_1 );
 	}
 
 	@Test
@@ -370,7 +368,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -378,7 +376,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
 
 		// onField().orFields(...)
 
@@ -388,7 +386,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -396,7 +394,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -404,7 +402,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
 
 		// onFields(...)
 
@@ -414,7 +412,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_1 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1 );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -422,7 +420,7 @@ public class RangeSearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, DOCUMENT_3 );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_3 );
 	}
 
 	@Test
@@ -543,7 +541,7 @@ public class RangeSearchPredicateIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY_ID );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, DOCUMENT_1, DOCUMENT_2, DOCUMENT_3, EMPTY_ID );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/SearchPredicateIT.java
@@ -35,6 +35,8 @@ import org.assertj.core.api.Assertions;
 
 public class SearchPredicateIT {
 
+	private static final String INDEX_NAME = "IndexName";
+
 	private static final String MATCHING_ID = "matching";
 	private static final String NON_MATCHING_ID = "nonMatching";
 	private static final String EMPTY_ID = "empty";
@@ -48,19 +50,15 @@ public class SearchPredicateIT {
 
 	private IndexAccessors indexAccessors;
 	private IndexManager<?> indexManager;
-	private String indexName;
 	private SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -77,7 +75,7 @@ public class SearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 	}
 
 	@Test
@@ -92,7 +90,7 @@ public class SearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 	}
 
 	@Test
@@ -105,7 +103,7 @@ public class SearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 	}
 
 	@Test
@@ -132,7 +130,7 @@ public class SearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 
 		Assertions.assertThat( cache ).doesNotHaveValue( null );
 
@@ -142,7 +140,7 @@ public class SearchPredicateIT {
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, MATCHING_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID );
 	}
 
 	private void initData() {
@@ -163,7 +161,7 @@ public class SearchPredicateIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName, MATCHING_ID, NON_MATCHING_ID, EMPTY_ID );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, MATCHING_ID, NON_MATCHING_ID, EMPTY_ID );
 	}
 
 	private static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/AbstractSpatialWithinSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/AbstractSpatialWithinSearchPredicateIT.java
@@ -27,6 +27,8 @@ import org.junit.Rule;
 
 public abstract class AbstractSpatialWithinSearchPredicateIT {
 
+	protected static final String INDEX_NAME = "IndexName";
+
 	protected static final String OURSON_QUI_BOIT_ID = "ourson qui boit";
 	protected static final GeoPoint OURSON_QUI_BOIT_GEO_POINT = new ImmutableGeoPoint( 45.7705687,4.835233 );
 	protected static final String OURSON_QUI_BOIT_STRING = "L'ourson qui boit";
@@ -46,19 +48,15 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 
 	protected IndexAccessors indexAccessors;
 	protected IndexManager<?> indexManager;
-	protected String indexName;
 	protected SessionContext sessionContext = new StubSessionContext();
 
 	@Before
 	public void setup() {
 		setupHelper.withDefaultConfiguration()
 				.withIndex(
-						"MappedType", "IndexName",
+						"MappedType", INDEX_NAME,
 						ctx -> this.indexAccessors = new IndexAccessors( ctx.getSchemaElement() ),
-						(indexManager, indexName) -> {
-							this.indexManager = indexManager;
-							this.indexName = indexName;
-						}
+						indexManager -> this.indexManager = indexManager
 				)
 				.setup();
 
@@ -101,7 +99,7 @@ public abstract class AbstractSpatialWithinSearchPredicateIT {
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		assertThat( query ).hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID, CHEZ_MARGOTTE_ID, EMPTY_ID );
+		assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID, CHEZ_MARGOTTE_ID, EMPTY_ID );
 	}
 
 	protected static class IndexAccessors {

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -62,7 +62,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -70,7 +70,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -81,7 +81,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -92,7 +92,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 	}
 
 	@Test
@@ -106,7 +106,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, ADDITIONAL_POINT_1_ID, ADDITIONAL_POINT_2_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, ADDITIONAL_POINT_1_ID, ADDITIONAL_POINT_2_ID );
 	}
 
 	@Test
@@ -137,7 +137,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -149,7 +149,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
 	}
 
 	@Test
@@ -164,7 +164,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -172,7 +172,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		// onField().orFields(...)
 
@@ -183,7 +183,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -192,7 +192,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -201,7 +201,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		// onFields(...)
 
@@ -211,7 +211,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -219,7 +219,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 	}
 
 	@Test
@@ -270,7 +270,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 				.asReferences()
 				.predicate().matchAll().end()
 				.build();
-		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID, CHEZ_MARGOTTE_ID, EMPTY_ID, ADDITIONAL_POINT_1_ID,
+		DocumentReferencesSearchResultAssert.assertThat( query ).hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID, CHEZ_MARGOTTE_ID, EMPTY_ID, ADDITIONAL_POINT_1_ID,
 				ADDITIONAL_POINT_2_ID );
 	}
 

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinCircleSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinCircleSearchPredicateIT.java
@@ -40,7 +40,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -48,7 +48,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -56,7 +56,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -65,7 +65,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -73,7 +73,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 	}
 
 	@Test
@@ -104,7 +104,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -116,7 +116,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
 	}
 
 	@Test
@@ -131,7 +131,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -139,7 +139,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID );
 
 		// onField().orFields(...)
 
@@ -150,7 +150,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -159,7 +159,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -168,7 +168,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID );
 
 		// onFields(...)
 
@@ -178,7 +178,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -186,7 +186,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID );
 	}
 
 	@Test

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinPolygonSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinPolygonSearchPredicateIT.java
@@ -63,7 +63,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -71,7 +71,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 	}
 
 	@Test
@@ -102,7 +102,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -114,7 +114,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsExactOrder( indexName, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
+				.hasReferencesHitsExactOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, OURSON_QUI_BOIT_ID );
 	}
 
 	@Test
@@ -129,7 +129,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -137,7 +137,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		// onField().orFields(...)
 
@@ -148,7 +148,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -157,7 +157,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -166,7 +166,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, IMOUTO_ID, CHEZ_MARGOTTE_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, IMOUTO_ID, CHEZ_MARGOTTE_ID );
 
 		// onFields(...)
 
@@ -176,7 +176,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, CHEZ_MARGOTTE_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, CHEZ_MARGOTTE_ID, IMOUTO_ID );
 
 		query = searchTarget.query( sessionContext )
 				.asReferences()
@@ -184,7 +184,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 				.build();
 
 		DocumentReferencesSearchResultAssert.assertThat( query )
-				.hasReferencesHitsAnyOrder( indexName, OURSON_QUI_BOIT_ID, IMOUTO_ID );
+				.hasReferencesHitsAnyOrder( INDEX_NAME, OURSON_QUI_BOIT_ID, IMOUTO_ID );
 	}
 
 	@Test

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/util/rule/SearchSetupHelper.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/util/rule/SearchSetupHelper.java
@@ -128,7 +128,7 @@ public class SearchSetupHelper implements TestRule {
 
 	public interface IndexSetupListener {
 
-		void onSetup(IndexManager<?> indexManager, String normalizedIndexName);
+		void onSetup(IndexManager<?> indexManager);
 
 	}
 
@@ -152,8 +152,7 @@ public class SearchSetupHelper implements TestRule {
 
 		void afterBuild(StubMapping mapping) {
 			listener.onSetup(
-					mapping.getIndexManagerByTypeIdentifier( typeName ),
-					mapping.getNormalizedIndexNameByTypeIdentifier( typeName )
+					mapping.getIndexManagerByTypeIdentifier( typeName )
 			);
 		}
 

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/rule/BackendMock.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/rule/BackendMock.java
@@ -12,10 +12,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.stream.Collectors;
 
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.StubBackendBehavior;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.StubBackendUtils;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.document.StubDocumentNode;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.document.model.StubIndexSchemaNode;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.index.StubIndexWork;
@@ -74,25 +72,22 @@ public class BackendMock implements TestRule {
 	}
 
 	public BackendMock expectSchema(String indexName, Consumer<StubIndexSchemaNode.Builder> contributor) {
-		String normalizedIndexName = StubBackendUtils.normalizeIndexName( indexName );
-		CallQueue<PushSchemaCall> callQueue = behaviorMock.getPushSchemaCalls( normalizedIndexName );
+		CallQueue<PushSchemaCall> callQueue = behaviorMock.getPushSchemaCalls( indexName );
 		StubIndexSchemaNode.Builder builder = StubIndexSchemaNode.schema();
 		contributor.accept( builder );
-		callQueue.expect( new PushSchemaCall( normalizedIndexName, builder.build() ) );
+		callQueue.expect( new PushSchemaCall( indexName, builder.build() ) );
 		return this;
 	}
 
 	public BackendMock expectAnySchema(String indexName) {
-		String normalizedIndexName = StubBackendUtils.normalizeIndexName( indexName );
-		CallQueue<PushSchemaCall> callQueue = behaviorMock.getPushSchemaCalls( normalizedIndexName );
-		callQueue.expect( new PushSchemaCall( normalizedIndexName, null ) );
+		CallQueue<PushSchemaCall> callQueue = behaviorMock.getPushSchemaCalls( indexName );
+		callQueue.expect( new PushSchemaCall( indexName, null ) );
 		return this;
 	}
 
 	public WorkCallListContext expectWorks(String indexName) {
-		String normalizedIndexName = StubBackendUtils.normalizeIndexName( indexName );
-		CallQueue<IndexWorkCall> callQueue = behaviorMock.getIndexWorkCalls( normalizedIndexName );
-		return new WorkCallListContext( normalizedIndexName, callQueue );
+		CallQueue<IndexWorkCall> callQueue = behaviorMock.getIndexWorkCalls( indexName );
+		return new WorkCallListContext( indexName, callQueue );
 	}
 
 	public BackendMock expectSearchReferences(List<String> indexNames, Consumer<StubSearchWork.Builder> contributor,
@@ -112,22 +107,20 @@ public class BackendMock implements TestRule {
 
 	private BackendMock expectSearch(List<String> indexNames, Consumer<StubSearchWork.Builder> contributor,
 			StubSearchWork.ResultType resultType, StubSearchWorkBehavior<?> behavior) {
-		List<String> normalizedIndexNames = indexNames.stream().map( StubBackendUtils::normalizeIndexName )
-				.collect( Collectors.toList() );
 		CallQueue<SearchWorkCall<?>> callQueue = behaviorMock.getSearchWorkCalls();
 		StubSearchWork.Builder builder = StubSearchWork.builder( resultType );
 		contributor.accept( builder );
-		callQueue.expect( new SearchWorkCall<>( normalizedIndexNames, builder.build(), behavior ) );
+		callQueue.expect( new SearchWorkCall<>( indexNames, builder.build(), behavior ) );
 		return this;
 	}
 
 	public class WorkCallListContext {
-		private final String normalizedIndexName;
+		private final String indexName;
 		private final CallQueue<IndexWorkCall> callQueue;
 		private final List<StubIndexWork> works = new ArrayList<>();
 
-		private WorkCallListContext(String normalizedIndexName, CallQueue<IndexWorkCall> callQueue) {
-			this.normalizedIndexName = normalizedIndexName;
+		private WorkCallListContext(String indexName, CallQueue<IndexWorkCall> callQueue) {
+			this.indexName = indexName;
 			this.callQueue = callQueue;
 		}
 
@@ -179,24 +172,24 @@ public class BackendMock implements TestRule {
 		public BackendMock preparedThenExecuted() {
 			// First expect all works to be prepared, then expect all works to be executed
 			works.stream()
-					.map( work -> new IndexWorkCall( normalizedIndexName, IndexWorkCall.Operation.PREPARE, work ) )
+					.map( work -> new IndexWorkCall( indexName, IndexWorkCall.Operation.PREPARE, work ) )
 					.forEach( callQueue::expect );
 			works.stream()
-					.map( work -> new IndexWorkCall( normalizedIndexName, IndexWorkCall.Operation.EXECUTE, work ) )
+					.map( work -> new IndexWorkCall( indexName, IndexWorkCall.Operation.EXECUTE, work ) )
 					.forEach( callQueue::expect );
 			return BackendMock.this;
 		}
 
 		public BackendMock executed() {
 			works.stream()
-					.map( work -> new IndexWorkCall( normalizedIndexName, IndexWorkCall.Operation.EXECUTE, work ) )
+					.map( work -> new IndexWorkCall( indexName, IndexWorkCall.Operation.EXECUTE, work ) )
 					.forEach( callQueue::expect );
 			return BackendMock.this;
 		}
 
 		public BackendMock prepared() {
 			works.stream()
-					.map( work -> new IndexWorkCall( normalizedIndexName, IndexWorkCall.Operation.PREPARE, work ) )
+					.map( work -> new IndexWorkCall( indexName, IndexWorkCall.Operation.PREPARE, work ) )
 					.forEach( callQueue::expect );
 			return BackendMock.this;
 		}

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/StubBackendUtils.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/StubBackendUtils.java
@@ -6,8 +6,6 @@
  */
 package org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend;
 
-import java.util.Locale;
-
 import org.hibernate.search.v6poc.search.DocumentReference;
 
 public final class StubBackendUtils {
@@ -15,15 +13,7 @@ public final class StubBackendUtils {
 	private StubBackendUtils() {
 	}
 
-	public static String normalizeIndexName(String indexName) {
-		return indexName.toLowerCase( Locale.ROOT );
-	}
-
 	public static DocumentReference reference(String indexName, String id) {
-		return rawReference( StubBackendUtils.normalizeIndexName( indexName ), id );
-	}
-
-	public static DocumentReference rawReference(String indexName, String id) {
 		return new StubDocumentReference( indexName, id );
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/backend/index/impl/StubBackend.java
@@ -13,7 +13,6 @@ import org.hibernate.search.v6poc.cfg.ConfigurationPropertySource;
 import org.hibernate.search.v6poc.engine.spi.BuildContext;
 import org.hibernate.search.v6poc.util.AssertionFailure;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.StubBackendBehavior;
-import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.StubBackendUtils;
 import org.hibernate.search.v6poc.util.impl.integrationtest.common.stub.backend.document.impl.StubDocumentElement;
 
 public class StubBackend implements BackendImplementor<StubDocumentElement>, Backend {
@@ -44,14 +43,9 @@ public class StubBackend implements BackendImplementor<StubDocumentElement>, Bac
 	}
 
 	@Override
-	public String normalizeIndexName(String rawIndexName) {
-		return StubBackendUtils.normalizeIndexName( rawIndexName );
-	}
-
-	@Override
-	public IndexManagerBuilder<StubDocumentElement> createIndexManagerBuilder(String name, boolean isMultiTenancyEnabled, BuildContext context,
+	public IndexManagerBuilder<StubDocumentElement> createIndexManagerBuilder(String indexName, boolean isMultiTenancyEnabled, BuildContext context,
 			ConfigurationPropertySource propertySource) {
-		return new StubIndexManagerBuilder( this, name );
+		return new StubIndexManagerBuilder( this, indexName );
 	}
 
 	@Override

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/mapper/StubMapper.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/mapper/StubMapper.java
@@ -39,10 +39,8 @@ class StubMapper implements Mapper<StubMapping> {
 
 	@Override
 	public StubMapping build() {
-		Map<String, String> normalizedIndexNamesByTypeIdentifier = indexManagerBuildingStates.entrySet().stream()
-				.collect( Collectors.toMap( e -> e.getKey().asString(), e -> e.getValue().getIndexName() ) );
 		Map<String, IndexManager<?>> indexManagersByTypeIdentifier = indexManagerBuildingStates.entrySet().stream()
 				.collect( Collectors.toMap( e -> e.getKey().asString(), e -> e.getValue().build() ) );
-		return new StubMapping( normalizedIndexNamesByTypeIdentifier, indexManagersByTypeIdentifier );
+		return new StubMapping( indexManagersByTypeIdentifier );
 	}
 }

--- a/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/mapper/StubMapping.java
+++ b/util/internal/integrationtest/common/src/main/java/org/hibernate/search/v6poc/util/impl/integrationtest/common/stub/mapper/StubMapping.java
@@ -13,22 +13,15 @@ import org.hibernate.search.v6poc.entity.mapping.spi.MappingImplementor;
 
 public class StubMapping implements MappingImplementor<StubMapping> {
 
-	private final Map<String, String> normalizedIndexNamesByTypeIdentifier;
 	private final Map<String, IndexManager<?>> indexManagersByTypeIdentifier;
 
-	StubMapping(Map<String, String> normalizedIndexNamesByTypeIdentifier,
-			Map<String, IndexManager<?>> indexManagersByTypeIdentifier) {
-		this.normalizedIndexNamesByTypeIdentifier = normalizedIndexNamesByTypeIdentifier;
+	StubMapping(Map<String, IndexManager<?>> indexManagersByTypeIdentifier) {
 		this.indexManagersByTypeIdentifier = indexManagersByTypeIdentifier;
 	}
 
 	@Override
 	public StubMapping toAPI() {
 		return this;
-	}
-
-	public String getNormalizedIndexNameByTypeIdentifier(String typeId) {
-		return normalizedIndexNamesByTypeIdentifier.get( typeId );
 	}
 
 	public IndexManager<?> getIndexManagerByTypeIdentifier(String typeId) {


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3231

Essentially, this makes sure that error messages and document references provided by the backend use the exact index name that was picked by the user when mapping his entities.

The internal name used by the backend may be different because of internal limitations, for example Elasticsearch is case-insensitive when it comes to index names.

It turns out there wasn't much to do on the Lucene side, since we were already using the user-provided index name as-is in documents.

Later, we may decide to add normalization/restrictions at the engine level, to fail the build when two index names are too similar (only differ by case) or use very exotic characters (non-printable characters in particular). However, this is beyond the scope of this PR, and does not even remove the need for this PR.