### PR TITLE
Follow-up: HSEARCH-3294 Send email notifications upon build failures in the Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -50,6 +50,7 @@ import org.jenkinsci.plugins.pipeline.modeldefinition.Utils
  * - new java.lang.IllegalArgumentException java.lang.String
  * - method hudson.plugins.git.GitSCM getUserRemoteConfigs
  * - method hudson.plugins.git.UserRemoteConfig getUrl
+ * - method java.lang.Throwable addSuppressed java.lang.Throwable
  *
  * Just run the script a few times, it will fail and display a link to allow these calls.
  */


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3294

Adding a way to configure which email addresses are used as notification recipients.

This is necessary because automatic email address detection from git changesets is not as reliable as I thought (I think it fails for the first build, or when force-pushing). When building branches in forks, we used to *only* rely on this automatic email address detection, because we didn't want to send notifications to, for example, Guillaume, when a branch in my fork fails to build.

So if we want to get proper notifications for branch builds in our forks, if , we must have a way to configure the notification recipients per fork. This is what this commit adds.

Failure to provide a configuration file will not fail the build, so this does not impair the ability to use the Jenkinsfile "out of the box", without configuration: http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-6-poc-yoann/detail/HSEARCH-3294/15/pipeline/4

Adding the correct configuration file to the job will, as expected, add additional recipients to email notifications: http://ci.hibernate.org/blue/organizations/jenkins/hibernate-search-6-poc-yoann/detail/HSEARCH-3294/16/pipeline/4