### PR TITLE
HSEARCH-3239 Setup a Jenkins pipeline build with a Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,8 +124,6 @@ ALL_ENV""",
 		case 'EXPERIMENTAL_ENV_ONLY':
 			enableExperimentalEnvIT = true
 			break
-		default:
-			echo "Unknown value for param 'INTEGRATION_TESTS': '$params.INTEGRATION_TESTS'. Defaulting to 'AUTOMATIC'."
 		case 'AUTOMATIC':
 			if (params.RELEASE_VERSION) {
 				echo "Skipping default build and integration tests to speed up the release of version $params.RELEASE_VERSION"
@@ -143,6 +141,10 @@ ALL_ENV""",
 				enableDefaultEnvIT = true
 			}
 			break
+		default:
+			throw new IllegalArgumentException(
+					"Unknown value for param 'INTEGRATION_TESTS': '$params.INTEGRATION_TESTS'."
+			)
 	}
 
 	enableDefaultBuild = enableDefaultEnvIT || enableNonDefaultSupportedEnvIT || enableExperimentalEnvIT

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -216,6 +216,13 @@ enableExperimentalEnvIT=$enableExperimentalEnvIT"""
 
 		echo "Inferred version family for the release to '$releaseVersionFamily'"
 	}
+
+	if (params.RELEASE_DEVELOPMENT_VERSION && !(params.RELEASE_DEVELOPMENT_VERSION ==~ versionPattern)) {
+		throw new IllegalArgumentException(
+				"Invalid development version number: '$params.RELEASE_DEVELOPMENT_VERSION'." +
+						" Version numbers must match /$versionPattern/"
+		)
+	}
 }
 
 stage('Default build') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -415,5 +415,5 @@ void mavenNonDefaultIT(ITEnvironment itEnv, String args) {
 	// Add a suffix to tests to distinguish between different executions
 	// of the same test in different environments in reports
 	def testSuffix = itEnv.tag.replaceAll('[^a-zA-Z0-9_\\-+]+', '_')
-	sh "mvn -Dsurefire.reportNameSuffix=$testSuffix $args"
+	sh "mvn -Dsurefire.environment=$testSuffix $args"
 }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -211,11 +211,19 @@ enableExperimentalEnvIT=$enableExperimentalEnvIT"""
 					"Invalid version number: '$params.RELEASE_VERSION'. Version numbers must match /$versionPattern/"
 			)
 		}
+
 		String major = matcher.group(1)
 		String minor = matcher.group(2)
 		releaseVersionFamily = "$major.$minor"
-
 		echo "Inferred version family for the release to '$releaseVersionFamily'"
+
+		// Check that all the necessary parameters are set
+		if (!params.RELEASE_DEVELOPMENT_VERSION) {
+			throw new IllegalArgumentException(
+					"Missing value for parameter RELEASE_DEVELOPMENT_VERSION." +
+							" This parameter must be set when RELEASE_VERSION is set."
+			)
+		}
 	}
 
 	def developmentVersionPattern = ~/^\d+\.\d+\.\d+-SNAPSHOT$/

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,419 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+
+import groovy.transform.Field
+import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
+
+/*
+ * See http://ci.hibernate.org/pipeline-syntax/ for help writing Jenkins pipeline steps.
+ *
+ * This file requires the following plugins in particular:
+ * - https://plugins.jenkins.io/pipeline-maven
+ * - https://plugins.jenkins.io/ec2
+ *
+ * Also you might need to allow the following calls in <jenkinsUrl>/scriptApproval/:
+ * - method java.util.Map putIfAbsent java.lang.Object java.lang.Object
+ * - staticMethod org.jenkinsci.plugins.pipeline.modeldefinition.Utils markStageSkippedForConditional java.lang.String
+ * Just run the script a few times, it will fail and display a link to allow these calls.
+ */
+
+@Field final String MAVEN_LOCAL_REPOSITORY_RELATIVE = '.repository'
+@Field final String MAVEN_TOOL = 'Apache Maven 3.5.2'
+
+@Field final String DEFAULT_JDK_TOOL = 'Oracle JDK 8'
+@Field final String DEFAULT_ES_PROFILE = 'elasticsearch-5.2'
+
+@Field final String NODE_PATTERN_BASE = 'Slave'
+
+@Field final List<JdkITEnvironment> nonDefaultJdkEnvs = [
+		// This should not include the default JDK, which is used in the default build
+		// This should not include every JDK; in particular let's not care too much about EOL'd JDKs like version 9
+		// See http://www.oracle.com/technetwork/java/javase/eol-135779.html
+		// TODO add support for JDK10/JDK11
+		new JdkITEnvironment(version: '10', tool: 'Oracle JDK 10.0.1', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new JdkITEnvironment(version: '11', tool: 'OpenJDK 11 Latest', status: ITEnvironmentStatus.EXPERIMENTAL)
+]
+@Field final List<DatabaseITEnvironment> nonDefaultDatabaseEnvs = [
+		// This should not include the default DB, which is used in the default build
+		new DatabaseITEnvironment(dbName: 'mariadb', mavenProfile: 'ci-mariadb', status: ITEnvironmentStatus.SUPPORTED),
+		new DatabaseITEnvironment(dbName: 'postgresql', mavenProfile: 'ci-postgresql', status: ITEnvironmentStatus.SUPPORTED)
+]
+@Field final List<EsLocalITEnvironment> nonDefaultEsLocalEnvs = [
+		// This should not include the default profile, which is used in the default build
+		// TODO add support for Elasticsearch 2? 5.0? 5.1?
+		new EsLocalITEnvironment(versionRange: '[2.0,2.2)', mavenProfile: 'elasticsearch-2.0', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new EsLocalITEnvironment(versionRange: '[2.2,5.0)', mavenProfile: 'elasticsearch-2.2', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new EsLocalITEnvironment(versionRange: '[5.0,5.2)', mavenProfile: 'elasticsearch-5.0', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new EsLocalITEnvironment(versionRange: '[6.0,6.x)', mavenProfile: 'elasticsearch-6.0', status: ITEnvironmentStatus.SUPPORTED)
+]
+@Field final List<EsAwsITEnvironment> nonDefaultEsAwsEnvs = [
+		// This should not include the default profile, which is used in the default build
+		// TODO add support for AWS (needs the plugin currently only available in Search 5)
+		new EsAwsITEnvironment(version: '2.3', mavenProfile: 'elasticsearch-2.0', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new EsAwsITEnvironment(version: '5.1', mavenProfile: 'elasticsearch-5.0', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new EsAwsITEnvironment(version: '5.3', mavenProfile: 'elasticsearch-5.2', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new EsAwsITEnvironment(version: '5.5', mavenProfile: 'elasticsearch-5.2', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new EsAwsITEnvironment(version: '6.0', mavenProfile: 'elasticsearch-6.0', status: ITEnvironmentStatus.EXPERIMENTAL),
+		new EsAwsITEnvironment(version: '6.2', mavenProfile: 'elasticsearch-6.0', status: ITEnvironmentStatus.EXPERIMENTAL)
+]
+@Field final List<List<? extends ITEnvironment>> allNonDefaultEnvironments = [
+		nonDefaultJdkEnvs, nonDefaultDatabaseEnvs, nonDefaultEsLocalEnvs, nonDefaultEsAwsEnvs
+]
+
+@Field boolean enableDefaultBuild = false
+@Field boolean enableDefaultEnvIT = false
+@Field boolean enableNonDefaultSupportedEnvIT = false
+@Field boolean enableExperimentalEnvIT = false
+
+stage('Configure') {
+	properties([
+			parameters([
+					choice(
+							name: 'INTEGRATION_TESTS',
+							choices: """AUTOMATIC
+DEFAULT_ENV_ONLY
+SUPPORTED_ENV_ONLY
+EXPERIMENTAL_ENV_ONLY
+ALL_ENV""",
+							defaultValue: 'AUTOMATIC',
+							description: """Which integration tests to run.
+'AUTOMATIC' chooses based on the branch name and whether a release is being performed.
+'DEFAULT_ENV_ONLY' means a single build, while other options will trigger multiple Maven executions in different environments."""
+					),
+					string(
+							name: 'RELEASE_VERSION',
+							defaultValue: '',
+							description: 'The version to be released, e.g. 5.10.0.Final. Setting this triggers a release.',
+							trim: true
+					),
+					string(
+							name: 'RELEASE_FAMILY_VERSION',
+							defaultValue: '5.10',
+							description: 'The minor version family to be used for the documentation upload, e.g. 5.10.',
+							trim: true
+					),
+					string(
+							name: 'RELEASE_DEVELOPMENT_VERSION',
+							defaultValue: '',
+							description: 'The next version to be used after the release, e.g. 5.10.0-SNAPSHOT.',
+							trim: true
+					),
+					booleanParam(
+							name: 'RELEASE_DRY_RUN',
+							defaultValue: false,
+							description: 'If true, just simulate the release, without pushing any commits or tags, and without uploading any artifacts or documentation.'
+					)
+			])
+	])
+
+	switch (params.INTEGRATION_TESTS) {
+		case 'DEFAULT_ENV_ONLY':
+			enableDefaultEnvIT = true
+			break
+		case 'SUPPORTED_ENV_ONLY':
+			enableDefaultEnvIT = true
+			enableNonDefaultSupportedEnvIT = true
+			break
+		case 'ALL_ENV':
+			enableDefaultEnvIT = true
+			enableNonDefaultSupportedEnvIT = true
+			enableExperimentalEnvIT = true
+			break
+		case 'EXPERIMENTAL_ENV_ONLY':
+			enableExperimentalEnvIT = true
+			break
+		default:
+			echo "Unknown value for param 'INTEGRATION_TESTS': '$params.INTEGRATION_TESTS'. Defaulting to 'AUTOMATIC'."
+		case 'AUTOMATIC':
+			if (params.RELEASE_VERSION) {
+				echo "Skipping default build and integration tests to speed up the release of version $params.RELEASE_VERSION"
+			} else if (env.CHANGE_ID) {
+				echo "Enabling only the default build and integration tests in the default environment for pull request $env.CHANGE_ID"
+				enableDefaultEnvIT = true
+			} else if (env.BRANCH_NAME ==~ /master|\d+\.\d+/) {
+				echo "Enabling integration tests on all supported environments for master or maintenance branch '$env.BRANCH_NAME'"
+				enableDefaultBuild = true
+				enableDefaultEnvIT = true
+				enableNonDefaultSupportedEnvIT = true
+			} else {
+				echo "Enabling only the default build and integration tests in the default environment for feature branch $env.BRANCH_NAME"
+				enableDefaultBuild = true
+				enableDefaultEnvIT = true
+			}
+			break
+	}
+
+	enableDefaultBuild = enableDefaultEnvIT || enableNonDefaultSupportedEnvIT || enableExperimentalEnvIT
+
+	echo """Integration test setting: $params.INTEGRATION_TESTS, result:
+enableDefaultBuild=$enableDefaultBuild
+enableDefaultEnvIT=$enableDefaultEnvIT
+enableNonDefaultSupportedEnvIT=$enableNonDefaultSupportedEnvIT
+enableExperimentalEnvIT=$enableExperimentalEnvIT"""
+
+	allNonDefaultEnvironments.each { envList ->
+		if (!enableNonDefaultSupportedEnvIT) {
+			envList.removeAll { itEnv -> itEnv.status == ITEnvironmentStatus.SUPPORTED }
+		}
+		if (!enableExperimentalEnvIT) {
+			envList.removeAll { itEnv -> itEnv.status == ITEnvironmentStatus.EXPERIMENTAL }
+		}
+	}
+
+	nonDefaultEsAwsEnvs.removeAll { itEnv ->
+		itEnv.endpointUrl = env.getProperty(itEnv.endpointVariableName)
+		if (!itEnv.endpointUrl) {
+			echo "Skipping test ${itEnv.tag} because environment variable '${itEnv.endpointVariableName}' is not defined."
+			return true
+		}
+		itEnv.awsRegion = env.ES_AWS_REGION
+		if (!itEnv.awsRegion) {
+			echo "Skipping test ${itEnv.tag} because environment variable 'ES_AWS_REGION' is not defined."
+			return true
+		}
+		return false // Environment is fully defined, do not remove
+	}
+
+	/*
+	 * There is something deeply wrong with collections in pipelines:
+	 * - referencing a collection directly with interpolation ("$foo") sometimes results
+	 *   in the echo statement not being executed at all, without even an exception
+	 * - calling collection.toString() only prints the first element in the collection
+	 * - calling flatten().join(', ') only prints the first element
+	 * Thus the workaround below...
+	 */
+	String stringToPrint = ''
+	allNonDefaultEnvironments.each { envList ->
+		envList.each {
+			stringToPrint += ' ' + it.toString()
+		}
+	}
+	if (stringToPrint) {
+		echo "Enabled non-default environment ITs:$stringToPrint"
+	}
+	else {
+		echo "Non-default environment ITs are completely disabled."
+	}
+}
+
+stage('Default build') {
+	if (!enableDefaultBuild) {
+		echo 'Skipping default build and integration tests in the default environment'
+		Utils.markStageSkippedForConditional(STAGE_NAME)
+		return
+	}
+	node(NODE_PATTERN_BASE) {
+		checkout scm
+		withDefaultedMaven {
+			sh """ \\
+					mvn clean install -Pdist -Pcoverage -Pjqassistant \\
+					${enableDefaultEnvIT ? '' : '-DskipITs'}
+			"""
+			dir("$env.WORKSPACE/$MAVEN_LOCAL_REPOSITORY_RELATIVE") {
+				stash name:'main-build', includes:"org/hibernate/search/v6poc/**"
+			}
+		}
+	}
+}
+
+stage('Non-default environment ITs') {
+	Map<String, Closure> executions = [:]
+
+	// Test with multiple JDKs
+	nonDefaultJdkEnvs.each { itEnv ->
+		executions.put(itEnv.tag, {
+			node(NODE_PATTERN_BASE) {
+				withDefaultedMaven(jdk: itEnv.tool) {
+					checkout scm
+					mavenNonDefaultIT itEnv,
+							"clean install --fail-at-end"
+				}
+			}
+		})
+	}
+
+	// Test ORM integration with multiple databases
+	nonDefaultDatabaseEnvs.each { itEnv ->
+		executions.put(itEnv.tag, {
+			node(NODE_PATTERN_BASE) {
+				withDefaultedMaven {
+					resumeFromDefaultBuild()
+					// We must re-generate the ORM integration test utils too, to re-generate hibernate.properties
+					mavenNonDefaultIT itEnv, """ \\
+							clean install -pl util/integrationtest/orm,integrationtest/orm -P$itEnv.mavenProfile
+					"""
+				}
+			}
+		})
+	}
+
+	// Test Elasticsearch integration with multiple versions in a local instance
+	nonDefaultEsLocalEnvs.each { itEnv ->
+		executions.put(itEnv.tag, {
+			node(NODE_PATTERN_BASE) {
+				withDefaultedMaven {
+					resumeFromDefaultBuild()
+					mavenNonDefaultIT itEnv, """ \\
+							clean install -pl integrationtest/backend-elasticsearch \\
+							-P!$DEFAULT_ES_PROFILE,$itEnv.mavenProfile
+					"""
+				}
+			}
+		})
+	}
+
+	// Test Elasticsearch integration with multiple versions in an AWS instance
+	nonDefaultEsAwsEnvs.each { itEnv ->
+		if (!itEnv.endpointUrl) {
+			throw new IllegalStateException("Unexpected empty endpoint URL")
+		}
+		if (!itEnv.awsRegion) {
+			throw new IllegalStateException("Unexpected empty AWS region")
+		}
+		executions.put(itEnv.tag, {
+			node(NODE_PATTERN_BASE + '&&AWS') {
+				withDefaultedMaven {
+					resumeFromDefaultBuild()
+					withAwsCredentials {
+						mavenNonDefaultIT itEnv, """ \\
+								clean install -pl integrationtest/backend-elasticsearch \\
+								-P!$DEFAULT_ES_PROFILE,$itEnv.mavenProfile \\
+								-Dtest.elasticsearch.host.provided=true \\
+								-Dtest.elasticsearch.host.url=$itEnv.endpointUrl \\
+								-Dtest.elasticsearch.host.aws.access_key=$AWS_ACCESS_KEY_ID \\
+								-Dtest.elasticsearch.host.aws.secret_key=$AWS_SECRET_ACCESS_KEY \\
+								-Dtest.elasticsearch.host.aws.region=$itEnv.awsRegion
+"""
+					}
+				}
+			}
+		})
+	}
+
+	if (executions.isEmpty()) {
+		echo 'Skipping integration tests in non-default environments'
+		Utils.markStageSkippedForConditional(STAGE_NAME)
+	}
+	else {
+		parallel(executions)
+	}
+}
+
+stage('Release') {
+	if (!params.RELEASE_VERSION) {
+		echo "Skipping the release"
+		Utils.markStageSkippedForConditional(STAGE_NAME)
+		return
+	}
+	node(NODE_PATTERN_BASE) {
+		cleanWs()
+
+		withDefaultedMaven {
+			checkout scm
+
+			sh "git clone https://github.com/hibernate/hibernate-noorm-release-scripts.git"
+			sh "bash -xe hibernate-noorm-release-scripts/prepare-release.sh search ${params.RELEASE_VERSION}"
+
+			if (!params.RELEASE_DRY_RUN) {
+				sh "bash -xe hibernate-noorm-release-scripts/deploy.sh search"
+			} else {
+				echo "WARNING: Not deploying"
+			}
+
+			if (!params.RELEASE_DRY_RUN) {
+				sh "bash -xe hibernate-noorm-release-scripts/upload-distribution.sh search ${params.RELEASE_VERSION}"
+				sh "bash -xe hibernate-noorm-release-scripts/upload-documentation.sh search ${params.RELEASE_VERSION} ${params.RELEASE_FAMILY_VERSION}"
+			}
+			else {
+				echo "WARNING: Not uploading anything"
+			}
+
+			sh "bash -xe hibernate-noorm-release-scripts/update-version.sh search ${params.RELEASE_DEVELOPMENT_VERSION}"
+			sh "bash -xe hibernate-noorm-release-scripts/push-upstream.sh search ${params.RELEASE_VERSION} ${env.BRANCH_NAME} ${!params.RELEASE_DRY_RUN}"
+		}
+	}
+}
+
+// Helpers
+
+enum ITEnvironmentStatus {
+	SUPPORTED,
+	EXPERIMENTAL
+}
+
+abstract class ITEnvironment {
+	ITEnvironmentStatus status
+	String toString() { getTag() }
+	abstract String getTag()
+}
+
+class JdkITEnvironment extends ITEnvironment {
+	ITEnvironmentStatus status
+	String version
+	String tool
+	String getTag() { "jdk-$version" }
+}
+
+class DatabaseITEnvironment extends ITEnvironment {
+	String dbName
+	String mavenProfile
+	String getTag() { "database-$dbName" }
+}
+
+class EsLocalITEnvironment extends ITEnvironment {
+	String versionRange
+	String mavenProfile
+	String getTag() { "elasticsearch-local-$versionRange" }
+}
+
+class EsAwsITEnvironment extends ITEnvironment {
+	String version
+	String mavenProfile
+	String endpointUrl = null
+	String awsRegion = null
+	String getTag() { "elasticsearch-aws-$version" }
+	String getEndpointVariableName() {
+		"ES_AWS_" + version.replaceAll('\\.', '') + "_ENDPOINT"
+	}
+}
+
+void withDefaultedMaven(Closure body) {
+	withDefaultedMaven([:], body)
+}
+
+void withDefaultedMaven(Map args, Closure body) {
+	args.putIfAbsent('jdk', DEFAULT_JDK_TOOL)
+	args.putIfAbsent('maven', MAVEN_TOOL)
+	args.putIfAbsent('options', [artifactsPublisher(disabled: true)])
+	args.putIfAbsent('mavenLocalRepo', "$env.WORKSPACE/$MAVEN_LOCAL_REPOSITORY_RELATIVE")
+	withMaven(args, body)
+}
+
+void withAwsCredentials(Closure body) {
+	withCredentials(
+		[[$class: 'AmazonWebServicesCredentialsBinding',
+			credentialsId: 'aws-elasticsearch',
+			usernameVariable: 'AWS_ACCESS_KEY_ID',
+			passwordVariable: 'AWS_SECRET_ACCESS_KEY'
+		]],
+		body
+	)
+}
+
+void resumeFromDefaultBuild() {
+	checkout scm
+	dir("$env.WORKSPACE/$MAVEN_LOCAL_REPOSITORY_RELATIVE") {
+		unstash name:'main-build'
+	}
+}
+
+void mavenNonDefaultIT(ITEnvironment itEnv, String args) {
+	// Add a suffix to tests to distinguish between different executions
+	// of the same test in different environments in reports
+	def testSuffix = itEnv.tag.replaceAll('[^a-zA-Z0-9_\\-+]+', '_')
+	sh "mvn -Dsurefire.reportNameSuffix=$testSuffix $args"
+}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -200,7 +200,7 @@ enableExperimentalEnvIT=$enableExperimentalEnvIT"""
 		echo "Non-default environment ITs are completely disabled."
 	}
 
-	def versionPattern = ~/^(\d+)\.(\d+)\.\d+\S*$/
+	def versionPattern = ~/^(\d+)\.(\d+)(\.0\.Alpha\d+|\.0\.Beta\d+|\.0\.CR\d+|\.\d+\.Final)$/
 
 	// Compute the version truncated to the minor component, a.k.a. the version family
 	// To be used for the documentation upload in particular
@@ -218,10 +218,12 @@ enableExperimentalEnvIT=$enableExperimentalEnvIT"""
 		echo "Inferred version family for the release to '$releaseVersionFamily'"
 	}
 
-	if (params.RELEASE_DEVELOPMENT_VERSION && !(params.RELEASE_DEVELOPMENT_VERSION ==~ versionPattern)) {
+	def developmentVersionPattern = ~/^\d+\.\d+\.\d+-SNAPSHOT$/
+
+	if (params.RELEASE_DEVELOPMENT_VERSION && !(params.RELEASE_DEVELOPMENT_VERSION ==~ developmentVersionPattern)) {
 		throw new IllegalArgumentException(
 				"Invalid development version number: '$params.RELEASE_DEVELOPMENT_VERSION'." +
-						" Version numbers must match /$versionPattern/"
+						" Development version numbers must match /$developmentVersionPattern/"
 		)
 	}
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,0 +1,4 @@
+Hibernate Search Changelog
+==========================
+
+

--- a/integrationtest/backend-elasticsearch/pom.xml
+++ b/integrationtest/backend-elasticsearch/pom.xml
@@ -11,6 +11,10 @@
     <name>Hibernate Search Integration Tests - Backend - Elasticsearch</name>
     <description>Hibernate Search integration tests for the Elasticsearch backend, running the Backend TCK in particular</description>
 
+    <properties>
+        <surefire.executing-module>it-elasticsearch</surefire.executing-module>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/integrationtest/backend-elasticsearch/pom.xml
+++ b/integrationtest/backend-elasticsearch/pom.xml
@@ -41,6 +41,12 @@
     </dependencies>
 
     <build>
+        <testResources>
+            <testResource>
+                <filtering>true</filtering>
+                <directory>src/test/resources</directory>
+            </testResource>
+        </testResources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/integrationtest/backend-elasticsearch/src/test/resources/backend-tck-multi-tenancy.properties
+++ b/integrationtest/backend-elasticsearch/src/test/resources/backend-tck-multi-tenancy.properties
@@ -1,3 +1,6 @@
 backend.type org.hibernate.search.v6poc.backend.elasticsearch.impl.ElasticsearchBackendFactory
+backend.host ${test.elasticsearch.host.url}
+backend.username ${test.elasticsearch.host.username}
+backend.password ${test.elasticsearch.host.password}
 backend.log.json_pretty_printing true
 backend.multi_tenancy_strategy discriminator

--- a/integrationtest/backend-elasticsearch/src/test/resources/backend-tck.properties
+++ b/integrationtest/backend-elasticsearch/src/test/resources/backend-tck.properties
@@ -1,2 +1,5 @@
 backend.type org.hibernate.search.v6poc.backend.elasticsearch.impl.ElasticsearchBackendFactory
+backend.host ${test.elasticsearch.host.url}
+backend.username ${test.elasticsearch.host.username}
+backend.password ${test.elasticsearch.host.password}
 backend.log.json_pretty_printing true

--- a/integrationtest/backend-lucene/pom.xml
+++ b/integrationtest/backend-lucene/pom.xml
@@ -11,6 +11,10 @@
     <name>Hibernate Search Integration Tests - Backend - Lucene</name>
     <description>Hibernate Search integration tests for the Lucene backend, running the Backend TCK in particular</description>
 
+    <properties>
+        <surefire.executing-module>it-lucene</surefire.executing-module>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>${project.groupId}</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -134,6 +134,19 @@
         <failsafe.jvm.args>${surefire.jvm.args.memory} ${surefire.jvm.args.java-version} ${failsafe.jvm.args.jacoco}</failsafe.jvm.args>
 
         <!--
+            Should be set by submodules.
+            Used by integration tests modules that execute tests from another module.
+            Allows to distinguish between multiple executions of the same test in test reports.
+         -->
+        <surefire.executing-module>default</surefire.executing-module>
+        <!--
+            Should be set from the command line.
+            Used by CI jobs that execute tests in multiple environments.
+            Allows to distinguish between multiple executions of the same test in test reports.
+         -->
+        <surefire.environment>default</surefire.environment>
+
+        <!--
             The path to the root project directory.
             This property is set by the build-helper plugin.
             We initialize it to some crude, potentially wrong value,
@@ -722,6 +735,7 @@
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <runOrder>alphabetical</runOrder>
                         <argLine>${surefire.jvm.args}</argLine>
+                        <reportNameSuffix>${surefire.environment}-${surefire.executing-module}</reportNameSuffix>
                     </configuration>
                 </plugin>
                 <plugin>
@@ -734,6 +748,7 @@
                         <redirectTestOutputToFile>true</redirectTestOutputToFile>
                         <runOrder>alphabetical</runOrder>
                         <argLine>${failsafe.jvm.args}</argLine>
+                        <reportNameSuffix>${surefire.environment}-${surefire.executing-module}</reportNameSuffix>
                     </configuration>
                 </plugin>
                 <plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1478,5 +1478,243 @@
                 <jdbc.isolation />
             </properties>
         </profile>
+
+        <!--
+            ###################################################################
+            Profiles naming db instances in the Red Hat QA/QE lab
+
+            First, those with OSS drivers
+            ###################################################################
+        -->
+
+        <!-- The MySQL 5.1 test environment -->
+        <profile>
+            <id>mysql51</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.MySQL5InnoDBDialect</db.dialect>
+                <jdbc.driver.groupId>mysql</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>mysql-connector-java</jdbc.driver.artifactId>
+                <!-- Version 6.0.5 fails with a ArrayIndexOutOfBoundsException during connection, so we'll stick to 5.x for now -->
+                <jdbc.driver.version>5.1.13</jdbc.driver.version>
+                <jdbc.driver>com.mysql.jdbc.Driver</jdbc.driver>
+                <jdbc.url>jdbc:mysql://vmg02.mw.lab.eng.bos.redhat.com/searctru</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <!-- The PostgreSQL 8.4  test environment -->
+        <profile>
+            <id>postgresql84</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.PostgreSQL82Dialect</db.dialect>
+                <jdbc.driver.groupId>org.postgresql</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>postgresql</jdbc.driver.artifactId>
+                <jdbc.driver.version>42.1.1</jdbc.driver.version>
+                <jdbc.driver>org.postgresql.Driver</jdbc.driver>
+                <jdbc.url>jdbc:postgresql://notinstalled.lab.eng.bos.redhat.com:5432:searctru</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <!-- The PostgreSQL test environment on ci.hibernate.org (v. 9.3.9)-->
+        <profile>
+            <id>ci-postgresql</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.PostgreSQL92Dialect</db.dialect>
+                <jdbc.driver.groupId>org.postgresql</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>postgresql</jdbc.driver.artifactId>
+                <jdbc.driver.version>42.1.1</jdbc.driver.version>
+                <jdbc.driver>org.postgresql.Driver</jdbc.driver>
+                <jdbc.url>jdbc:postgresql://localhost:5432/testingdb</jdbc.url>
+                <jdbc.user>hibernate_user</jdbc.user>
+                <jdbc.pass>hibernate_password</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <!-- The MySQL test environment test environment on ci.hibernate.org (v. 10.0.19-MariaDB)-->
+        <profile>
+            <id>ci-mariadb</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.MySQL5InnoDBDialect</db.dialect>
+                <jdbc.driver.groupId>org.mariadb.jdbc</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>mariadb-java-client</jdbc.driver.artifactId>
+                <jdbc.driver.version>2.2.4</jdbc.driver.version>
+                <jdbc.driver>org.mariadb.jdbc.Driver</jdbc.driver>
+                <jdbc.url>jdbc:mariadb://localhost/testingdb</jdbc.url>
+                <jdbc.user>hibernate_user</jdbc.user>
+                <jdbc.pass>hibernate_password</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <!--
+            ###################################################################
+            Then, those with commercial drivers
+            ###################################################################
+        -->
+        <!--
+             Those drivers are not available on public repos.
+             In CI jobs, we use internal build tools to fetch the drivers
+             and make the jars available to the build.
+             Thus, the maven coordinates of the drivers below are fake.
+             See https://svn.devel.redhat.com/repos/jboss-qa/hudson/config_repository/scripts/groovy.classes/hudson/util/JDBCLoader.groovy
+        -->
+
+        <!-- The DB2 9.7 test environment (using 9x drivers)-->
+        <profile>
+            <id>db2-97</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.DB2Dialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>jdbcdrivers</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>db2-97</jdbc.driver.artifactId>
+                <jdbc.driver.version>4.11.77</jdbc.driver.version>
+                <jdbc.driver>com.ibm.db2.jcc.DB2Driver</jdbc.driver>
+                <jdbc.url>jdbc:db2://vmg06.mw.lab.eng.bos.redhat.com:50000/jbossqa</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <!-- The Oracle11g test environment -->
+        <profile>
+            <id>oracle11gR1</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.Oracle10gDialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>jdbcdrivers</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>oracle</jdbc.driver.artifactId>
+                <jdbc.driver.version>11.2.0.2.0</jdbc.driver.version>
+                <jdbc.driver>oracle.jdbc.driver.OracleDriver</jdbc.driver>
+                <jdbc.url>jdbc:oracle:thin:@dev04.qa.atl2.redhat.com:1521:qaora11</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <profile>
+            <id>oracle11gR2</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.Oracle10gDialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>jdbcdrivers</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>oracle</jdbc.driver.artifactId>
+                <jdbc.driver.version>11.2.0.2.0</jdbc.driver.version>
+                <jdbc.driver>oracle.jdbc.driver.OracleDriver</jdbc.driver>
+                <jdbc.url>jdbc:oracle:thin:@dev04.qa.atl2.redhat.com:1521:qaora11</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <!-- The Oracle11gRAC test environment -->
+        <profile>
+            <id>oracle11gR1RAC</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.Oracle10gDialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>jdbcdrivers</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>oracle</jdbc.driver.artifactId>
+                <jdbc.driver.version>11.2.0.2.0</jdbc.driver.version>
+                <jdbc.driver>oracle.jdbc.driver.OracleDriver</jdbc.driver>
+                <jdbc.url>
+                    jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS_LIST=(LOAD_BALANCE=ON)(ADDRESS=(PROTOCOL=TCP)(HOST=vmg24-vip.mw.lab.eng.bos.redhat.com)(PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=vmg25-vip.mw.lab.eng.bos.redhat.com)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=qarac.jboss)))
+                </jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+        <profile>
+            <id>oracle11gR2RAC</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.Oracle10gDialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>jdbcdrivers</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>oracle</jdbc.driver.artifactId>
+                <jdbc.driver.version>11.2.0.2.0</jdbc.driver.version>
+                <jdbc.driver>oracle.jdbc.driver.OracleDriver</jdbc.driver>
+                <jdbc.url>
+                    jdbc:oracle:thin:@(DESCRIPTION=(ADDRESS_LIST=(LOAD_BALANCE=ON)(ADDRESS=(PROTOCOL=TCP)(HOST=vmg24-vip.mw.lab.eng.bos.redhat.com)(PORT=1521))(ADDRESS=(PROTOCOL=TCP)(HOST=vmg25-vip.mw.lab.eng.bos.redhat.com)(PORT=1521)))(CONNECT_DATA=(SERVICE_NAME=qarac.jboss)))
+                </jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <!-- The Sybase ASE 15.5 test environment -->
+        <profile>
+            <id>sybase155</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.SybaseASE15Dialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>jdbcdrivers</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>sybase</jdbc.driver.artifactId>
+                <jdbc.driver.version>26502</jdbc.driver.version>
+                <jdbc.driver>com.sybase.jdbc4.jdbc.SybDriver</jdbc.driver>
+                <jdbc.url>jdbc:sybase:Tds:vmg07.mw.lab.eng.bos.redhat.com:5000/searctru</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+        <profile>
+            <id>sybase155-jtds</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.SybaseASE15Dialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>net.sourceforge.jtds</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>jtds</jdbc.driver.artifactId>
+                <jdbc.driver.version>1.2.4</jdbc.driver.version>
+                <jdbc.driver>net.sourceforge.jtds.jdbc.Driver</jdbc.driver>
+                <jdbc.url>jdbc:jtds:sybase://vmg07.mw.lab.eng.bos.redhat.com:5000/searctru</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation />
+            </properties>
+        </profile>
+
+        <!-- The SQLServer2008 R1 (MS JDBC) test environment -->
+        <profile>
+            <id>mssql2008R1</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.SQLServer2008Dialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>jdbcdrivers</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>mssql</jdbc.driver.artifactId>
+                <jdbc.driver.version>3.0.1301.101</jdbc.driver.version>
+                <jdbc.driver>com.microsoft.sqlserver.jdbc.SQLServerDriver</jdbc.driver>
+                <jdbc.url>jdbc:sqlserver://vmg04.mw.lab.eng.bos.redhat.com:1433</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation>4096</jdbc.isolation>
+            </properties>
+        </profile>
+
+        <!-- The SQLServer2008 R2 (MS JDBC) test environment -->
+        <profile>
+            <id>mssql2008R2</id>
+            <properties>
+                <db.dialect>org.hibernate.dialect.SQLServer2008Dialect</db.dialect>
+                <!-- These maven coordinates are fake (see above) -->
+                <jdbc.driver.groupId>jdbcdrivers</jdbc.driver.groupId>
+                <jdbc.driver.artifactId>mssql</jdbc.driver.artifactId>
+                <jdbc.driver.version>3.0.1301.101</jdbc.driver.version>
+                <jdbc.driver>com.microsoft.sqlserver.jdbc.SQLServerDriver</jdbc.driver>
+                <jdbc.url>jdbc:sqlserver://vmg04.mw.lab.eng.bos.redhat.com:1433</jdbc.url>
+                <jdbc.user>searctru</jdbc.user>
+                <jdbc.pass>searctru</jdbc.pass>
+                <jdbc.isolation>4096</jdbc.isolation>
+            </properties>
+        </profile>
     </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,12 @@
          -->
         <jacoco.mergedExecFilePath>${rootProject.directory}/target/jacoco-merged.exec</jacoco.mergedExecFilePath>
 
+        <!-- Elasticsearch tests properties -->
+
+        <test.elasticsearch.host.url>http://localhost:9200</test.elasticsearch.host.url>
+        <test.elasticsearch.host.username></test.elasticsearch.host.username>
+        <test.elasticsearch.host.password></test.elasticsearch.host.password>
+
         <!-- JDK version required for the build; we target 1.8 since Hibernate ORM 5.3 requires Java 8 -->
         <jdk.min.version>${maven.compiler.argument.source}</jdk.min.version>
         <maven.min.version>3.2.3</maven.min.version>
@@ -1170,6 +1176,8 @@
                             <version>${test.elasticsearch.mavenPlugin.version}</version>
                             <configuration>
                                 <skip>${test.elasticsearch.host.provided}</skip>
+                                <clusterName>hsearchEsTestCluster</clusterName>
+                                <httpPort>9200</httpPort>
                                 <tcpPort>9300</tcpPort>
                                 <pluginsPath>${project.build.directory}/_ES_PLUGINS_</pluginsPath>
                                 <outputDirectory>${project.build.directory}/elastisearch0</outputDirectory>
@@ -1266,6 +1274,8 @@
                             <version>${test.elasticsearch.mavenPlugin.version}</version>
                             <configuration>
                                 <skip>${test.elasticsearch.host.provided}</skip>
+                                <clusterName>hsearchEsTestCluster</clusterName>
+                                <httpPort>9200</httpPort>
                                 <tcpPort>9300</tcpPort>
                                 <pluginsPath>${project.build.directory}/_ES_PLUGINS_</pluginsPath>
                                 <outputDirectory>${project.build.directory}/elastisearch0</outputDirectory>
@@ -1318,6 +1328,7 @@
                             <configuration>
                                 <skip>${test.elasticsearch.host.provided}</skip>
                                 <version>${test.elasticsearch.host.version}</version>
+                                <clusterName>hsearchEsTestCluster</clusterName>
                                 <timeout>90</timeout><!-- Make it work on our slow CI -->
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/5.0/configuration/</pathConf>
                                 <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/5.0/init/init.script</pathInitScript>
@@ -1369,6 +1380,7 @@
                             <configuration>
                                 <skip>${test.elasticsearch.host.provided}</skip>
                                 <version>${test.elasticsearch.host.version}</version>
+                                <clusterName>hsearchEsTestCluster</clusterName>
                                 <timeout>90</timeout><!-- Make it work on our slow CI -->
                                 <pathConf>${project.build.directory}/elasticsearch-maven-plugin/5.0/configuration/</pathConf>
                                 <pathInitScript>${project.build.directory}/elasticsearch-maven-plugin/5.0/init/init.script</pathInitScript>

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
 
         <version.org.slf4j>1.7.25</version.org.slf4j>
         <version.log4j>1.2.16</version.log4j>
-        <version.org.jboss.logging.jboss-logging>3.3.0.Final</version.org.jboss.logging.jboss-logging>
-        <version.org.jboss.logging.jboss-logging-tools>2.0.1.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logging.jboss-logging>3.3.2.Final</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging-tools>2.1.0.Final</version.org.jboss.logging.jboss-logging-tools>
 
         <!-- Test dependencies -->
 
@@ -86,7 +86,7 @@
         <version.site.plugin>3.6</version.site.plugin>
         <version.source.plugin>3.0.1</version.source.plugin>
         <!-- Surefire versions are a minefield of bugs, so depending on context we need to choose a different one -->
-        <version.surefire.plugin>2.20.1</version.surefire.plugin>
+        <version.surefire.plugin>2.21.0</version.surefire.plugin>
         <version.failsafe.plugin>${version.surefire.plugin}</version.failsafe.plugin>
         <version.jacoco.plugin>0.8.0</version.jacoco.plugin>
         <version.coveralls.plugin>4.3.0</version.coveralls.plugin>


### PR DESCRIPTION
See the ticket for pros and cons of pipelines:
https://hibernate.atlassian.net//browse/HSEARCH-3239

See http://ci.hibernate.org/view/Search/job/hibernate-search-6-poc/ and http://ci.hibernate.org/view/Search/job/hibernate-search-6-poc/job/HSEARCH-3239/ for how it looks in Jenkins.

[Build 23](http://ci.hibernate.org/view/Search/job/hibernate-search-6-poc/job/HSEARCH-3239/23/) in particular shows an execution with parallel steps. Admittedly, the interface is not very user-friendly. You can go to the [Pipeline steps](http://ci.hibernate.org/view/Search/job/hibernate-search-6-poc/job/HSEARCH-3239/23/flowGraphTable/) page to display the details of each parallel execution and get links to the logs of each step, but it's not obvious.

A better option would be to use BlueOcean, which is definitely better. Here are some screenshots I took on a local installation: https://imgur.com/a/Nukrd3g . But as we've seen in the past, this would mean every single email indicating a build failure would link to the BlueOcean page, which is not something everybody in the team wants. The URL is apparently altered by this plugin, which unfortunately cannot be uninstalled without uninstalling BlueOcean: https://plugins.jenkins.io/blueocean-display-url

However, even with the old interface, we still have a nice breakdown of all test executions, which stays nice even when the same tests are executed in multiple environments: see http://ci.hibernate.org/job/hibernate-search-6-poc/job/HSEARCH-3239/43/testReport/org.hibernate.search.v6poc.integrationtest.backend.tck/