### PR TITLE
HSEARCH-3196 Give up on per-module project codes and book ranges of IDs per module instead

### DIFF
--- a/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/logging/impl/Log.java
+++ b/backend-elasticsearch/src/main/java/org/hibernate/search/v6poc/backend/elasticsearch/logging/impl/Log.java
@@ -19,6 +19,7 @@ import org.hibernate.search.v6poc.util.SearchException;
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.SearchSort;
 import org.hibernate.search.v6poc.util.AssertionFailure;
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger.Level;
@@ -27,35 +28,52 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Param;
+import org.jboss.logging.annotations.ValidIdRange;
+import org.jboss.logging.annotations.ValidIdRanges;
 
-@MessageLogger(projectCode = "HSEARCH-ES")
+@MessageLogger(projectCode = MessageConstants.PROJECT_CODE)
+@ValidIdRanges({
+		@ValidIdRange(min = MessageConstants.BACKEND_ES_ID_RANGE_MIN, max = MessageConstants.BACKEND_ES_ID_RANGE_MAX),
+		// Exceptions for legacy messages from Search 5 (engine module)
+		// TODO HSEARCH-3308 add exceptions here for legacy messages from Search 5 (engine module).
+})
 public interface Log extends BasicLogger {
 
-	// -----------------------
-	// Pre-existing messages
-	// -----------------------
+	// -----------------------------------
+	// Pre-existing messages from Search 5 (engine module)
+	// DO NOT ADD ANY NEW MESSAGES HERE
+	// -----------------------------------
+	int ID_OFFSET_1 = MessageConstants.ENGINE_ID_RANGE_MIN;
+
+	// TODO HSEARCH-3308 migrate relevant messages from Search 5 (engine module) here
+
+	// -----------------------------------
+	// Pre-existing messages from Search 5 (ES module)
+	// DO NOT ADD ANY NEW MESSAGES HERE
+	// -----------------------------------
+	int ID_OFFSET_2 = MessageConstants.BACKEND_ES_ID_RANGE_MIN;
 
 	@LogMessage(level = Level.WARN)
-	@Message(id = /*ES_BACKEND_MESSAGES_START_ID +*/ 73,
+	@Message(id = ID_OFFSET_2 + 73,
 			value = "Hibernate Search will connect to Elasticsearch server '%1$s' with authentication over plain HTTP (not HTTPS)."
 					+ " The password will be sent in clear text over the network."
 	)
 	void usingPasswordOverHttp(String serverUris);
 
 	@LogMessage(level = Level.DEBUG)
-	@Message(id = /*ES_BACKEND_MESSAGES_START_ID +*/ 82,
+	@Message(id = ID_OFFSET_2 + 82,
 			value = "Executed Elasticsearch HTTP %s request to path '%s' with query parameters %s in %dms."
 					+ " Response had status %d '%s'."
 	)
 	void executedRequest(String method, String path, Map<String, String> getParameters, long timeInMs,
 			int responseStatusCode, String responseStatusMessage);
 
-	@Message(id = /*ES_BACKEND_MESSAGES_START_ID +*/ 89,
-			value = "Failed to parse Elasticsearch response. Status code was '%1$d', status phrase was '%2$s'." )
+	@Message(id = ID_OFFSET_2 + 89,
+			value = "Failed to parse Elasticsearch response. Status code was '%1$d', status phrase was '%2$s'.")
 	SearchException failedToParseElasticsearchResponse(int statusCode, String statusPhrase, @Cause Exception cause);
 
 	@LogMessage(level = Level.TRACE)
-	@Message(id = /*ES_BACKEND_MESSAGES_START_ID +*/ 93,
+	@Message(id = ID_OFFSET_2 + 93,
 			value = "Executed Elasticsearch HTTP %s request to path '%s' with query parameters %s in %dms."
 					+ " Response had status %d '%s'. Request body: <%s>. Response body: <%s>"
 	)
@@ -63,117 +81,149 @@ public interface Log extends BasicLogger {
 			int responseStatusCode, String responseStatusMessage,
 			String requestBodyParts, String responseBody);
 
-	// -----------------------
-	// New messages
-	// -----------------------
+	// TODO HSEARCH-3308 migrate relevant messages from Search 5 (ES module) here
 
-	@Message(id = 502, value = "A search query cannot target both an Elasticsearch index and other types of index."
-			+ " First target was: '%1$s', other target was: '%2$s'" )
+	// -----------------------------------
+	// New messages from Search 6 onwards
+	// -----------------------------------
+	int ID_OFFSET_3 = MessageConstants.BACKEND_ES_ID_RANGE_MIN + 500;
+
+	@Message(id = ID_OFFSET_3 + 2,
+			value = "A search query cannot target both an Elasticsearch index and other types of index."
+					+ " First target was: '%1$s', other target was: '%2$s'")
 	SearchException cannotMixElasticsearchSearchTargetWithOtherType(IndexSearchTargetBuilder firstTarget,
 			ElasticsearchIndexManager otherTarget, @Param EventContext context);
 
-	@Message(id = 503, value = "A search query cannot target multiple Elasticsearch backends."
-			+ " First target was: '%1$s', other target was: '%2$s'" )
+	@Message(id = ID_OFFSET_3 + 3,
+			value = "A search query cannot target multiple Elasticsearch backends."
+					+ " First target was: '%1$s', other target was: '%2$s'")
 	SearchException cannotMixElasticsearchSearchTargetWithOtherBackend(IndexSearchTargetBuilder firstTarget,
 			ElasticsearchIndexManager otherTarget, @Param EventContext context);
 
-	@Message(id = 504, value = "Unknown field '%1$s'." )
+	@Message(id = ID_OFFSET_3 + 4,
+			value = "Unknown field '%1$s'.")
 	SearchException unknownFieldForSearch(String absoluteFieldPath, @Param EventContext context);
 
-	@Message(id = 505, value = "Multiple conflicting types for field '%1$s': '%2$s' vs. '%3$s'." )
+	@Message(id = ID_OFFSET_3 + 5,
+			value = "Multiple conflicting types for field '%1$s': '%2$s' vs. '%3$s'.")
 	SearchException conflictingFieldTypesForSearch(String absoluteFieldPath,
 			ElasticsearchIndexSchemaFieldNode<?> schemaNode1, ElasticsearchIndexSchemaFieldNode<?> schemaNode2,
 			@Param EventContext context);
 
-	@Message(id = 506, value = "The Elasticsearch extension can only be applied to objects"
-			+ " derived from the Elasticsearch backend. Was applied to '%1$s' instead." )
+	@Message(id = ID_OFFSET_3 + 6,
+			value = "The Elasticsearch extension can only be applied to objects"
+			+ " derived from the Elasticsearch backend. Was applied to '%1$s' instead.")
 	SearchException elasticsearchExtensionOnUnknownType(Object context);
 
-	@Message(id = 507, value = "Unknown projections %1$s." )
+	@Message(id = ID_OFFSET_3 + 7,
+			value = "Unknown projections %1$s.")
 	SearchException unknownProjectionForSearch(Collection<String> projections, @Param EventContext context);
 
-	@Message(id = 508, value = "An Elasticsearch query cannot include search predicates built using a non-Elasticsearch search target."
-			+ " Given predicate was: '%1$s'" )
+	@Message(id = ID_OFFSET_3 + 8,
+			value = "An Elasticsearch query cannot include search predicates built using a non-Elasticsearch search target."
+					+ " Given predicate was: '%1$s'")
 	SearchException cannotMixElasticsearchSearchQueryWithOtherPredicates(SearchPredicate predicate);
 
-	@Message(id = 509, value = "Field '%1$s' is not an object field." )
+	@Message(id = ID_OFFSET_3 + 9,
+			value = "Field '%1$s' is not an object field.")
 	SearchException nonObjectFieldForNestedQuery(String absoluteFieldPath, @Param EventContext context);
 
-	@Message(id = 510, value = "Object field '%1$s' is not stored as nested." )
+	@Message(id = ID_OFFSET_3 + 10,
+			value = "Object field '%1$s' is not stored as nested.")
 	SearchException nonNestedFieldForNestedQuery(String absoluteFieldPath, @Param EventContext context);
 
-	@Message(id = 511, value = "An Elasticsearch query cannot include search sorts built using a non-Elasticsearch search target."
-			+ " Given sort was: '%1$s'" )
+	@Message(id = ID_OFFSET_3 + 11,
+			value = "An Elasticsearch query cannot include search sorts built using a non-Elasticsearch search target."
+					+ " Given sort was: '%1$s'")
 	SearchException cannotMixElasticsearchSearchSortWithOtherSorts(SearchSort sort);
 
-	@Message(id = 512, value = "An analyzer was set on field '%1$s' with type '%2$s', but fields of this type cannot be analyzed." )
+	@Message(id = ID_OFFSET_3 + 12,
+			value = "An analyzer was set on field '%1$s' with type '%2$s', but fields of this type cannot be analyzed.")
 	SearchException cannotUseAnalyzerOnFieldType(String relativeName, DataType fieldType,
 			@Param EventContext context);
 
-	@Message(id = 513, value = "A normalizer was set on field '%1$s' with type '%2$s', but fields of this type cannot be analyzed." )
+	@Message(id = ID_OFFSET_3 + 13,
+			value = "A normalizer was set on field '%1$s' with type '%2$s', but fields of this type cannot be analyzed.")
 	SearchException cannotUseNormalizerOnFieldType(String relativeName, DataType fieldType,
 			@Param EventContext context);
 
-	@Message(id = 514, value = "Index '%1$s' requires multi-tenancy but the backend does not support it in its current configuration.")
+	@Message(id = ID_OFFSET_3 + 14,
+			value = "Index '%1$s' requires multi-tenancy but the backend does not support it in its current configuration.")
 	SearchException multiTenancyRequiredButNotSupportedByBackend(String indexName, @Param EventContext context);
 
-	@Message(id = 515, value = "Unknown multi-tenancy strategy '%1$s'.")
+	@Message(id = ID_OFFSET_3 + 15,
+			value = "Unknown multi-tenancy strategy '%1$s'.")
 	SearchException unknownMultiTenancyStrategyConfiguration(String multiTenancyStrategy);
 
-	@Message(id = 516, value = "Tenant identifier '%1$s' is provided, but multi-tenancy is disabled for this backend.")
+	@Message(id = ID_OFFSET_3 + 16,
+			value = "Tenant identifier '%1$s' is provided, but multi-tenancy is disabled for this backend.")
 	SearchException tenantIdProvidedButMultiTenancyDisabled(String tenantId, @Param EventContext context);
 
-	@Message(id = 517, value = "Backend has multi-tenancy enabled, but no tenant identifier is provided.")
+	@Message(id = ID_OFFSET_3 + 17,
+			value = "Backend has multi-tenancy enabled, but no tenant identifier is provided.")
 	SearchException multiTenancyEnabledButNoTenantIdProvided(@Param EventContext context);
 
-	@Message(id = 518, value = "Attempt to unwrap the Elasticsearch low-level client to %1$s,"
-			+ " but the client can only be unwrapped to %2$s." )
+	@Message(id = ID_OFFSET_3 + 18,
+			value = "Attempt to unwrap the Elasticsearch low-level client to %1$s,"
+					+ " but the client can only be unwrapped to %2$s.")
 	SearchException clientUnwrappingWithUnkownType(Class<?> requestedClass, Class<?> actualClass);
 
-	@Message(id = 519, value = "Attempt to unwrap an Elasticsearch backend to %1$s,"
-			+ " but this backend can only be unwrapped to %2$s." )
+	@Message(id = ID_OFFSET_3 + 19,
+			value = "Attempt to unwrap an Elasticsearch backend to %1$s,"
+					+ " but this backend can only be unwrapped to %2$s.")
 	SearchException backendUnwrappingWithUnknownType(Class<?> requestedClass, Class<?> actualClass,
 			@Param EventContext context);
 
-	@Message(id = 520, value = "The index schema node '%1$s' was added twice."
-			+ " Multiple bridges may be trying to access the same index field, "
-			+ " or two indexed-embeddeds may have prefixes that lead to conflicting field names,"
-			+ " or you may have declared multiple conflicting mappings."
-			+ " In any case, there is something wrong with your mapping and you should fix it." )
+	@Message(id = ID_OFFSET_3 + 20,
+			value = "The index schema node '%1$s' was added twice."
+					+ " Multiple bridges may be trying to access the same index field, "
+					+ " or two indexed-embeddeds may have prefixes that lead to conflicting field names,"
+					+ " or you may have declared multiple conflicting mappings."
+					+ " In any case, there is something wrong with your mapping and you should fix it.")
 	SearchException indexSchemaNodeNameConflict(String name,
 			@Param EventContext context);
 
-	@Message(id = 523, value = "Range predicates are not supported by the GeoPoint field type, use spatial predicates instead.")
+	@Message(id = ID_OFFSET_3 + 23,
+			value = "Range predicates are not supported by the GeoPoint field type, use spatial predicates instead.")
 	SearchException rangePredicatesNotSupportedByGeoPoint(@Param EventContext context);
 
-	@Message(id = 524, value = "Match predicates are not supported by the GeoPoint field type, use spatial predicates instead.")
+	@Message(id = ID_OFFSET_3 + 24,
+			value = "Match predicates are not supported by the GeoPoint field type, use spatial predicates instead.")
 	SearchException matchPredicatesNotSupportedByGeoPoint(@Param EventContext context);
 
-	@Message(id = 525, value = "Invalid parent object for this field accessor; expected path '%1$s', got '%2$s'.")
+	@Message(id = ID_OFFSET_3 + 25,
+			value = "Invalid parent object for this field accessor; expected path '%1$s', got '%2$s'.")
 	SearchException invalidParentDocumentObjectState(String expectedPath, String actualPath);
 
-	@Message(id = 526, value = "Expected data was missing in the Elasticsearch response.")
+	@Message(id = ID_OFFSET_3 + 26,
+			value = "Expected data was missing in the Elasticsearch response.")
 	AssertionFailure elasticsearchResponseMissingData();
 
-	@Message(id = 527, value = "Spatial predicates are not supported by this field's type.")
+	@Message(id = ID_OFFSET_3 + 27,
+			value = "Spatial predicates are not supported by this field's type.")
 	SearchException spatialPredicatesNotSupportedByFieldType(@Param EventContext context);
 
-	@Message(id = 528, value = "Distance related operations are not supported by this field's type.")
+	@Message(id = ID_OFFSET_3 + 28,
+			value = "Distance related operations are not supported by this field's type.")
 	SearchException distanceOperationsNotSupportedByFieldType(@Param EventContext context);
 
-	@Message(id = 529, value = "Multiple conflicting minimumShouldMatch constraints for ceiling '%1$s'")
+	@Message(id = ID_OFFSET_3 + 29,
+			value = "Multiple conflicting minimumShouldMatch constraints for ceiling '%1$s'")
 	SearchException minimumShouldMatchConflictingConstraints(int ceiling);
 
-	@Message(id = 530, value = "Duplicate index names when normalized to conform to Elasticsearch rules:"
-			+ " '%1$s' and '%2$s' both become '%3$s'")
+	@Message(id = ID_OFFSET_3 + 30,
+			value = "Duplicate index names when normalized to conform to Elasticsearch rules:"
+					+ " '%1$s' and '%2$s' both become '%3$s'")
 	SearchException duplicateNormalizedIndexNames(String firstHibernateSearchIndexName,
 			String secondHibernateSearchIndexName, String elasticsearchIndexName,
 			@Param EventContext context);
 
-	@Message(id = 531, value = "Unknown index name encountered in Elasticsearch response: '%1$s'")
+	@Message(id = ID_OFFSET_3 + 31,
+			value = "Unknown index name encountered in Elasticsearch response: '%1$s'")
 	SearchException elasticsearchResponseUnknownIndexName(String elasticsearchIndexName,
 			@Param EventContext context);
 
-	@Message(id = 532, value = "Unable to convert DSL parameter: %1$s")
+	@Message(id = ID_OFFSET_3 + 32,
+			value = "Unable to convert DSL parameter: %1$s")
 	SearchException cannotConvertDslParameter(String errorMessage, @Cause Exception cause, @Param EventContext context);
 }

--- a/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/logging/impl/Log.java
+++ b/backend-lucene/src/main/java/org/hibernate/search/v6poc/backend/lucene/logging/impl/Log.java
@@ -18,6 +18,7 @@ import org.hibernate.search.v6poc.util.impl.common.logging.EventContextFormatter
 import org.hibernate.search.v6poc.util.SearchException;
 import org.hibernate.search.v6poc.search.SearchPredicate;
 import org.hibernate.search.v6poc.search.SearchSort;
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger.Level;
@@ -27,15 +28,29 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Param;
+import org.jboss.logging.annotations.ValidIdRange;
+import org.jboss.logging.annotations.ValidIdRanges;
 
 import org.apache.lucene.search.Query;
 
-@MessageLogger(projectCode = "HSEARCH-LUCENE")
+@MessageLogger(projectCode = MessageConstants.PROJECT_CODE)
+@ValidIdRanges({
+		@ValidIdRange(min = MessageConstants.BACKEND_LUCENE_ID_RANGE_MIN, max = MessageConstants.BACKEND_LUCENE_ID_RANGE_MAX),
+		// Exceptions for legacy messages from Search 5
+		@ValidIdRange(min = 35, max = 35),
+		@ValidIdRange(min = 55, max = 55),
+		@ValidIdRange(min = 284, max = 284),
+		@ValidIdRange(min = 320, max = 320),
+		@ValidIdRange(min = 321, max = 321)
+		// TODO HSEARCH-3308 add exceptions here for legacy messages from Search 5.
+})
 public interface Log extends BasicLogger {
 
-	// -----------------------
-	// Pre-existing messages
-	// -----------------------
+	// -----------------------------------
+	// Pre-existing messages from Search 5
+	// DO NOT ADD ANY NEW MESSAGES HERE
+	// -----------------------------------
+	int ID_OFFSET_1 = MessageConstants.ENGINE_ID_RANGE_MIN;
 
 	@LogMessage(level = Level.WARN)
 	@Message(id = 35, value = "Could not close resource.")
@@ -56,166 +71,213 @@ public interface Log extends BasicLogger {
 			+ " (synonyms) should not be used on sortable fields or range queries. Only the first token will be considered.")
 	void multipleTermsDetectedDuringNormalization(String absoluteFieldPath);
 
-	// -----------------------
-	// New messages
-	// -----------------------
+	// TODO HSEARCH-3308 migrate relevant messages from Search 5 here
 
-	@Message(id = 500, value = "Unknown field '%1$s'." )
+	// -----------------------------------
+	// New messages from Search 6 onwards
+	// -----------------------------------
+	int ID_OFFSET_2 = MessageConstants.BACKEND_LUCENE_ID_RANGE_MIN;
+
+	@Message(id = ID_OFFSET_2 + 0,
+			value = "Unknown field '%1$s'.")
 	SearchException unknownFieldForSearch(String absoluteFieldPath, @Param EventContext context);
 
-	@Message(id = 501, value = "Root directory '%1$s' exists but is not a writable directory.")
+	@Message(id = ID_OFFSET_2 + 1,
+			value = "Root directory '%1$s' exists but is not a writable directory.")
 	SearchException localDirectoryBackendRootDirectoryNotWritableDirectory(Path rootDirectory,
 			@Param EventContext context);
 
-	@Message(id = 502, value = "Unable to create root directory '%1$s'.")
+	@Message(id = ID_OFFSET_2 + 2,
+			value = "Unable to create root directory '%1$s'.")
 	SearchException unableToCreateRootDirectoryForLocalDirectoryBackend(Path rootDirectory,
 			@Param EventContext context, @Cause Exception e);
 
-	@Message(id = 503, value = "Undefined Lucene directory provider.")
+	@Message(id = ID_OFFSET_2 + 3,
+			value = "Undefined Lucene directory provider.")
 	SearchException undefinedLuceneDirectoryProvider(@Param EventContext context);
 
-	@Message(id = 504, value = "Unrecognized Lucene directory provider '%1$s'.")
+	@Message(id = ID_OFFSET_2 + 4,
+			value = "Unrecognized Lucene directory provider '%1$s'.")
 	SearchException unrecognizedLuceneDirectoryProvider(String directoryProvider, @Param EventContext context);
 
-	@Message(id = 505, value = "The Lucene extension can only be applied to objects"
-			+ " derived from the Lucene backend. Was applied to '%1$s' instead." )
+	@Message(id = ID_OFFSET_2 + 5,
+			value = "The Lucene extension can only be applied to objects"
+			+ " derived from the Lucene backend. Was applied to '%1$s' instead.")
 	SearchException luceneExtensionOnUnknownType(Object context);
 
-	@Message(id = 506, value = "An analyzer was set on field '%1$s', but fields of this type cannot be analyzed." )
+	@Message(id = ID_OFFSET_2 + 6,
+			value = "An analyzer was set on field '%1$s', but fields of this type cannot be analyzed.")
 	SearchException cannotUseAnalyzerOnFieldType(String relativeFieldName, @Param EventContext context);
 
-	@Message(id = 507, value = "A normalizer was set on field '%1$s', but fields of this type cannot be analyzed." )
+	@Message(id = ID_OFFSET_2 + 7,
+			value = "A normalizer was set on field '%1$s', but fields of this type cannot be analyzed.")
 	SearchException cannotUseNormalizerOnFieldType(String relativeFieldName, @Param EventContext context);
 
-	@Message(id = 510, value = "A Lucene query cannot include search predicates built using a non-Lucene search target."
-			+ " Given predicate was: '%1$s'" )
+	@Message(id = ID_OFFSET_2 + 10,
+			value = "A Lucene query cannot include search predicates built using a non-Lucene search target."
+			+ " Given predicate was: '%1$s'")
 	SearchException cannotMixLuceneSearchQueryWithOtherPredicates(SearchPredicate predicate);
 
-	@Message(id = 511, value = "Multiple conflicting types for field '%1$s': '%2$s' vs. '%3$s'." )
+	@Message(id = ID_OFFSET_2 + 11,
+			value = "Multiple conflicting types for field '%1$s': '%2$s' vs. '%3$s'.")
 	SearchException conflictingFieldTypesForSearch(String absoluteFieldPath,
 			LuceneIndexSchemaFieldNode<?> schemaNode1, LuceneIndexSchemaFieldNode<?> schemaNode2,
 			@Param EventContext context);
 
-	@Message(id = 512, value = "Field '%1$s' is not an object field." )
+	@Message(id = ID_OFFSET_2 + 12,
+			value = "Field '%1$s' is not an object field.")
 	SearchException nonObjectFieldForNestedQuery(String absoluteFieldPath, @Param EventContext context);
 
-	@Message(id = 513, value = "Object field '%1$s' is not stored as nested." )
+	@Message(id = ID_OFFSET_2 + 13,
+			value = "Object field '%1$s' is not stored as nested.")
 	SearchException nonNestedFieldForNestedQuery(String absoluteFieldPath, @Param EventContext context);
 
-	@Message(id = 514, value = "A Lucene query cannot include search sorts built using a non-Lucene search target."
-			+ " Given sort was: '%1$s'" )
+	@Message(id = ID_OFFSET_2 + 14,
+			value = "A Lucene query cannot include search sorts built using a non-Lucene search target."
+			+ " Given sort was: '%1$s'")
 	SearchException cannotMixLuceneSearchSortWithOtherSorts(SearchSort sort);
 
-	@Message(id = 515, value = "Unable to create the IndexWriter." )
+	@Message(id = ID_OFFSET_2 + 15,
+			value = "Unable to create the IndexWriter.")
 	SearchException unableToCreateIndexWriter(@Param EventContext context, @Cause Exception e);
 
-	@Message(id = 516, value = "Unable to index entry '%2$s' with tenant identifier '%1$s'." )
+	@Message(id = ID_OFFSET_2 + 16, value = "Unable to index entry '%2$s' with tenant identifier '%1$s'.")
 	SearchException unableToIndexEntry(String tenantId, String id,
 			@Param EventContext context, @Cause Exception e);
 
-	@Message(id = 517, value = "Unable to delete entry '%2$s' with tenant identifier '%1$s'." )
+	@Message(id = ID_OFFSET_2 + 17,
+			value = "Unable to delete entry '%2$s' with tenant identifier '%1$s'.")
 	SearchException unableToDeleteEntryFromIndex(String tenantId, String id,
 			@Param EventContext context, @Cause Exception e);
 
-	@Message(id = 518, value = "Unable to flush." )
+	@Message(id = ID_OFFSET_2 + 18,
+			value = "Unable to flush.")
 	SearchException unableToFlushIndex(@Param EventContext context, @Cause Exception e);
 
-	@Message(id = 519, value = "Unable to commit." )
+	@Message(id = ID_OFFSET_2 + 19,
+			value = "Unable to commit.")
 	SearchException unableToCommitIndex(@Param EventContext context, @Cause Exception e);
 
-	@Message(id = 520, value = "Index directory '%1$s' exists but is not a writable directory.")
+	@Message(id = ID_OFFSET_2 + 20,
+			value = "Index directory '%1$s' exists but is not a writable directory.")
 	SearchException localDirectoryIndexRootDirectoryNotWritableDirectory(Path indexDirectory,
 			@Param EventContext context);
 
-	@Message(id = 521, value = "Unable to create index root directory '%1$s'.")
+	@Message(id = ID_OFFSET_2 + 21,
+			value = "Unable to create index root directory '%1$s'.")
 	SearchException unableToCreateIndexRootDirectoryForLocalDirectoryBackend(Path indexDirectory,
 			@Param EventContext context, @Cause Exception e);
 
-	@Message(id = 522, value = "Could not open an index reader.")
+	@Message(id = ID_OFFSET_2 + 22,
+			value = "Could not open an index reader.")
 	SearchException unableToCreateIndexReader(@Param EventContext context, @Cause Exception e);
 
-	@Message(id = 524, value = "A search query cannot target both a Lucene index and other types of index."
-			+ " First target was: '%1$s', other target was: '%2$s'" )
+	@Message(id = ID_OFFSET_2 + 24,
+			value = "A search query cannot target both a Lucene index and other types of index."
+					+ " First target was: '%1$s', other target was: '%2$s'")
 	SearchException cannotMixLuceneSearchTargetWithOtherType(IndexSearchTargetBuilder firstTarget,
 			LuceneIndexManager otherTarget, @Param EventContext context);
 
-	@Message(id = 525, value = "A search query cannot target multiple Lucene backends."
-			+ " First target was: '%1$s', other target was: '%2$s'" )
+	@Message(id = ID_OFFSET_2 + 25,
+			value = "A search query cannot target multiple Lucene backends."
+					+ " First target was: '%1$s', other target was: '%2$s'")
 	SearchException cannotMixLuceneSearchTargetWithOtherBackend(IndexSearchTargetBuilder firstTarget,
 			LuceneIndexManager otherTarget, @Param EventContext context);
 
-	@Message(id = 526, value = "Unknown projections %1$s." )
+	@Message(id = ID_OFFSET_2 + 26,
+			value = "Unknown projections %1$s.")
 	SearchException unknownProjectionForSearch(Collection<String> projections, @Param EventContext context);
 
-	@Message(id = 527, value = "An IOException happened while executing the query '%1$s'." )
+	@Message(id = ID_OFFSET_2 + 27,
+			value = "An IOException happened while executing the query '%1$s'.")
 	SearchException ioExceptionOnQueryExecution(Query luceneQuery, @Param EventContext context, @Cause IOException e);
 
-	@Message(id = 529, value = "Index '%1$s' requires multi-tenancy but the backend does not support it in its current configuration.")
+	@Message(id = ID_OFFSET_2 + 29,
+			value = "Index '%1$s' requires multi-tenancy but the backend does not support it in its current configuration.")
 	SearchException multiTenancyRequiredButNotSupportedByBackend(String indexName, @Param EventContext context);
 
-	@Message(id = 530, value = "Unknown multi-tenancy strategy '%1$s'.")
+	@Message(id = ID_OFFSET_2 + 30,
+			value = "Unknown multi-tenancy strategy '%1$s'.")
 	SearchException unknownMultiTenancyStrategyConfiguration(String multiTenancyStrategy);
 
-	@Message(id = 531, value = "Tenant identifier '%1$s' is provided, but multi-tenancy is disabled for this backend.")
+	@Message(id = ID_OFFSET_2 + 31,
+			value = "Tenant identifier '%1$s' is provided, but multi-tenancy is disabled for this backend.")
 	SearchException tenantIdProvidedButMultiTenancyDisabled(String tenantId, @Param EventContext context);
 
-	@Message(id = 532, value = "Backend has multi-tenancy enabled, but no tenant identifier is provided.")
+	@Message(id = ID_OFFSET_2 + 32,
+			value = "Backend has multi-tenancy enabled, but no tenant identifier is provided.")
 	SearchException multiTenancyEnabledButNoTenantIdProvided(@Param EventContext context);
 
-	@Message(id = 533, value = "Attempt to unwrap a Lucene backend to %1$s,"
-			+ " but this backend can only be unwrapped to %2$s." )
+	@Message(id = ID_OFFSET_2 + 33,
+			value = "Attempt to unwrap a Lucene backend to %1$s,"
+					+ " but this backend can only be unwrapped to %2$s.")
 	SearchException backendUnwrappingWithUnknownType(Class<?> requestedClass, Class<?> actualClass,
 			@Param EventContext context);
 
-	@Message(id = 534, value = "The index schema node '%1$s' was added twice."
-			+ " Multiple bridges may be trying to access the same index field, "
-			+ " or two indexed-embeddeds may have prefixes that lead to conflicting field names,"
-			+ " or you may have declared multiple conflicting mappings."
-			+ " In any case, there is something wrong with your mapping and you should fix it." )
+	@Message(id = ID_OFFSET_2 + 34,
+			value = "The index schema node '%1$s' was added twice."
+					+ " Multiple bridges may be trying to access the same index field, "
+					+ " or two indexed-embeddeds may have prefixes that lead to conflicting field names,"
+					+ " or you may have declared multiple conflicting mappings."
+					+ " In any case, there is something wrong with your mapping and you should fix it.")
 	SearchException indexSchemaNodeNameConflict(String relativeFieldName,
 			@Param EventContext context);
 
-	@Message(id = 537, value = "Range predicates are not supported by the GeoPoint field type, use spatial predicates instead.")
+	@Message(id = ID_OFFSET_2 + 37,
+			value = "Range predicates are not supported by the GeoPoint field type, use spatial predicates instead.")
 	SearchException rangePredicatesNotSupportedByGeoPoint(@Param EventContext context);
 
-	@Message(id = 538, value = "Match predicates are not supported by the GeoPoint field type, use spatial predicates instead.")
+	@Message(id = ID_OFFSET_2 + 38,
+			value = "Match predicates are not supported by the GeoPoint field type, use spatial predicates instead.")
 	SearchException matchPredicatesNotSupportedByGeoPoint(@Param EventContext context);
 
-	@Message(id = 539, value = "Invalid parent object for this field accessor; expected path '%1$s', got '%2$s'.")
+	@Message(id = ID_OFFSET_2 + 39,
+			value = "Invalid parent object for this field accessor; expected path '%1$s', got '%2$s'.")
 	SearchException invalidParentDocumentObjectState(String expectedPath, String actualPath);
 
-	@Message(id = 540, value = "Spatial predicates are not supported by this field's type.")
+	@Message(id = ID_OFFSET_2 + 40,
+			value = "Spatial predicates are not supported by this field's type.")
 	SearchException spatialPredicatesNotSupportedByFieldType(@Param EventContext context);
 
-	@Message(id = 541, value = "Distance related operations are not supported by this field's type.")
+	@Message(id = ID_OFFSET_2 + 41,
+			value = "Distance related operations are not supported by this field's type.")
 	SearchException distanceOperationsNotSupportedByFieldType(@Param EventContext context);
 
-	@Message(id = 542, value = "Traditional sorting operations are not supported by the GeoPoint field type, use distance sorting instead.")
+	@Message(id = ID_OFFSET_2 + 42,
+			value = "Traditional sorting operations are not supported by the GeoPoint field type, use distance sorting instead.")
 	SearchException traditionalSortNotSupportedByGeoPoint(@Param EventContext context);
 
-	@Message(id = 543, value = "Descending order is not supported for distance sort.")
+	@Message(id = ID_OFFSET_2 + 43,
+			value = "Descending order is not supported for distance sort.")
 	SearchException descendingOrderNotSupportedByDistanceSort(@Param EventContext context);
 
-	@Message(id = 544, value = "Computed minimum for minimumShouldMatch constraint is out of bounds:"
-			+ " expected a number between 1 and '%1$s', got '%2$s'.")
+	@Message(id = ID_OFFSET_2 + 44,
+			value = "Computed minimum for minimumShouldMatch constraint is out of bounds:"
+					+ " expected a number between 1 and '%1$s', got '%2$s'.")
 	SearchException minimumShouldMatchMinimumOutOfBounds(int minimum, int totalShouldClauseNumber);
 
-	@Message(id = 545, value = "Multiple conflicting minimumShouldMatch constraints for ceiling '%1$s'")
+	@Message(id = ID_OFFSET_2 + 45,
+			value = "Multiple conflicting minimumShouldMatch constraints for ceiling '%1$s'")
 	SearchException minimumShouldMatchConflictingConstraints(int ignoreConstraintCeiling);
 
-	@Message(id = 546, value = "Native fields do not support defining predicates with the DSL: use the Lucene extension and a native query.")
+	@Message(id = ID_OFFSET_2 + 46,
+			value = "Native fields do not support defining predicates with the DSL: use the Lucene extension and a native query.")
 	SearchException unsupportedDSLPredicates(@Param EventContext context);
 
-	@Message(id = 547, value = "Native fields do not support defining sorts with the DSL: use the Lucene extension and a native sort.")
+	@Message(id = ID_OFFSET_2 + 47,
+			value = "Native fields do not support defining sorts with the DSL: use the Lucene extension and a native sort.")
 	SearchException unsupportedDSLSorts(@Param EventContext context);
 
-	@Message(id = 548, value = "This native field does not support projection.")
+	@Message(id = ID_OFFSET_2 + 48,
+			value = "This native field does not support projection.")
 	SearchException unsupportedProjection(@Param EventContext context);
 
-	@Message(id = 549, value = "Invalid field path; expected path '%1$s', got '%2$s'.")
+	@Message(id = ID_OFFSET_2 + 49,
+			value = "Invalid field path; expected path '%1$s', got '%2$s'.")
 	SearchException invalidFieldPath(String expectedPath, String actualPath);
 
-	@Message(id = 550, value = "Unable to convert DSL parameter: %1$s")
+	@Message(id = ID_OFFSET_2 + 50,
+			value = "Unable to convert DSL parameter: %1$s")
 	SearchException cannotConvertDslParameter(String errorMessage, @Cause Exception cause, @Param EventContext context);
 
 }

--- a/engine/src/main/java/org/hibernate/search/v6poc/logging/impl/EngineEventContextMessages.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/logging/impl/EngineEventContextMessages.java
@@ -8,13 +8,15 @@ package org.hibernate.search.v6poc.logging.impl;
 
 import java.util.Set;
 
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
+
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 
 /**
  * Message bundle for event contexts related to engine concepts.
  */
-@MessageBundle(projectCode = "HSEARCH")
+@MessageBundle(projectCode = MessageConstants.PROJECT_CODE)
 public interface EngineEventContextMessages {
 
 	@Message(value = "    ")

--- a/engine/src/main/java/org/hibernate/search/v6poc/logging/impl/Log.java
+++ b/engine/src/main/java/org/hibernate/search/v6poc/logging/impl/Log.java
@@ -14,6 +14,7 @@ import org.hibernate.search.v6poc.util.EventContext;
 import org.hibernate.search.v6poc.logging.spi.MappableTypeModelFormatter;
 import org.hibernate.search.v6poc.util.SearchException;
 import org.hibernate.search.v6poc.spatial.GeoPoint;
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -23,103 +24,141 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.jboss.logging.annotations.Param;
+import org.jboss.logging.annotations.ValidIdRange;
+import org.jboss.logging.annotations.ValidIdRanges;
 
-@MessageLogger(projectCode = "HSEARCH")
+@MessageLogger(projectCode = MessageConstants.PROJECT_CODE)
+@ValidIdRanges({
+		@ValidIdRange(min = MessageConstants.ENGINE_ID_RANGE_MIN, max = MessageConstants.ENGINE_ID_RANGE_MAX)
+		// Exceptions for legacy messages from Search 5
+		// TODO HSEARCH-3308 add exceptions here for legacy messages from Search 5. See the Lucene logger for examples.
+})
 public interface Log extends BasicLogger {
 
-	@Message(id = 1, value = "Unable to convert configuration property '%1$s' with value '%2$s': %3$s")
+	// -----------------------------------
+	// Pre-existing messages from Search 5
+	// DO NOT ADD ANY NEW MESSAGES HERE
+	// -----------------------------------
+	int ID_OFFSET_1 = MessageConstants.ENGINE_ID_RANGE_MIN;
+
+	// TODO HSEARCH-3308 migrate relevant messages from Search 5 here
+
+	// -----------------------------------
+	// New messages from Search 6 onwards
+	// -----------------------------------
+	int ID_OFFSET_2 = MessageConstants.ENGINE_ID_RANGE_MIN + 500;
+
+	@Message(id = ID_OFFSET_2 + 1,
+			value = "Unable to convert configuration property '%1$s' with value '%2$s': %3$s")
 	SearchException unableToConvertConfigurationProperty(String key, Object rawValue, String errorMessage, @Cause Exception cause);
 
-	@Message(id = 2, value = "Invalid value: expected either an instance of '%1$s' or a parsable String.")
+	@Message(id = ID_OFFSET_2 + 2,
+			value = "Invalid value: expected either an instance of '%1$s' or a parsable String.")
 	SearchException invalidPropertyValue(Class<?> expectedType, @Cause Exception cause);
 
-	@Message(id = 3, value = "Invalid boolean value: expected either a Boolean, the String 'true' or the String 'false'.")
+	@Message(id = ID_OFFSET_2 + 3,
+			value = "Invalid boolean value: expected either a Boolean, the String 'true' or the String 'false'.")
 	SearchException invalidBooleanPropertyValue(@Cause Exception cause);
 
-	@Message(id = 4, value = "%1$s")
+	@Message(id = ID_OFFSET_2 + 4,
+			value = "%1$s")
 	SearchException invalidIntegerPropertyValue(String errorMessage, @Cause Exception cause);
 
-	@Message(id = 5, value = "%1$s")
+	@Message(id = ID_OFFSET_2 + 5,
+			value = "%1$s")
 	SearchException invalidLongPropertyValue(String errorMessage, @Cause Exception cause);
 
-	@Message(id = 6, value = "Invalid multi value: expected either a Collection or a String.")
+	@Message(id = ID_OFFSET_2 + 6,
+			value = "Invalid multi value: expected either a Collection or a String.")
 	SearchException invalidMultiPropertyValue();
 
-	@Message(id = 7, value = "Cannot add multiple predicates to the query root; use an explicit boolean predicate instead.")
+	@Message(id = ID_OFFSET_2 + 7,
+			value = "Cannot add multiple predicates to the query root; use an explicit boolean predicate instead.")
 	SearchException cannotAddMultiplePredicatesToQueryRoot();
 
-	@Message(id = 9, value = "Cannot add multiple predicates to a nested predicate; use an explicit boolean predicate instead.")
+	@Message(id = ID_OFFSET_2 + 9,
+			value = "Cannot add multiple predicates to a nested predicate; use an explicit boolean predicate instead.")
 	SearchException cannotAddMultiplePredicatesToNestedPredicate();
 
-	@Message(id = 11, value = "Invalid value: the value to match in match predicates must be non-null." +
-			" Null value was passed to match predicate on fields %1$s")
+	@Message(id = ID_OFFSET_2 + 11,
+			value = "Invalid value: the value to match in match predicates must be non-null."
+					+ " Null value was passed to match predicate on fields %1$s")
 	SearchException matchPredicateCannotMatchNullValue(List<String> strings);
 
-	@Message(id = 12, value = "Invalid value: at least one bound in range predicates must be non-null." +
-			" Null bounds were passed to range predicate on fields %1$s")
+	@Message(id = ID_OFFSET_2 + 12,
+			value = "Invalid value: at least one bound in range predicates must be non-null."
+					+ " Null bounds were passed to range predicate on fields %1$s")
 	SearchException rangePredicateCannotMatchNullValue(List<String> strings);
 
-	@Message(id = 13, value = "Cannot map type '%1$s' to index '%2$s', because this type is abstract."
-			+ " Index mappings are not inherited: they apply to exact instances of a given type."
-			+ " As a result, mapping an abstract type to an index does not make sense,"
-			+ " since the index would always be empty.")
+	@Message(id = ID_OFFSET_2 + 13,
+			value = "Cannot map type '%1$s' to index '%2$s', because this type is abstract."
+					+ " Index mappings are not inherited: they apply to exact instances of a given type."
+					+ " As a result, mapping an abstract type to an index does not make sense,"
+					+ " since the index would always be empty.")
 	SearchException cannotMapAbstractTypeToIndex(
 			@FormatWith(MappableTypeModelFormatter.class) MappableTypeModel typeModel, String indexName);
 
-	@Message(id = 14, value = "Field name '%1$s' is invalid: field names cannot be null or empty." )
+	@Message(id = ID_OFFSET_2 + 14,
+			value = "Field name '%1$s' is invalid: field names cannot be null or empty.")
 	SearchException relativeFieldNameCannotBeNullOrEmpty(String relativeFieldName,
 			@Param EventContext context);
 
-	@Message(id = 15, value = "Field name '%1$s' is invalid: field names cannot contain a dot ('.')."
-			+ " Remove the dot from your field name,"
-			+ " or if you are declaring the field in a bridge and want a tree of fields,"
-			+ " declare an object field using the objectField() method." )
+	@Message(id = ID_OFFSET_2 + 15,
+			value = "Field name '%1$s' is invalid: field names cannot contain a dot ('.')."
+					+ " Remove the dot from your field name,"
+					+ " or if you are declaring the field in a bridge and want a tree of fields,"
+					+ " declare an object field using the objectField() method.")
 	SearchException relativeFieldNameCannotContainDot(String relativeFieldName,
 			@Param EventContext context);
 
-	@Message(id = 16, value = "Invalid polygon: the first point '%1$s' should be identical to the last point '%2$s' to properly close the polygon." )
+	@Message(id = ID_OFFSET_2 + 16,
+			value = "Invalid polygon: the first point '%1$s' should be identical to the last point '%2$s' to properly close the polygon." )
 	IllegalArgumentException invalidGeoPolygonFirstPointNotIdenticalToLastPoint(GeoPoint firstPoint, GeoPoint lastPoint);
 
-	@Message(id = 17, value = "Cannot add a predicate to this DSL context anymore, because the DSL context was already closed."
-			+ " If you want to re-use predicates, do not re-use the predicate DSL context objects,"
-			+ " but rather build SearchPredicate objects."
-	)
+	@Message(id = ID_OFFSET_2 + 17,
+			value = "Cannot add a predicate to this DSL context anymore, because the DSL context was already closed."
+					+ " If you want to re-use predicates, do not re-use the predicate DSL context objects,"
+					+ " but rather build SearchPredicate objects.")
 	SearchException cannotAddPredicateToUsedContext();
 
-	@Message(id = 18, value = "Cannot add a sort to this DSL context anymore, because the DSL context was already closed."
-			+ " If you want to re-use sorts, do not re-use the sort DSL context objects,"
-			+ " but rather build SearchSort objects."
-	)
+	@Message(id = ID_OFFSET_2 + 18,
+			value = "Cannot add a sort to this DSL context anymore, because the DSL context was already closed."
+					+ " If you want to re-use sorts, do not re-use the sort DSL context objects,"
+					+ " but rather build SearchSort objects.")
 	SearchException cannotAddSortToUsedContext();
 
-	@Message(id = 19, value = "Hibernate Search bootstrap failed; stopped collecting failures after '%2$s' failures."
-			+ " Failures:\n%1$s"
-	)
+	@Message(id = ID_OFFSET_2 + 19,
+			value = "Hibernate Search bootstrap failed; stopped collecting failures after '%2$s' failures."
+					+ " Failures:\n%1$s")
 	SearchException boostrapCollectedFailureLimitReached(String renderedFailures, int failureCount);
 
-	@Message(id = 20, value = "Hibernate Search bootstrap failed."
-			+ " Failures:\n%1$s"
-	)
+	@Message(id = ID_OFFSET_2 + 20,
+			value = "Hibernate Search bootstrap failed."
+					+ " Failures:\n%1$s")
 	SearchException bootstrapCollectedFailures(String renderedFailures);
 
 	@LogMessage(level = Logger.Level.ERROR)
-	@Message(id = 21, value = "Hibernate Search bootstrap encountered a non-fatal failure;"
-			+ " continuing bootstrap for now to list all mapping problems,"
-			+ " but the bootstrap process will ultimately be aborted.\n"
-			+ "Context: %1$s\n"
-			+ "Failure:" // The stack trace follows
+	@Message(id = ID_OFFSET_2 + 21,
+			value = "Hibernate Search bootstrap encountered a non-fatal failure;"
+					+ " continuing bootstrap for now to list all mapping problems,"
+					+ " but the bootstrap process will ultimately be aborted.\n"
+					+ "Context: %1$s\n"
+					+ "Failure:" // The stack trace follows
 	)
 	void newBootstrapCollectedFailure(String context, @Cause Throwable failure);
 
 	@LogMessage(level = Logger.Level.DEBUG)
-	@Message(id = 22, value = "Unexpected empty event context; there is a bug in Hibernate Search, please report it")
+	@Message(id = ID_OFFSET_2 + 22,
+			value = "Unexpected empty event context; there is a bug in Hibernate Search, please report it")
 	void unexpectedEmptyEventContext(@Cause SearchException exceptionForStackTrace);
 
-	@Message(id = 23, value = "Incomplete field definition."
-			+ " You must call createAccessor() to complete the field definition." )
+	@Message(id = ID_OFFSET_2 + 23,
+			value = "Incomplete field definition."
+					+ " You must call createAccessor() to complete the field definition.")
 	SearchException incompleteFieldDefinition(@Param EventContext context);
 
-	@Message(id = 24, value = "Multiple calls to createAccessor() for the same field definition."
-			+ " You must call createAccessor() exactly once." )
+	@Message(id = ID_OFFSET_2 + 24,
+			value = "Multiple calls to createAccessor() for the same field definition."
+					+ " You must call createAccessor() exactly once.")
 	SearchException cannotCreateAccessorMultipleTimes(@Param EventContext context);
 }

--- a/engine/src/test/java/org/hibernate/search/v6poc/spatial/GeoPolygonTest.java
+++ b/engine/src/test/java/org/hibernate/search/v6poc/spatial/GeoPolygonTest.java
@@ -44,7 +44,7 @@ public class GeoPolygonTest {
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH000016" );
+				.hasMessageContaining( "HSEARCH000516" );
 
 		SubTest.expectException(
 				() -> new ImmutableGeoPolygon( Arrays.asList(
@@ -56,6 +56,6 @@ public class GeoPolygonTest {
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH000016" );
+				.hasMessageContaining( "HSEARCH000516" );
 	}
 }

--- a/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
+++ b/integrationtest/backend-lucene/src/test/java/org/hibernate/search/v6poc/integrationtest/backend/lucene/search/LuceneSearchSortIT.java
@@ -76,7 +76,7 @@ public class LuceneSearchSortIT {
 	@Test
 	public void byDistanceDesc() {
 		thrown.expect( SearchException.class );
-		thrown.expectMessage( "HSEARCH-LUCENE000543" );
+		thrown.expectMessage( "HSEARCH600043" );
 
 		simpleQuery( b -> b.byDistance( "geoPoint", new ImmutableGeoPoint( 45.757864, 4.834496 ) ).desc() );
 	}

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -236,7 +236,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH-UTIL000018" );
+				.hasMessageContaining( "HSEARCH000018" );
 	}
 
 	@Test

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinBoundingBoxSearchPredicateIT.java
@@ -236,7 +236,7 @@ public class SpatialWithinBoundingBoxSearchPredicateIT extends AbstractSpatialWi
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH000018" );
+				.hasMessageContaining( "HSEARCH900000" );
 	}
 
 	@Test

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinCircleSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinCircleSearchPredicateIT.java
@@ -204,7 +204,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH000018" );
+				.hasMessageContaining( "HSEARCH900000" );
 
 		SubTest.expectException(
 				"spatial().within().circle() predicate with null distance unit",
@@ -213,7 +213,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH000018" );
+				.hasMessageContaining( "HSEARCH900000" );
 	}
 
 	@Test

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinCircleSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinCircleSearchPredicateIT.java
@@ -204,7 +204,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH-UTIL000018" );
+				.hasMessageContaining( "HSEARCH000018" );
 
 		SubTest.expectException(
 				"spatial().within().circle() predicate with null distance unit",
@@ -213,7 +213,7 @@ public class SpatialWithinCircleSearchPredicateIT extends AbstractSpatialWithinS
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH-UTIL000018" );
+				.hasMessageContaining( "HSEARCH000018" );
 	}
 
 	@Test

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinPolygonSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinPolygonSearchPredicateIT.java
@@ -201,7 +201,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH000018" );
+				.hasMessageContaining( "HSEARCH900000" );
 	}
 
 	@Test

--- a/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinPolygonSearchPredicateIT.java
+++ b/integrationtest/backend-tck/src/main/java/org/hibernate/search/v6poc/integrationtest/backend/tck/search/predicate/spatial/SpatialWithinPolygonSearchPredicateIT.java
@@ -201,7 +201,7 @@ public class SpatialWithinPolygonSearchPredicateIT extends AbstractSpatialWithin
 		)
 				.assertThrown()
 				.isInstanceOf( IllegalArgumentException.class )
-				.hasMessageContaining( "HSEARCH-UTIL000018" );
+				.hasMessageContaining( "HSEARCH000018" );
 	}
 
 	@Test

--- a/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanMappingFailureReportIT.java
+++ b/integrationtest/mapper-pojo/src/test/java/org/hibernate/search/v6poc/integrationtest/mapper/pojo/JavaBeanMappingFailureReportIT.java
@@ -30,7 +30,7 @@ public class JavaBeanMappingFailureReportIT {
 			+ " continuing bootstrap for now to list all mapping problems,"
 			+ " but the bootstrap process will ultimately be aborted.\n"
 			+ "Context: ";
-	private static final String FAILURE_REPORT_INTRODUCTION = "HSEARCH000020: Hibernate Search bootstrap failed."
+	private static final String FAILURE_REPORT_INTRODUCTION = "HSEARCH000520: Hibernate Search bootstrap failed."
 			+ " Failures:\n"
 			+ "\n"
 			+ "    JavaBean mapping: \n";

--- a/mapper-javabean/src/main/java/org/hibernate/search/v6poc/entity/javabean/log/impl/JavaBeanEventContextMessages.java
+++ b/mapper-javabean/src/main/java/org/hibernate/search/v6poc/entity/javabean/log/impl/JavaBeanEventContextMessages.java
@@ -6,13 +6,15 @@
  */
 package org.hibernate.search.v6poc.entity.javabean.log.impl;
 
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
+
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 
 /**
  * Message bundle for event contexts in the JavaBean mapper.
  */
-@MessageBundle(projectCode = "HSEARCH")
+@MessageBundle(projectCode = MessageConstants.PROJECT_CODE)
 public interface JavaBeanEventContextMessages {
 
 	@Message(value = "JavaBean mapping")

--- a/mapper-javabean/src/main/java/org/hibernate/search/v6poc/entity/javabean/log/impl/Log.java
+++ b/mapper-javabean/src/main/java/org/hibernate/search/v6poc/entity/javabean/log/impl/Log.java
@@ -10,20 +10,27 @@ package org.hibernate.search.v6poc.entity.javabean.log.impl;
 import org.hibernate.search.v6poc.entity.pojo.logging.spi.PojoTypeModelFormatter;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.v6poc.util.SearchException;
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.FormatWith;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.ValidIdRange;
 
-@MessageLogger(projectCode = "HSEARCH-JAVABEAN")
+@MessageLogger(projectCode = MessageConstants.PROJECT_CODE)
+@ValidIdRange(min = MessageConstants.MAPPER_JAVABEAN_ID_RANGE_MIN, max = MessageConstants.MAPPER_JAVABEAN_ID_RANGE_MAX)
 public interface Log extends BasicLogger {
 
-	@Message(id = 1, value = "Unable to find property '%2$s' on type '%1$s'.")
+	int ID_OFFSET_1 = MessageConstants.MAPPER_JAVABEAN_ID_RANGE_MIN;
+
+	@Message(id = ID_OFFSET_1 + 1,
+			value = "Unable to find property '%2$s' on type '%1$s'.")
 	SearchException cannotFindProperty(@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
 			String propertyName);
 
-	@Message(id = 2, value = "Cannot read property '%2$s' on type '%1$s'.")
+	@Message(id = ID_OFFSET_1 + 2,
+			value = "Cannot read property '%2$s' on type '%1$s'.")
 	SearchException cannotReadProperty(@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
 			String propertyName);
 

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/Log.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/Log.java
@@ -23,6 +23,7 @@ import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoTypeModel;
 import org.hibernate.search.v6poc.util.AssertionFailure;
 import org.hibernate.search.v6poc.util.impl.common.logging.ClassFormatter;
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
 import org.hibernate.search.v6poc.util.impl.common.logging.ToStringTreeAppendableMultilineFormatter;
 import org.hibernate.search.v6poc.util.SearchException;
 import org.hibernate.search.v6poc.util.impl.common.logging.TypeFormatter;
@@ -34,120 +35,161 @@ import org.jboss.logging.annotations.FormatWith;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.ValidIdRange;
+import org.jboss.logging.annotations.ValidIdRanges;
 
-@MessageLogger(projectCode = "HSEARCH-POJO")
+@MessageLogger(projectCode = MessageConstants.PROJECT_CODE)
+@ValidIdRanges({
+		@ValidIdRange(min = MessageConstants.MAPPER_POJO_ID_RANGE_MIN, max = MessageConstants.MAPPER_POJO_ID_RANGE_MAX)
+		// Exceptions for legacy messages from Search 5
+		// TODO HSEARCH-3308 add exceptions here for legacy messages from Search 5. See the Lucene logger for examples.
+})
 public interface Log extends BasicLogger {
 
-	@Message(id = 1, value = "Unable to find a default identifier bridge implementation for type '%1$s'")
+	// -----------------------------------
+	// Pre-existing messages from Search 5
+	// DO NOT ADD ANY NEW MESSAGES HERE
+	// -----------------------------------
+	int ID_OFFSET_1 = MessageConstants.ENGINE_ID_RANGE_MIN;
+
+	// TODO HSEARCH-3308 migrate relevant messages from Search 5 here
+
+	// -----------------------------------
+	// New messages from Search 6 onwards
+	// -----------------------------------
+	int ID_OFFSET_2 = MessageConstants.MAPPER_POJO_ID_RANGE_MIN;
+
+	@Message(id = ID_OFFSET_2 + 1,
+			value = "Unable to find a default identifier bridge implementation for type '%1$s'")
 	SearchException unableToResolveDefaultIdentifierBridgeFromSourceType(
 			@FormatWith(PojoTypeModelFormatter.class) PojoTypeModel<?> sourceType);
 
-	@Message(id = 2, value = "Unable to find a default value bridge implementation for type '%1$s'")
+	@Message(id = ID_OFFSET_2 + 2,
+			value = "Unable to find a default value bridge implementation for type '%1$s'")
 	SearchException unableToResolveDefaultValueBridgeFromSourceType(
 			@FormatWith(PojoTypeModelFormatter.class) PojoTypeModel<?> sourceType);
 
-	@Message(id = 3, value = "Annotation type '%2$s' is annotated with '%1$s',"
-			+ " but neither a bridge reference nor a bridge builder reference was provided.")
+	@Message(id = ID_OFFSET_2 + 3,
+			value = "Annotation type '%2$s' is annotated with '%1$s',"
+					+ " but neither a bridge reference nor a bridge builder reference was provided.")
 	SearchException missingBridgeReferenceInBridgeMapping(
 			@FormatWith(ClassFormatter.class) Class<? extends Annotation> metaAnnotationType,
 			@FormatWith(ClassFormatter.class) Class<? extends Annotation> annotationType);
 
-	@Message(id = 4, value = "Annotation type '%2$s' is annotated with '%1$s',"
-			+ " but the marker builder reference is empty.")
+	@Message(id = ID_OFFSET_2 + 4,
+			value = "Annotation type '%2$s' is annotated with '%1$s',"
+					+ " but the marker builder reference is empty.")
 	SearchException missingBuilderReferenceInMarkerMapping(
 			@FormatWith(ClassFormatter.class) Class<? extends Annotation> metaAnnotationType,
 			@FormatWith(ClassFormatter.class) Class<? extends Annotation> annotationType);
 
-	@Message(id = 5, value = "Annotation @Field on property '%1$s' defines both valueBridge and valueBridgeBuilder."
-			+ " Only one of those can be defined, not both."
+	@Message(id = ID_OFFSET_2 + 5,
+			value = "Annotation @Field on property '%1$s' defines both valueBridge and valueBridgeBuilder."
+					+ " Only one of those can be defined, not both."
 	)
 	SearchException invalidFieldDefiningBothBridgeReferenceAndBridgeBuilderReference(String property);
 
-	@Message(id = 6, value = "Annotation @DocumentId on property '%1$s' defines both identifierBridge and identifierBridgeBuilder."
-			+ " Only one of those can be defined, not both."
+	@Message(id = ID_OFFSET_2 + 6,
+			value = "Annotation @DocumentId on property '%1$s' defines both identifierBridge and identifierBridgeBuilder."
+					+ " Only one of those can be defined, not both."
 	)
 	SearchException invalidDocumentIdDefiningBothBridgeReferenceAndBridgeBuilderReference(String property);
 
-	@Message(id = 7, value = "Cannot query on an empty target."
-			+ " If you want to target all indexes, put Object.class in the collection of target types,"
-			+ " or use the method of the same name, but without Class<?> parameters."
+	@Message(id = ID_OFFSET_2 + 7,
+			value = "Cannot query on an empty target."
+					+ " If you want to target all indexes, put Object.class in the collection of target types,"
+					+ " or use the method of the same name, but without Class<?> parameters."
 	)
 	SearchException cannotSearchOnEmptyTarget();
 
-	@Message(id = 8, value = "Could not auto-detect the input type for value bridge '%1$s'."
-			+ " There is a bug in Hibernate Search, please report it.")
+	@Message(id = ID_OFFSET_2 + 8,
+			value = "Could not auto-detect the input type for value bridge '%1$s'."
+					+ " There is a bug in Hibernate Search, please report it.")
 	AssertionFailure unableToInferValueBridgeInputType(ValueBridge<?, ?> bridge);
 
-	@Message(id = 9, value = "Could not auto-detect the return type for value bridge '%1$s'."
-			+ " There is a bug in Hibernate Search, please report it.")
+	@Message(id = ID_OFFSET_2 + 9,
+			value = "Could not auto-detect the return type for value bridge '%1$s'."
+					+ " There is a bug in Hibernate Search, please report it.")
 	AssertionFailure unableToInferValueBridgeIndexFieldType(ValueBridge<?, ?> bridge);
 
-	@Message(id = 10, value = "Value bridge '%1$s' cannot be applied to input type '%2$s'.")
+	@Message(id = ID_OFFSET_2 + 10,
+			value = "Value bridge '%1$s' cannot be applied to input type '%2$s'.")
 	SearchException invalidInputTypeForValueBridge(ValueBridge<?, ?> bridge,
 			@FormatWith(PojoTypeModelFormatter.class) PojoTypeModel<?> typeModel);
 
-	@Message(id = 11, value = "Missing field name for GeoPointBridge on type %1$s."
-			+ " The field name is mandatory when the bridge is applied on an type, optional when applied on a property.")
+	@Message(id = ID_OFFSET_2 + 11,
+			value = "Missing field name for GeoPointBridge on type %1$s."
+					+ " The field name is mandatory when the bridge is applied on an type, optional when applied on a property.")
 	SearchException missingFieldNameForGeoPointBridgeOnType(String typeName);
 
-	@Message(id = 12, value = "Requested type argument %3$s to type %2$s"
-			+ " in implementing type %1$s, but %2$s doesn't declare any type parameter")
+	@Message(id = ID_OFFSET_2 + 12,
+			value = "Requested type argument %3$s to type %2$s"
+					+ " in implementing type %1$s, but %2$s doesn't declare any type parameter")
 	IllegalArgumentException cannotRequestTypeParameterOfUnparameterizedType(@FormatWith(TypeFormatter.class) Type type,
 			@FormatWith(ClassFormatter.class) Class<?> rawSuperType, int typeArgumentIndex);
 
-	@Message(id = 13, value = "Requested type argument %3$s to type %2$s"
-			+ " in implementing type %1$s, but %2$s only declares %4$s type parameter(s)")
+	@Message(id = ID_OFFSET_2 + 13,
+			value = "Requested type argument %3$s to type %2$s"
+					+ " in implementing type %1$s, but %2$s only declares %4$s type parameter(s)")
 	IllegalArgumentException typeParameterIndexOutOfBound(@FormatWith(TypeFormatter.class) Type type,
 			@FormatWith(ClassFormatter.class) Class<?> rawSuperType,
 			int typeArgumentIndex, int typeParametersLength);
 
-	@Message(id = 14, value = "Requested type argument index %3$s to type %2$s"
-			+ " in implementing type %1$s should be 0 or greater")
+	@Message(id = ID_OFFSET_2 + 14,
+			value = "Requested type argument index %3$s to type %2$s"
+					+ " in implementing type %1$s should be 0 or greater")
 	IllegalArgumentException invalidTypeParameterIndex(@FormatWith(TypeFormatter.class) Type type,
 			@FormatWith(ClassFormatter.class) Class<?> rawSuperType, int typeArgumentIndex);
 
-	@Message(id = 15, value = "Cannot interpret the type arguments to the ContainerValueExtractor interface in "
-			+ " implementation '%1$s'. Only the following implementations of ContainerValueExtractor are valid: "
-			+ " 1) implementations setting both type parameters to *raw* types,"
-			+ " e.g. class MyExtractor implements ContainerValueExtractor<MyBean, String>;"
-			+ " 2) implementations setting the first type parameter to an array of an unbounded type variable,"
-			+ " and setting the second parameter to the same type variable,"
-			+ " e.g. MyExtractor<T> implements ContainerValueExtractor<T[], T>"
-			+ " 3) implementations setting the first type parameter to a parameterized type"
-			+ " with one argument set to an unbounded type variable and the other to unbounded wildcards,"
-			+ " and setting the second type parameter to the same type variable,"
-			+ " e.g. MyExtractor<T> implements ContainerValueExtractor<MyParameterizedBean<?, T, ?>, T>")
+	@Message(id = ID_OFFSET_2 + 15,
+			value = "Cannot interpret the type arguments to the ContainerValueExtractor interface in "
+					+ " implementation '%1$s'. Only the following implementations of ContainerValueExtractor are valid: "
+					+ " 1) implementations setting both type parameters to *raw* types,"
+					+ " e.g. class MyExtractor implements ContainerValueExtractor<MyBean, String>;"
+					+ " 2) implementations setting the first type parameter to an array of an unbounded type variable,"
+					+ " and setting the second parameter to the same type variable,"
+					+ " e.g. MyExtractor<T> implements ContainerValueExtractor<T[], T>"
+					+ " 3) implementations setting the first type parameter to a parameterized type"
+					+ " with one argument set to an unbounded type variable and the other to unbounded wildcards,"
+					+ " and setting the second type parameter to the same type variable,"
+					+ " e.g. MyExtractor<T> implements ContainerValueExtractor<MyParameterizedBean<?, T, ?>, T>")
 	SearchException cannotInferContainerValueExtractorClassTypePattern(
 			@FormatWith(ClassFormatter.class) Class<?> extractorClass);
 
-	@Message(id = 16, value = "Cannot apply the requested container value extractor '%1$s' to type '%2$s'")
+	@Message(id = ID_OFFSET_2 + 16,
+			value = "Cannot apply the requested container value extractor '%1$s' to type '%2$s'")
 	SearchException invalidContainerValueExtractorForType(
 			@FormatWith(ClassFormatter.class) Class<? extends ContainerValueExtractor> extractorClass,
 			@FormatWith(PojoTypeModelFormatter.class) PojoGenericTypeModel<?> extractedType);
 
 	@LogMessage(level = Logger.Level.DEBUG)
-	@Message(id = 17, value = "Created POJO indexed type manager: %1$s")
+	@Message(id = ID_OFFSET_2 + 17,
+			value = "Created POJO indexed type manager: %1$s")
 	void createdPojoIndexedTypeManager(
 			@FormatWith(ToStringTreeAppendableMultilineFormatter.class) PojoIndexedTypeManager<?, ?, ?> typeManager);
 
 	@LogMessage(level = Logger.Level.DEBUG)
-	@Message(id = 18, value = "Detected entity types: %1$s")
+	@Message(id = ID_OFFSET_2 + 18,
+			value = "Detected entity types: %1$s")
 	void detectedEntityTypes(Set<PojoRawTypeModel<?>> entityTypes);
 
 	@LogMessage(level = Logger.Level.DEBUG)
-	@Message(id = 19, value = "Created POJO contained type manager: %1$s")
+	@Message(id = ID_OFFSET_2 + 19,
+			value = "Created POJO contained type manager: %1$s")
 	void createdPojoContainedTypeManager(
 			@FormatWith(ToStringTreeAppendableMultilineFormatter.class) PojoContainedTypeManager<?> typeManager);
 
-	@Message(id = 20, value = "Cannot find the inverse side of the association at path '%3$s' from type '%2$s' on type '%1$s'")
+	@Message(id = ID_OFFSET_2 + 20,
+			value = "Cannot find the inverse side of the association at path '%3$s' from type '%2$s' on type '%1$s'")
 	SearchException cannotInvertAssociation(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> inverseSideTypeModel,
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
 			@FormatWith(PojoModelPathFormatter.class) PojoModelPathValueNode associationPath);
 
-	@Message(id = 21, value = "Cannot apply the path of the inverse association '%2$s' from type '%1$s'."
-			+ " Association on the original side (which was being inverted) was '%4$s' on type '%3$s'."
-			+ " Error was: '%5$s'")
+	@Message(id = ID_OFFSET_2 + 21,
+			value = "Cannot apply the path of the inverse association '%2$s' from type '%1$s'."
+					+ " Association on the original side (which was being inverted) was '%4$s' on type '%3$s'."
+					+ " Error was: '%5$s'")
 	SearchException cannotApplyInvertAssociationPath(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> inverseSideTypeModel,
 			@FormatWith(PojoModelPathFormatter.class) PojoModelPathValueNode inverseSideAssociationPath,
@@ -156,54 +198,63 @@ public interface Log extends BasicLogger {
 			String errorMessage,
 			@Cause Exception cause);
 
-	@Message(id = 22, value = "The inverse association targets type '%1$s',"
-			+ " but a supertype or subtype of '%2$s' was expected.")
+	@Message(id = ID_OFFSET_2 + 22,
+			value = "The inverse association targets type '%1$s',"
+					+ " but a supertype or subtype of '%2$s' was expected.")
 	SearchException incorrectTargetTypeForInverseAssociation(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> inverseAssociationTargetType,
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> entityType);
 
-	@Message(id = 23, value = "Property '%2$s' from type '%1$s' is annotated with @AssociationInverseSide,"
-			+ " but the inverse path is empty.")
+	@Message(id = ID_OFFSET_2 + 23,
+			value = "Property '%2$s' from type '%1$s' is annotated with @AssociationInverseSide,"
+					+ " but the inverse path is empty.")
 	SearchException missingInversePathInAssociationInverseSideMapping(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel, String propertyName);
 
-	@Message(id = 24, value = "Found an infinite embedded recursion involving path '%2$s' on type '%1$s'")
+	@Message(id = ID_OFFSET_2 + 24,
+			value = "Found an infinite embedded recursion involving path '%2$s' on type '%1$s'")
 	SearchException infiniteRecursionForAssociationEmbeddeds(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
 			@FormatWith(PojoModelPathFormatter.class) PojoModelPathValueNode path);
 
 	@LogMessage(level = Logger.Level.INFO)
-	@Message(id = 25, value = "Cannot access the value of containing annotation '%1$s'."
-			+ " Ignoring annotation.")
+	@Message(id = ID_OFFSET_2 + 25,
+			value = "Cannot access the value of containing annotation '%1$s'."
+					+ " Ignoring annotation.")
 	void cannotAccessRepeateableContainingAnnotationValue(
 			@FormatWith(ClassFormatter.class) Class<?> containingAnnotationType, @Cause Throwable e);
 
-	@Message(id = 26, value = "Annotation type '%2$s' is annotated with '%1$s',"
-			+ " but both a bridge reference and a bridge builder reference were provided."
-			+ " Only one can be provided.")
+	@Message(id = ID_OFFSET_2 + 26,
+			value = "Annotation type '%2$s' is annotated with '%1$s',"
+					+ " but both a bridge reference and a bridge builder reference were provided."
+					+ " Only one can be provided.")
 	SearchException conflictingBridgeReferenceInBridgeMapping(
 			@FormatWith(ClassFormatter.class) Class<? extends Annotation> metaAnnotationType,
 			@FormatWith(ClassFormatter.class) Class<? extends Annotation> annotationType);
 
-	@Message(id = 27, value = "Type '%1$s' is not marked as an entity type, yet it is indexed or targeted"
+	@Message(id = ID_OFFSET_2 + 27,
+			value = "Type '%1$s' is not marked as an entity type, yet it is indexed or targeted"
 			+ " by an association from an indexed type. Please check your configuration.")
 	SearchException missingEntityTypeMetadata(@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel);
 
-	@Message(id = 28, value = "There isn't any explicit document ID mapping for indexed type '%1$s',"
-			+ " and the entity ID cannot be used as a default because it is unknown.")
+	@Message(id = ID_OFFSET_2 + 28,
+			value = "There isn't any explicit document ID mapping for indexed type '%1$s',"
+					+ " and the entity ID cannot be used as a default because it is unknown.")
 	SearchException missingIdentifierMapping(@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel);
 
-	@Message(id = 29, value = "Property '%2$s' from type '%1$s' is annotated with @IndexingDependency,"
-			+ " but 'derivedFrom' contains an empty path.")
+	@Message(id = ID_OFFSET_2 + 29,
+			value = "Property '%2$s' from type '%1$s' is annotated with @IndexingDependency,"
+					+ " but 'derivedFrom' contains an empty path.")
 	SearchException missingPathInIndexingDependencyDerivedFrom(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel, String propertyName);
 
-	@Message(id = 30, value = "Found a cyclic dependency between derived properties involving path '%2$s' on type '%1$s'."
-			+ " Derived properties cannot be marked as derived from themselves, even indirectly through other "
-			+ " derived properties."
-			+ " If your model actually contains such cyclic dependency, "
-			+ " you should consider disabling automatic reindexing, at least partially "
-			+ " using @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO) on one of the properties in the cycle."
+	@Message(id = ID_OFFSET_2 + 30,
+			value = "Found a cyclic dependency between derived properties involving path '%2$s' on type '%1$s'."
+					+ " Derived properties cannot be marked as derived from themselves, even indirectly through other "
+					+ " derived properties."
+					+ " If your model actually contains such cyclic dependency, "
+					+ " you should consider disabling automatic reindexing, at least partially "
+					+ " using @IndexingDependency(reindexOnUpdate = ReindexOnUpdate.NO) on one of the properties in the cycle."
 	)
 	SearchException infiniteRecursionForDerivedFrom(
 			@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,

--- a/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/PojoEventContextMessages.java
+++ b/mapper-pojo/src/main/java/org/hibernate/search/v6poc/entity/pojo/logging/impl/PojoEventContextMessages.java
@@ -6,13 +6,15 @@
  */
 package org.hibernate.search.v6poc.entity.pojo.logging.impl;
 
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
+
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 
 /**
  * Message bundle for event contexts in the POJO mapper.
  */
-@MessageBundle(projectCode = "HSEARCH")
+@MessageBundle(projectCode = MessageConstants.PROJECT_CODE)
 public interface PojoEventContextMessages {
 
 	@Message(value = "path '%1$s'")

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/logging/impl/HibernateOrmEventContextMessages.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/logging/impl/HibernateOrmEventContextMessages.java
@@ -6,13 +6,15 @@
  */
 package org.hibernate.search.v6poc.entity.orm.logging.impl;
 
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
+
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 
 /**
  * Message bundle for event contexts in the Hibernate ORM mapper.
  */
-@MessageBundle(projectCode = "HSEARCH")
+@MessageBundle(projectCode = MessageConstants.PROJECT_CODE)
 public interface HibernateOrmEventContextMessages {
 
 	@Message(value = "Hibernate ORM mapping")

--- a/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/logging/impl/Log.java
+++ b/orm/src/main/java/org/hibernate/search/v6poc/entity/orm/logging/impl/Log.java
@@ -18,6 +18,7 @@ import org.hibernate.search.v6poc.entity.pojo.logging.spi.PojoTypeModelFormatter
 import org.hibernate.search.v6poc.entity.pojo.model.path.PojoModelPath;
 import org.hibernate.search.v6poc.entity.pojo.model.spi.PojoRawTypeModel;
 import org.hibernate.search.v6poc.util.SearchException;
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
 
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.Logger;
@@ -26,48 +27,78 @@ import org.jboss.logging.annotations.FormatWith;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.ValidIdRange;
+import org.jboss.logging.annotations.ValidIdRanges;
 
-@MessageLogger(projectCode = "HSEARCH-ORM")
+@MessageLogger(projectCode = MessageConstants.PROJECT_CODE)
+@ValidIdRanges({
+		@ValidIdRange(min = MessageConstants.ORM_ID_RANGE_MIN, max = MessageConstants.ORM_ID_RANGE_MAX)
+		// Exceptions for legacy messages from Search 5
+		// TODO HSEARCH-3308 add exceptions here for legacy messages from Search 5. See the Lucene logger for examples.
+})
 public interface Log extends BasicLogger {
 
-	@Message(id = 1, value = "Hibernate Search was not initialized.")
+	// -----------------------------------
+	// Pre-existing messages from Search 5
+	// DO NOT ADD ANY NEW MESSAGES HERE
+	// -----------------------------------
+	int ID_OFFSET_1 = MessageConstants.ENGINE_ID_RANGE_MIN;
+
+	// TODO HSEARCH-3308 migrate relevant messages from Search 5 here
+
+	// -----------------------------------
+	// New messages from Search 6 onwards
+	// -----------------------------------
+	int ID_OFFSET_2 = MessageConstants.ORM_ID_RANGE_MIN;
+
+	@Message(id = ID_OFFSET_2 + 1,
+			value = "Hibernate Search was not initialized.")
 	SearchException hibernateSearchNotInitialized();
 
-	@Message(id = 2, value = "Unexpected entity type for a query hit: %1$s. Expected one of %2$s.")
+	@Message(id = ID_OFFSET_2 + 2,
+			value = "Unexpected entity type for a query hit: %1$s. Expected one of %2$s.")
 	SearchException unexpectedSearchHitType(Class<?> entityType, Collection<? extends Class<?>> expectedTypes);
 
-	@Message(id = 3, value = "Unknown indexing mode: %1$s")
+	@Message(id = ID_OFFSET_2 + 3,
+			value = "Unknown indexing mode: %1$s")
 	SearchException unknownIndexingMode(String indexingMode);
 
-	@Message(id = 4, value = "Could not retrieve metadata for type %1$s, property '%2$s' accessed through getter '%3$s'")
+	@Message(id = ID_OFFSET_2 + 4,
+			value = "Could not retrieve metadata for type %1$s, property '%2$s' accessed through getter '%3$s'")
 	SearchException unknownPropertyForGetter(Class<?> entityType, String propertyName, Getter getter);
 
 	@LogMessage(level = Logger.Level.INFO)
-	@Message(id = 5, value = "Configuration property tracking is disabled; unused properties will not be logged.")
+	@Message(id = ID_OFFSET_2 + 5,
+			value = "Configuration property tracking is disabled; unused properties will not be logged.")
 	void configurationPropertyTrackingDisabled();
 
 	@LogMessage(level = Logger.Level.WARN)
-	@Message(id = 6, value = "Some properties in the Hibernate Search configuration were not used;"
-			+ " there might be misspelled property keys in your configuration. Unused properties were: %1$s."
-			+ " To disable this warning, set '"
-			+ SearchOrmSettings.ENABLE_CONFIGURATION_PROPERTY_TRACKING + "' to false.")
+	@Message(id = ID_OFFSET_2 + 6,
+			value = "Some properties in the Hibernate Search configuration were not used;"
+					+ " there might be misspelled property keys in your configuration. Unused properties were: %1$s."
+					+ " To disable this warning, set '"
+					+ SearchOrmSettings.ENABLE_CONFIGURATION_PROPERTY_TRACKING + "' to false.")
 	void configurationPropertyTrackingUnusedProperties(Set<String> propertyKeys);
 
-	@Message(id = 7, value = "Path '%2$s' on entity type '%1$s' cannot be resolved using Hibernate ORM metadata."
-			+ " Please check that this path points to a persisted value.")
+	@Message(id = ID_OFFSET_2 + 7,
+			value = "Path '%2$s' on entity type '%1$s' cannot be resolved using Hibernate ORM metadata."
+					+ " Please check that this path points to a persisted value.")
 	SearchException unknownPathForDirtyChecking(Class<?> entityType, PojoModelPath path, @Cause Exception e);
 
-	@Message(id = 8, value = "Path '%2$s' on entity type '%1$s' can be resolved using Hibernate ORM metadata,"
-			+ " but points to value '%3$s' that will never be reported as dirty by Hibernate ORM."
-			+ " Please check that this path points to a persisted value, and in particular not an embedded property.")
+	@Message(id = ID_OFFSET_2 + 8,
+			value = "Path '%2$s' on entity type '%1$s' can be resolved using Hibernate ORM metadata,"
+					+ " but points to value '%3$s' that will never be reported as dirty by Hibernate ORM."
+					+ " Please check that this path points to a persisted value, and in particular not an embedded property.")
 	SearchException unreportedPathForDirtyChecking(Class<?> entityType, PojoModelPath path, Value value);
 
-	@Message(id = 9, value = "Container value extractor of type '%2$s' cannot be applied to"
-			+ " Hibernate ORM metadata node of type '%1$s'.")
+	@Message(id = ID_OFFSET_2 + 9,
+			value = "Container value extractor of type '%2$s' cannot be applied to"
+					+ " Hibernate ORM metadata node of type '%1$s'.")
 	SearchException invalidContainerValueExtractorForDirtyChecking(Class<?> ormMappingClass,
 			Class<? extends ContainerValueExtractor> extractorClass);
 
-	@Message(id = 10, value = "Unable to find a readable property '%2$s' on type '%1$s'.")
+	@Message(id = ID_OFFSET_2 + 10,
+			value = "Unable to find a readable property '%2$s' on type '%1$s'.")
 	SearchException cannotFindReadableProperty(@FormatWith(PojoTypeModelFormatter.class) PojoRawTypeModel<?> typeModel,
 			String propertyName);
 }

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/MessageConstants.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/MessageConstants.java
@@ -1,0 +1,67 @@
+/*
+ * Hibernate Search, full-text search for your domain model
+ *
+ * License: GNU Lesser General Public License (LGPL), version 2.1 or later
+ * See the lgpl.txt file in the root directory or <http://www.gnu.org/licenses/lgpl-2.1.html>.
+ */
+package org.hibernate.search.v6poc.util.impl.common;
+
+public final class MessageConstants {
+
+	private MessageConstants() {
+	}
+
+	public static final String PROJECT_CODE = "HSEARCH";
+
+	// -----------------------------------
+	// Message ID ranges
+	// These ID ranges should NOT OVERLAP
+	// -----------------------------------
+
+	public static final int ENGINE_ID_RANGE_MIN = 0;
+	public static final int ENGINE_ID_RANGE_MAX = 9999;
+
+	/*
+	 * Legacy range from Search 5:
+	 * Engine: min = 1, max = 99999 (max used: 0000353)
+	 */
+
+	/*
+	 * Legacy range from Search 5:
+	 * JGroups: min = 200001, max = 299999 (max used: 200025)
+	 */
+
+	/*
+	 * Legacy range from Search 5:
+	 * Avro: min = 300001, max = 399999 (max used: 300002)
+	 */
+
+	public static final int BACKEND_ES_ID_RANGE_MIN = 400000;
+	public static final int BACKEND_ES_ID_RANGE_MAX = 409999;
+
+	/*
+	 * Legacy range from Search 5:
+	 * Elasticsearch: min = 400001, max = 499999 (max used: 400094)
+	 */
+
+	/*
+	 * Legacy range from Search 5:
+	 * JSR352 integration: min = 500000, max = undefined (max used: 500033)
+	 */
+
+	public static final int BACKEND_LUCENE_ID_RANGE_MIN = 600000;
+	public static final int BACKEND_LUCENE_ID_RANGE_MAX = 609999;
+
+	public static final int MAPPER_POJO_ID_RANGE_MIN = 700000;
+	public static final int MAPPER_POJO_ID_RANGE_MAX = 709999;
+
+	public static final int MAPPER_JAVABEAN_ID_RANGE_MIN = 750000;
+	public static final int MAPPER_JAVABEAN_ID_RANGE_MAX = 759999;
+
+	public static final int ORM_ID_RANGE_MIN = 800000;
+	public static final int ORM_ID_RANGE_MAX = 809999;
+
+	public static final int UTIL_ID_RANGE_MIN = 900000;
+	public static final int UTIL_ID_RANGE_MAX = 909999;
+
+}

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/logging/CommonEventContextMessages.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/logging/CommonEventContextMessages.java
@@ -6,13 +6,15 @@
  */
 package org.hibernate.search.v6poc.util.impl.common.logging;
 
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
+
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageBundle;
 
 /**
  * Common message bundle related to event contexts.
  */
-@MessageBundle(projectCode = "HSEARCH")
+@MessageBundle(projectCode = MessageConstants.PROJECT_CODE)
 public interface CommonEventContextMessages {
 
 	@Message(value = "Context: ")

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/logging/Log.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/logging/Log.java
@@ -9,17 +9,30 @@ package org.hibernate.search.v6poc.util.impl.common.logging;
 
 import static org.jboss.logging.Logger.Level.ERROR;
 
+import org.hibernate.search.v6poc.util.impl.common.MessageConstants;
+
 import org.jboss.logging.BasicLogger;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
+import org.jboss.logging.annotations.ValidIdRange;
+import org.jboss.logging.annotations.ValidIdRanges;
 
-@MessageLogger(projectCode = "HSEARCH-UTIL")
+@MessageLogger(projectCode = MessageConstants.PROJECT_CODE)
+@ValidIdRanges({
+		@ValidIdRange(min = MessageConstants.UTIL_ID_RANGE_MIN, max = MessageConstants.UTIL_ID_RANGE_MAX),
+		// Exceptions for legacy messages from Search 5
+		// TODO HSEARCH-3308 add exceptions here for legacy messages from Search 5.
+		@ValidIdRange(min = 17, max = 17),
+		@ValidIdRange(min = 18, max = 18)
+})
 public interface Log extends BasicLogger {
 
-	// -----------------------
-	// Pre-existing messages
-	// -----------------------
+	// -----------------------------------
+	// Pre-existing messages from Search 5
+	// DO NOT ADD ANY NEW MESSAGES HERE
+	// -----------------------------------
+	int ID_OFFSET_1 = MessageConstants.ENGINE_ID_RANGE_MIN;
 
 	@LogMessage(level = ERROR)
 	@Message(id = 17, value = "Work discarded, thread was interrupted while waiting for space to schedule: %1$s")
@@ -28,13 +41,18 @@ public interface Log extends BasicLogger {
 	@Message(id = 18, value = "'%1$s' must not be null.")
 	IllegalArgumentException mustNotBeNull(String objectDescription);
 
-	// -----------------------
-	// New messages
-	// -----------------------
+	// TODO HSEARCH-3308 migrate relevant messages from Search 5 here
 
-	@Message(id = 500, value = "'%1$s' must not be null or empty.")
+	// -----------------------------------
+	// New messages from Search 6 onwards
+	// -----------------------------------
+	int ID_OFFSET_2 = MessageConstants.UTIL_ID_RANGE_MIN;
+
+	@Message(id = ID_OFFSET_2 + 0,
+			value = "'%1$s' must not be null or empty.")
 	IllegalArgumentException mustNotBeNullNorEmpty(String objectDescription);
 
-	@Message(id = 501, value = "'%1$s' must be positive or zero.")
+	@Message(id = ID_OFFSET_2 + 1,
+			value = "'%1$s' must be positive or zero.")
 	IllegalArgumentException mustBePositiveOrZero(String objectDescription);
 }

--- a/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/logging/Log.java
+++ b/util/internal/common/src/main/java/org/hibernate/search/v6poc/util/impl/common/logging/Log.java
@@ -38,9 +38,6 @@ public interface Log extends BasicLogger {
 	@Message(id = 17, value = "Work discarded, thread was interrupted while waiting for space to schedule: %1$s")
 	void interruptedWorkError(Runnable r);
 
-	@Message(id = 18, value = "'%1$s' must not be null.")
-	IllegalArgumentException mustNotBeNull(String objectDescription);
-
 	// TODO HSEARCH-3308 migrate relevant messages from Search 5 here
 
 	// -----------------------------------
@@ -49,10 +46,14 @@ public interface Log extends BasicLogger {
 	int ID_OFFSET_2 = MessageConstants.UTIL_ID_RANGE_MIN;
 
 	@Message(id = ID_OFFSET_2 + 0,
+			value = "'%1$s' must not be null.")
+	IllegalArgumentException mustNotBeNull(String objectDescription);
+
+	@Message(id = ID_OFFSET_2 + 1,
 			value = "'%1$s' must not be null or empty.")
 	IllegalArgumentException mustNotBeNullNorEmpty(String objectDescription);
 
-	@Message(id = ID_OFFSET_2 + 1,
+	@Message(id = ID_OFFSET_2 + 2,
 			value = "'%1$s' must be positive or zero.")
 	IllegalArgumentException mustBePositiveOrZero(String objectDescription);
 }


### PR DESCRIPTION
https://hibernate.atlassian.net//browse/HSEARCH-3196

As mentioned in the commit message:

```
Unfortunately, this means I had to change the ID of many, many messages.
Since this will make git blame unusable for these files anyway, I
decided to take advantage of this and make the syntax of all the
@message annotations consistent.
```

In particular I took care to put message strings on a different line than message IDs, so that we won't mess up the git history for the lines containing message string when we change message IDs (though I'd rather not do that again...).

Note that this does not add more changes to this patch, because I had to change these lines anyway (to change the message ID).

Not sure I'm making sense... Let's talk about it on HipChat if I'm unclear.